### PR TITLE
fix compile problem on g++ 4.8.2 on os x

### DIFF
--- a/src/MagnumExternal/Optional/optional.hpp
+++ b/src/MagnumExternal/Optional/optional.hpp
@@ -154,7 +154,7 @@ template <class T> inline constexpr typename std::remove_reference<T>::type&& co
   # elif defined __clang__ || defined __GNU_LIBRARY__
     __assert(expr, file, line);
   # elif defined __GNUC__
-    _assert(expr, file, line);
+    __assert(expr, file, line);
   # else
   #   error UNSUPPORTED COMPILER
   # endif


### PR DESCRIPTION
I had to apply this patch to optional.hpp to get it to compile under Gnu g++ 4.8.2 on OS X.  The source file seems to be from Boost, so I figure it's possible I'm just doing something wrong?

Here's the error I was getting:

```
cd /Users/smw/dev/mag/magnum/build-fail/src/Magnum && /usr/local/bin/g++-4.8   -DMagnum_EXPORTS -std=c++0x -fno-strict-aliasing -Wall -Wextra -Wold-style-cast -Winit-self -Werror=return-type -Wmissing-declarations -pedantic -fvisibility=hidden -Wzero-as-null-pointer-constant -Wdouble-promotion -fPIC -I/Users/smw/dev/mag/magnum/src -I/Users/smw/dev/mag/magnum/build-fail/src -I/usr/local/magnum/include -I/Corrade -I/Users/smw/dev/mag/magnum/src/MagnumExternal/OpenGL    -DGLLoadGen_EXPORTS -fPIC -o CMakeFiles/Magnum.dir/Trade/AbstractImporter.cpp.o -c /Users/smw/dev/mag/magnum/src/Magnum/Trade/AbstractImporter.cpp
In file included from /Users/smw/dev/mag/magnum/src/Magnum/Trade/AbstractImporter.h:39:0,
                 from /Users/smw/dev/mag/magnum/src/Magnum/Trade/AbstractImporter.cpp:26:
/Users/smw/dev/mag/magnum/src/MagnumExternal/Optional/optional.hpp: In function 'void std::fail(const char*, const char*, unsigned int)':
/Users/smw/dev/mag/magnum/src/MagnumExternal/Optional/optional.hpp:157:29: error: '_assert' was not declared in this scope
     _assert(expr, file, line);
                             ^
make[2]: *** [src/Magnum/CMakeFiles/Magnum.dir/Trade/AbstractImporter.cpp.o] Error 1
make[1]: *** [src/Magnum/CMakeFiles/Magnum.dir/all] Error 2
make: *** [all] Error 2
```

CMake like this:

```
2.0.0 foo:~/dev/mag/magnum/build-fail master $ export CC=/usr/local/bin/gcc-4.8
2.0.0 foo:~/dev/mag/magnum/build-fail master $ export CXX+=/usr/local/bin/g++-4.8
2.0.0 foo:~/dev/mag/magnum/build-fail master $ cmake -DCMAKE_INSTALL_PREFIX=/usr/local/magnum ..
```
