### PR TITLE
Added a workaround for a bug in my graphics driver(?) whereby ...

### DIFF
--- a/src/Magnum/Mesh.cpp
+++ b/src/Magnum/Mesh.cpp
@@ -406,7 +406,15 @@ void Mesh::attributePointerImplementationDSAEXT(const GenericAttribute& attribut
     _created = true;
     glEnableVertexArrayAttribEXT(_id, attribute.location);
     glVertexArrayVertexAttribOffsetEXT(_id, attribute.buffer->id(), attribute.location, attribute.size, attribute.type, attribute.normalized, attribute.stride, attribute.offset);
-    if(attribute.divisor) glVertexArrayVertexAttribDivisorEXT(_id, attribute.location, attribute.divisor);
+    if(attribute.divisor) {
+		if (glVertexArrayVertexAttribDivisorEXT) {
+			glVertexArrayVertexAttribDivisorEXT(_id, attribute.location, attribute.divisor);
+		}
+		else {
+			glVertexArrayVertexAttribBindingEXT(_id, attribute.location, attribute.location);
+			glVertexArrayVertexBindingDivisorEXT(_id, attribute.location, attribute.divisor);
+		}
+	}
 }
 #endif
 


### PR DESCRIPTION
glVertexArrayVertexAttribDivisorEXT was not defined. Not sure about the bindingindex parameter, re-used location, maybe that's bad.

Here's some of my glxinfo:
server glx vendor string: ATI
server glx version string: 1.4
client glx vendor string: ATI
client glx version string: 1.4
OpenGL vendor string: Advanced Micro Devices, Inc.
OpenGL renderer string: AMD Radeon HD 7800 Series  
OpenGL core profile version string: 4.3.12874 Core Profile Context 13.35.1005
OpenGL core profile shading language version string: 4.30
OpenGL version string: 4.4.12874 Compatibility Profile Context 13.35.1005
OpenGL shading language version string: 4.30

And from lspci:
05:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Pitcairn PRO [Radeon HD 7850](prog-if 00 [VGA controller])
    Subsystem: Micro-Star International Co., Ltd. [MSI] Device 2733
    Flags: bus master, fast devsel, latency 0, IRQ 47
    Memory at e0000000 (64-bit, prefetchable) [size=256M]
    Memory at feb80000 (64-bit, non-prefetchable) [size=256K]
    I/O ports at e000 [size=256]
    [virtual] Expansion ROM at feb00000 [disabled] [size=128K]
    Capabilities: [48] Vendor Specific Information: Len=08 <?>
    Capabilities: [50] Power Management version 3
    Capabilities: [58] Express Legacy Endpoint, MSI 00
    Capabilities: [a0] MSI: Enable+ Count=1/1 Maskable- 64bit+
    Capabilities: [100] Vendor Specific Information: ID=0001 Rev=1 Len=010 <?>
    Capabilities: [150] Advanced Error Reporting
    Capabilities: [270] #19
    Capabilities: [2b0] Address Translation Service (ATS)
    Capabilities: [2c0] #13
    Capabilities: [2d0] #1b
    Kernel driver in use: fglrx_pci
