### PR TITLE
Added colour option for Flat shader even when texturing is enabled

### DIFF
--- a/src/Shaders/Flat.cpp
+++ b/src/Shaders/Flat.cpp
@@ -41,22 +41,23 @@ template<UnsignedInt dimensions> Flat<dimensions>::Flat(const Flags flags): tran
     Utility::Resource rs("MagnumShaders");
 
     #ifndef MAGNUM_TARGET_GLES
-    const Version version = Context::current()->supportedVersion({Version::GL310, Version::GL300, Version::GL210});
+    const Version version = Context::current()->supportedVersion({Version::GL320, Version::GL310, Version::GL300, Version::GL210});
     #else
     const Version version = Context::current()->supportedVersion({Version::GLES300, Version::GLES200});
     #endif
 
-    Shader vert(version, Shader::Type::Fragment);
+    Shader vert(version, Shader::Type::Vertex);
     vert.addSource(flags & Flag::Textured ? "#define TEXTURED\n" : "")
         .addSource(rs.get("compatibility.glsl"))
-        .addSource(rs.get("Flat.frag"));
+        .addSource(rs.get("generic.glsl"))
+        .addSource(rs.get(vertexShaderName<dimensions>()));
     CORRADE_INTERNAL_ASSERT_OUTPUT(vert.compile());
     attachShader(vert);
 
-    Shader frag(version, Shader::Type::Vertex);
+    Shader frag(version, Shader::Type::Fragment);
     frag.addSource(flags & Flag::Textured ? "#define TEXTURED\n" : "")
         .addSource(rs.get("compatibility.glsl"))
-        .addSource(rs.get(vertexShaderName<dimensions>()));
+        .addSource(rs.get("Flat.frag"));
     CORRADE_INTERNAL_ASSERT_OUTPUT(frag.compile());
     attachShader(frag);
 
@@ -77,11 +78,11 @@ template<UnsignedInt dimensions> Flat<dimensions>::Flat(const Flags flags): tran
     #endif
     {
         transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
-        if(!(flags & Flag::Textured)) colorUniform = uniformLocation("color");
+        colorUniform = uniformLocation("color");
     }
 
     #ifndef MAGNUM_TARGET_GLES
-    if(flags && !Context::current()->isExtensionSupported<Extensions::GL::ARB::shading_language_420pack>(version))
+    if(!Context::current()->isExtensionSupported<Extensions::GL::ARB::shading_language_420pack>(version))
     #endif
     {
         if(flags & Flag::Textured) setUniform(uniformLocation("textureData"), TextureLayer);

--- a/src/Shaders/Flat.frag
+++ b/src/Shaders/Flat.frag
@@ -25,6 +25,7 @@
 #ifndef NEW_GLSL
 #define fragmentColor gl_FragColor
 #define texture texture2D
+#define in varying
 #endif
 
 #ifdef TEXTURED
@@ -33,16 +34,16 @@ layout(binding = 0) uniform sampler2D textureData;
 #else
 uniform sampler2D textureData;
 #endif
-#else
+#endif
+
 #ifdef EXPLICIT_UNIFORM_LOCATION
 layout(location = 1) uniform vec4 color;
 #else
 uniform lowp vec4 color;
 #endif
-#endif
 
 #ifdef TEXTURED
-in mediump vec2 interpolatedTextureCoords;
+in mediump vec2 interpolatedTextureCoordinates;
 #endif
 
 #ifdef NEW_GLSL
@@ -51,7 +52,7 @@ out lowp vec4 fragmentColor;
 
 void main() {
     #ifdef TEXTURED
-    fragmentColor = texture(textureData, interpolatedTextureCoords);
+    fragmentColor = color * texture(textureData, interpolatedTextureCoordinates);
     #else
     fragmentColor = color;
     #endif

--- a/src/Shaders/Flat.h
+++ b/src/Shaders/Flat.h
@@ -30,9 +30,9 @@
 
 #include "Math/Matrix3.h"
 #include "Math/Matrix4.h"
-#include "AbstractShaderProgram.h"
 #include "Color.h"
 #include "DimensionTraits.h"
+#include "Shaders/Generic.h"
 
 #include "magnumShadersVisibility.h"
 
@@ -44,7 +44,7 @@ namespace Implementation {
 }
 
 /**
-@brief Flat shader
+@brief %Flat shader
 
 Draws whole mesh with given unshaded color or texture. For colored mesh you
 need to provide @ref Position attribute in your triangle mesh and call at least
@@ -67,14 +67,14 @@ myTexture.bind(Shaders::Flat2D::TextureLayer);
 template<UnsignedInt dimensions> class MAGNUM_SHADERS_EXPORT Flat: public AbstractShaderProgram {
     public:
         /** @brief Vertex position */
-        typedef Attribute<0, typename DimensionTraits<dimensions, Float>::VectorType> Position;
+        typedef typename Generic<dimensions>::Position Position;
 
         /**
          * @brief Texture coordinates
          *
          * Used only if @ref Flag::Textured is set.
          */
-        typedef Attribute<2, Vector2> TextureCoordinates;
+        typedef typename Generic<dimensions>::TextureCoordinates TextureCoordinates;
 
         enum: Int {
             /** Layer for color texture. Used only if @ref Flag::Textured is set. */
@@ -124,7 +124,8 @@ template<UnsignedInt dimensions> class MAGNUM_SHADERS_EXPORT Flat: public Abstra
          * @brief Set color
          * @return Reference to self (for method chaining)
          *
-         * Has no effect if @ref Flag::Textured is set.
+         * Color will be multiplied with texture
+         * if @ref Flag::Textured is set.
          */
         Flat<dimensions>& setColor(const Color4& color);
 
@@ -144,7 +145,7 @@ typedef Flat<3> Flat3D;
 CORRADE_ENUMSET_OPERATORS(Implementation::FlatFlags)
 
 template<UnsignedInt dimensions> inline Flat<dimensions>& Flat<dimensions>::setColor(const Color4& color) {
-    if(!(_flags & Flag::Textured)) setUniform(colorUniform, color);
+    setUniform(colorUniform, color);
     return *this;
 }
 


### PR DESCRIPTION
This allows blending to be done (with the texture and colour).

It is quite useful as with this you can change the transparency of an object quite simply*. Also, this allows re-colouring of textures to be done. e.g. if you made a coin image for your game, and wish to have different types of coins without having to re-create assets, you could just re-colour them.

*it might be wise to actually have this as a separate uniform, with the color attribute only having RGB values.
