### PR TITLE
1.Build problems on Mac OS X (10.9) #23

### DIFF
--- a/modules/FindSDL2.cmake
+++ b/modules/FindSDL2.cmake
@@ -43,7 +43,7 @@ endif()
 
 # Include dir
 find_path(SDL2_INCLUDE_DIR
-    NAMES SDL.h SDL_scancode.h
+    NAMES SDL_scancode.h
     PATH_SUFFIXES ${PATH_SUFFIXES}
 )
 


### PR DESCRIPTION
Recommended fix:
https://github.com/mosra/magnum/blob/master/modules/FindSDL2.cmake#L46 to list only SDL_scancode.h (i.e. remove SDL.h)

Test:
Add SDL2 Lib to the /Libraries/Frameworks/
Builds file.

Add SDL2 Lib and SDL1 to the /Libraries/Frameworks/
Build fails.

Remove SDL.h from at line 46.

Builds fine.

Remove SDL 1 from the /Libraries/Frameworks/

Builds fine.
