### PR TITLE
Added colour uniform to flat shader (even when texturing is enabled)

### DIFF
--- a/src/Shaders/Flat.cpp
+++ b/src/Shaders/Flat.cpp
@@ -78,7 +78,7 @@ template<UnsignedInt dimensions> Flat<dimensions>::Flat(const Flags flags): tran
     #endif
     {
         transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
-        if(!(flags & Flag::Textured)) colorUniform = uniformLocation("color");
+        colorUniform = uniformLocation("color");
     }
 
     #ifndef MAGNUM_TARGET_GLES
@@ -87,6 +87,11 @@ template<UnsignedInt dimensions> Flat<dimensions>::Flat(const Flags flags): tran
     {
         if(flags & Flag::Textured) setUniform(uniformLocation("textureData"), TextureLayer);
     }
+
+    /* Set defaults in OpenGL ES (for desktop they are set in shader code itself) */
+    #ifdef MAGNUM_TARGET_GLES
+    setColor(Color4(1.0f)); // Default to white, with full transperancy (so we can see the texture)
+    #endif
 }
 
 template class Flat<2>;

--- a/src/Shaders/Flat.frag
+++ b/src/Shaders/Flat.frag
@@ -34,12 +34,20 @@ layout(binding = 0) uniform sampler2D textureData;
 #else
 uniform sampler2D textureData;
 #endif
-#else
-#ifdef EXPLICIT_UNIFORM_LOCATION
-layout(location = 1) uniform vec4 color;
-#else
-uniform lowp vec4 color;
 #endif
+
+#ifdef EXPLICIT_UNIFORM_LOCATION
+#   ifndef GL_ES
+layout(location = 1) uniform vec4 color = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+#   else
+layout(location = 1) uniform vec4 color;
+#   endif
+#else
+#   ifndef GL_ES
+uniform lowp vec4 color = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+#   else
+unfirom lowp vec4 color;
+#   endif
 #endif
 
 #ifdef TEXTURED
@@ -52,7 +60,7 @@ out lowp vec4 fragmentColor;
 
 void main() {
     #ifdef TEXTURED
-    fragmentColor = texture(textureData, interpolatedTextureCoordinates);
+    fragmentColor = color * texture(textureData, interpolatedTextureCoordinates);
     #else
     fragmentColor = color;
     #endif

--- a/src/Shaders/Flat.h
+++ b/src/Shaders/Flat.h
@@ -124,7 +124,8 @@ template<UnsignedInt dimensions> class MAGNUM_SHADERS_EXPORT Flat: public Abstra
          * @brief Set color
          * @return Reference to self (for method chaining)
          *
-         * Has no effect if @ref Flag::Textured is set.
+         * Color will be multiplied with texture
+         * if @ref Flag::Textured is set.
          */
         Flat<dimensions>& setColor(const Color4& color);
 
@@ -144,7 +145,7 @@ typedef Flat<3> Flat3D;
 CORRADE_ENUMSET_OPERATORS(Implementation::FlatFlags)
 
 template<UnsignedInt dimensions> inline Flat<dimensions>& Flat<dimensions>::setColor(const Color4& color) {
-    if(!(_flags & Flag::Textured)) setUniform(colorUniform, color);
+    setUniform(colorUniform, color);
     return *this;
 }
 


### PR DESCRIPTION
This allows blending to be done (with the texture and colour).

It is quite useful as with this you can change the transparency of an object quite simply*. Also, this allows re-colouring of textures to be done. e.g. if you made a coin image for your game, and wish to have different types of coins without having to re-create assets, you could just re-colour them.

*it might be wise to actually have this as a separate uniform, with the color attribute only having RGB values.

---

Basically a duplicate of #33, except I:
- Added default colour to be white (with OpenGL ES it calls `setColor`, and on desktop it is set in the shader)
- Updated the fork to be of the same commit you have (although I basically re-made a fork instead of updating it, oopsies, my bad there)
