### PR TITLE
Switched SDL2 application's wheel direction

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -271,7 +271,7 @@ void Sdl2Application::mainLoop() {
 
             case SDL_MOUSEWHEEL:
                 if(event.wheel.y != 0) {
-                    MouseEvent e(event.wheel.y < 0 ? MouseEvent::Button::WheelUp : MouseEvent::Button::WheelDown, {event.wheel.x, event.wheel.y});
+                    MouseEvent e(event.wheel.y > 0 ? MouseEvent::Button::WheelUp : MouseEvent::Button::WheelDown, {event.wheel.x, event.wheel.y});
                     mousePressEvent(e);
                 } break;
 


### PR DESCRIPTION
Currently scrolling down generates wheel up events and vice versa. From SDL2 docs: "Movements down (scroll backward) generate negative y values and up (scroll forward) generate positive y values."
