### PR TITLE
    cmake:  better library handling on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,20 @@
 cmake_minimum_required(VERSION 2.8.8)
 project(Magnum)
 
+if (APPLE)
+    # enable @rpath in the install name for any shared library being built
+    # note: it is planned that a future version of CMake will enable this by default
+    set(CMAKE_MACOSX_RPATH 1)
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    # the RPATH to be used when installing, but only if it's not a system directory
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    IF("${isSystemDir}" STREQUAL "-1")
+       SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    ENDIF("${isSystemDir}" STREQUAL "-1")
+endif()
+
 # Find Corrade first so we can check on the target
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/modules/")
 find_package(Corrade REQUIRED)


### PR DESCRIPTION
```
    added stanza to automatically add @rpath relative path to shared libraries a
    store rpath info to libraries in non-system-standard locations on OS X
```

Without this patch, executables can't find shared libraries that they're built with, in the original location, without mucking with DYLD_FALLBACK_LIBRARY_PATH or the like.

For instance, if I build corrade with `cmake -DCMAKE_INSTALL_PREFIX=/usr/local/magnum ..` and then install, /usr/local/magnum/bin/corrade-rc will fail to run because it's unable to find libCorradeUtility.

With this patch, executables that have a shared library dependency outside of the system-defined library locations will have an LC_RPATH attribute set with the library directories they should search, and those shared libraries will have an `@rpath` relative location.

This represents my newly acquired, limited knowledge on the subject, but it does seem to work correctly under both clang and gcc, and seems like it should really be the default for CMake on OS X.

Code adopted from an example in the first link.

```
$ otool -l /usr/local/magnum/bin/corrade-rc | tail -3
          cmd LC_RPATH
      cmdsize 40
         path /usr/local/magnum/lib (offset 12)

$ otool -D /usr/local/magnum/lib/libCorradeUtility.dylib
/usr/local/magnum/lib/libCorradeUtility.dylib:
@rpath/libCorradeUtility.0.dylib
```

*http://www.cmake.org/Wiki/CMake_RPATH_handling#Mac_OS_X_and_the_RPATH
*https://blogs.oracle.com/dipol/entry/dynamic_libraries_rpath_and_mac
