### PR TITLE
Changed AppleGLGetProcAddress signature in gl_magnum.c

### DIFF
--- a/external/OpenGL/GL/gl_magnum.c
+++ b/external/OpenGL/GL/gl_magnum.c
@@ -6,7 +6,7 @@
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
 
-static void* AppleGLGetProcAddress (const GLubyte *name)
+static void* AppleGLGetProcAddress (const char* name)
 {
   static const struct mach_header* image = NULL;
   NSSymbol symbol;


### PR DESCRIPTION
Changed const GLubyte\* name parameter to const char\* name parameter
Fix issue #22: fixed 820 warnings on OS X builds
