### PR TITLE
OpenAL extension support

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -277,7 +277,9 @@ ALIASES                = \
     "es_extension2{3}=<a href=\"http://www.khronos.org/registry/gles/extensions/\1/\3.txt\"><tt>\1_\2</tt></a>" \
     "webgl_extension{2}=<a href=\"https://www.khronos.org/registry/webgl/extensions/\1_\2/\"><tt>\1_\2</tt></a>" \
     "fn_al{1}=`al\1()`" \
+    "fn_alc{1}=`alc\1()`" \
     "def_al{1}=`AL_\1`" \
+    "def_alc{1}=`ALC_\1`" \
     "al_extension{2}=<a href=\"http://icculus.org/alextreg/index.php?operation=op_showext&extname=\1_\2\"><tt>AL_\1_\2</tt></a>" \
     "alc_extension{2}=<a href=\"http://icculus.org/alextreg/index.php?operation=op_showext&extname=\1_\2\"><tt>ALC_\1_\2</tt></a>"
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -277,7 +277,9 @@ ALIASES                = \
     "es_extension2{3}=<a href=\"http://www.khronos.org/registry/gles/extensions/\1/\3.txt\"><tt>\1_\2</tt></a>" \
     "webgl_extension{2}=<a href=\"https://www.khronos.org/registry/webgl/extensions/\1_\2/\"><tt>\1_\2</tt></a>" \
     "fn_al{1}=`al\1()`" \
-    "def_al{1}=`AL_\1`"
+    "def_al{1}=`AL_\1`" \
+    "al_extension{2}=<a href=\"http://icculus.org/alextreg/index.php?operation=op_showext&extname=\1_\2\"><tt>AL_\1_\2</tt></a>" \
+    "alc_extension{2}=<a href=\"http://icculus.org/alextreg/index.php?operation=op_showext&extname=\1_\2\"><tt>ALC_\1_\2</tt></a>"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/doc/openal-support.dox
+++ b/doc/openal-support.dox
@@ -47,6 +47,7 @@ Extension                                   | Status
 Extension                                   | Status
 ------------------------------------------- | ------
 @alc_extension{SOFTX,HRTF}                  | done
+@alc_extension{SOFT,HRTF}                   | done
 
 
 */

--- a/doc/openal-support.dox
+++ b/doc/openal-support.dox
@@ -1,0 +1,52 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @page openal-support OpenAL support state
+@brief List of (un)supported OpenAL features and extensions.
+
+@tableofcontents
+
+@section openal-support-state OpenAL implementation state
+
+The extension implementation is considered complete if all its defined types,
+functions and enum values are exposed through the API.
+
+
+@subsection openal-extension-support Extensions
+
+Extension                                   | Status
+------------------------------------------- | ------
+@al_extension{EXT,double}                   | done
+@al_extension{EXT,float32}                  | done
+
+@subsection openal-extension-support OpenAL Soft Extensions
+
+Extension                                   | Status
+------------------------------------------- | ------
+@alc_extension{SOFTX,HRTF}                  | done
+
+
+*/

--- a/src/Magnum/Audio/Buffer.cpp
+++ b/src/Magnum/Audio/Buffer.cpp
@@ -36,6 +36,9 @@ Debug& operator<<(Debug& debug, const Buffer::Format value) {
         _c(Mono16)
         _c(Stereo8)
         _c(Stereo16)
+
+        _c(MonoFloat32)
+        _c(StereoFloat32)
         #undef _c
     }
 

--- a/src/Magnum/Audio/Buffer.h
+++ b/src/Magnum/Audio/Buffer.h
@@ -31,6 +31,9 @@
 
 #include <utility>
 #include <al.h>
+#include <alc.h>
+#include "MagnumExternal/OpenAL/extensions.h"
+
 #include <Corrade/Containers/ArrayView.h>
 
 #include "Magnum/Magnum.h"
@@ -52,7 +55,21 @@ class Buffer {
             Mono8 = AL_FORMAT_MONO8,        /**< 8-bit unsigned mono */
             Mono16 = AL_FORMAT_MONO16,      /**< 16-bit signed mono */
             Stereo8 = AL_FORMAT_STEREO8,    /**< 8-bit interleaved unsigned stereo */
-            Stereo16 = AL_FORMAT_STEREO16   /**< 16-bit interleaved signed stereo */
+            Stereo16 = AL_FORMAT_STEREO16,   /**< 16-bit interleaved signed stereo */
+
+            /**
+             * @brief 32-bit mono
+             *
+             * @requires_al_extension extension @al_extension{EXT,float32}
+             */
+            MonoFloat32 = AL_FORMAT_MONO_FLOAT32,
+
+            /**
+             * @brief 32-bit interleaved stereo
+             *
+             * @requires_al_extension extension @al_extension{EXT,float32}
+             */
+            StereoFloat32 = AL_FORMAT_STEREO_FLOAT32,
         };
 
         /**

--- a/src/Magnum/Audio/Buffer.h
+++ b/src/Magnum/Audio/Buffer.h
@@ -70,6 +70,20 @@ class Buffer {
              * @requires_al_extension extension @al_extension{EXT,float32}
              */
             StereoFloat32 = AL_FORMAT_STEREO_FLOAT32,
+
+            /**
+             * @brief 64-bit mono
+             *
+             * @requires_al_extension extension @al_extension{EXT,double}
+             */
+            MonoDouble = AL_FORMAT_MONO_DOUBLE_EXT,
+
+            /**
+             * @brief 64-bit interleaved stereo
+             *
+             * @requires_al_extension extension @al_extension{EXT,double}
+             */
+            StereoDouble = AL_FORMAT_STEREO_DOUBLE_EXT,
         };
 
         /**

--- a/src/Magnum/Audio/CMakeLists.txt
+++ b/src/Magnum/Audio/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MagnumAudio_HEADERS
     Audio.h
     Buffer.h
     Context.h
+    Extensions.h
     Renderer.h
     Source.h
 

--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -45,7 +45,8 @@ const std::vector<Extension>& Extension::extensions() {
         _extension(AL,EXT,FLOAT32),
         _extension(AL,EXT,DOUBLE),
         _extension(ALC,EXT,ENUMERATION),
-        _extension(ALC,SOFTX,HRTF)
+        _extension(ALC,SOFTX,HRTF),
+        _extension(ALC,SOFT,HRTF)
     };
     #undef _entension
 

--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -54,6 +54,10 @@ Context::Context() {
 
     alcMakeContextCurrent(_context);
     _current = this;
+
+    /* Print some info */
+    Debug() << "Audio Renderer:" << rendererString() << "by" << vendorString();
+    Debug() << "OpenAL version:" << versionString();
 }
 
 Context::~Context() {

--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -44,6 +44,7 @@ const std::vector<Extension>& Extension::extensions() {
     static const std::vector<Extension> extensions{
         _extension(AL,EXT,FLOAT32),
         _extension(AL,EXT,DOUBLE),
+        _extension(ALC,EXT,ENUMERATION),
         _extension(ALC,SOFTX,HRTF)
     };
     #undef _entension

--- a/src/Magnum/Audio/Context.h
+++ b/src/Magnum/Audio/Context.h
@@ -240,13 +240,20 @@ class MAGNUM_AUDIO_EXPORT Context::Configuration {
             return *this;
         }
 
-        /** @brief Whether to use hrtfs */
+        /**
+         * @brief Whether to use hrtfs
+         * @requires_alc_extension for HRTFs, extension @alc_extension{SOFTX,HRTF}
+         *      or @alc_extension{SOFT,HRTF}
+         */
         EnabledState isHrtfEnabled() const { return _enableHrtf; }
 
         /**
          * @brief Set whether to use hrtfs
          *
          * Defaults to local OpenAL configuration or false.
+         * @requires_alc_extension for HRTFs otherwise setting will be ignored,
+         *      extension @alc_extension{SOFTX,HRTF} or
+         *      @alc_extension{SOFT,HRTF}
          */
         Configuration& setHrtfEnabled(EnabledState hrtf) {
             _enableHrtf = hrtf;

--- a/src/Magnum/Audio/Context.h
+++ b/src/Magnum/Audio/Context.h
@@ -140,7 +140,8 @@ class MAGNUM_AUDIO_EXPORT Context {
          * @ref supportedExtensions(), @ref Extension::extensions() or
          * @ref isExtensionSupported() for alternatives.
          * @see @fn_al{Get} with @def_al{NUM_EXTENSIONS}, @fn_al{GetString}
-         *      with @def_al{EXTENSIONS}
+         *      with @def_al{EXTENSIONS}, @fn_alc{GetString} with
+         *      @def_alc{EXTENSIONS}
          */
         std::vector<std::string> extensionStrings() const;
 

--- a/src/Magnum/Audio/Extensions.h
+++ b/src/Magnum/Audio/Extensions.h
@@ -67,6 +67,12 @@ namespace Extensions {
         constexpr static const char* string() { return #prefix "_" #vendor "_" #extension; } \
     };
 
+#define _extension_rev(prefix, vendor, extension) \
+    struct extension {                                                      \
+        enum: std::size_t { Index = __LINE__-1 };                                \
+        constexpr static const char* string() { return #prefix "_" #extension "_" #vendor; } \
+    };
+
 /* IMPORTANT: don't forget to add new extensions also in Context.cpp */
 namespace AL {
     #line 1
@@ -75,6 +81,9 @@ namespace AL {
         _extension(AL,EXT,DOUBLE) // #???
     }
 } namespace ALC {
+    namespace EXT {
+        _extension_rev(ALC,EXT,ENUMERATION) // #???
+    }
     namespace SOFTX {
         _extension(ALC,SOFTX,HRTF) // #???
     }

--- a/src/Magnum/Audio/Extensions.h
+++ b/src/Magnum/Audio/Extensions.h
@@ -87,6 +87,9 @@ namespace AL {
     namespace SOFTX {
         _extension(ALC,SOFTX,HRTF) // #???
     }
+    namespace SOFT {
+        _extension(ALC,SOFT,HRTF) // #???
+    }
 }
 #undef _extension
 #undef _extension_rev

--- a/src/Magnum/Audio/Extensions.h
+++ b/src/Magnum/Audio/Extensions.h
@@ -89,6 +89,7 @@ namespace AL {
     }
 }
 #undef _extension
+#undef _extension_rev
 #endif
 
 }

--- a/src/Magnum/Audio/Extensions.h
+++ b/src/Magnum/Audio/Extensions.h
@@ -1,0 +1,89 @@
+#ifndef Magnum_Audio_Extensions_h
+#define Magnum_Audio_Extensions_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Namespace @ref Magnum::Audio::Extensions
+ */
+
+#include "MagnumExternal/OpenAL/extensions.h"
+
+namespace Magnum { namespace Audio {
+
+/**
+@brief Compile-time information about OpenAL extensions
+
+Each extension is `struct` named hierarchically by prefix, vendor and
+extension name taken from list at @ref openal-support, for example
+`ALC::SOFTX::HRTF`.
+
+Each struct has the same public methods as @ref Extension class
+(@ref Extension::requiredVersion() "requiredVersion()",
+@ref Extension::coreVersion() "coreVersion()" and @ref Extension::string() "string()"),
+but these structs are better suited for compile-time decisions rather than
+@ref Extension instances. See @ref Context::isExtensionSupported() for example
+usage.
+
+This namespace is not built by default. It is built if `WITH_AUDIO` is
+enabled when building Magnum. To use this library, you need to request
+`Audio` component of `Magnum` package in CMake, add `${MAGNUM_AUDIO_INCLUDE_DIRS}`
+to include path and link to `${MAGNUM_AUDIO_LIBRARIES}`. See @ref building and
+@ref cmake for more information. Additional plugins are enabled separately, see
+particular `*Importer` class documentation, @ref building-plugins,
+@ref cmake-plugins and @ref plugins for more information.
+@see @ref MAGNUM_ASSERT_AUDIO_EXTENSION_SUPPORTED()
+@todo Manual indices for extensions, this has gaps
+*/
+namespace Extensions {
+
+#ifndef DOXYGEN_GENERATING_OUTPUT
+#define _extension(prefix, vendor, extension) \
+    struct extension {                                                      \
+        enum: std::size_t { Index = __LINE__-1 };                                \
+        constexpr static const char* string() { return #prefix "_" #vendor "_" #extension; } \
+    };
+
+/* IMPORTANT: don't forget to add new extensions also in Context.cpp */
+namespace AL {
+    #line 1
+    namespace EXT {
+        _extension(AL,EXT,FLOAT32) // #???
+        _extension(AL,EXT,DOUBLE) // #???
+    }
+} namespace ALC {
+    namespace SOFTX {
+        _extension(ALC,SOFTX,HRTF) // #???
+    }
+}
+#undef _extension
+#endif
+
+}
+
+}}
+
+#endif

--- a/src/Magnum/Audio/Renderer.cpp
+++ b/src/Magnum/Audio/Renderer.cpp
@@ -60,4 +60,19 @@ Debug& operator<<(Debug& debug, const Renderer::DistanceModel value) {
     return debug << "Audio::Renderer::DistanceModel::(invalid)";
 }
 
+Debug& operator<<(Debug& debug, const Renderer::HrtfStatus value) {
+    switch(value) {
+        #define _c(value) case Renderer::HrtfStatus::value: return debug << "Audio::Renderer::HrtfStatus::" #value;
+        _c(Disabled)
+        _c(Enabled)
+        _c(Denied)
+        _c(Required)
+        _c(Detected)
+        _c(UnsupportedFormat)
+        #undef _c
+    }
+
+    return debug << "Audio::Renderer::HrtfStatus::(invalid)";
+}
+
 }}

--- a/src/Magnum/Audio/Test/CMakeLists.txt
+++ b/src/Magnum/Audio/Test/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(AudioAbstractImporterTest AbstractImporterTest.cpp LIBRARIES MagnumAudio)
 corrade_add_test(AudioBufferTest BufferTest.cpp LIBRARIES MagnumAudio)
+corrade_add_test(AudioContextTest ContextTest.cpp LIBRARIES MagnumAudio)
 corrade_add_test(AudioRendererTest RendererTest.cpp LIBRARIES MagnumAudio)
 corrade_add_test(AudioSourceTest SourceTest.cpp LIBRARIES MagnumAudio)
 

--- a/src/Magnum/Audio/Test/ContextTest.cpp
+++ b/src/Magnum/Audio/Test/ContextTest.cpp
@@ -1,0 +1,61 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <sstream>
+#include <Corrade/TestSuite/Tester.h>
+
+#include "Magnum/Audio/Extensions.h"
+#include "Magnum/Audio/Context.h"
+
+namespace Magnum { namespace Audio { namespace Test {
+
+struct ContextTest: TestSuite::Tester {
+    explicit ContextTest();
+
+    void extensionsString();
+    void isExtensionEnabled();
+
+    Context _context;
+};
+
+ContextTest::ContextTest() {
+    addTests({&ContextTest::extensionsString,
+              &ContextTest::isExtensionEnabled});
+}
+
+void ContextTest::extensionsString() {
+    std::vector<std::string> extensions = _context.extensionStrings();
+
+    CORRADE_VERIFY(extensions.size() > 0);
+}
+
+void ContextTest::isExtensionEnabled() {
+    CORRADE_VERIFY(Context::current()->isExtensionSupported<Extensions::ALC::EXT::ENUMERATION>());
+}
+
+}}}
+
+CORRADE_TEST_MAIN(Magnum::Audio::Test::ContextTest)

--- a/src/Magnum/Audio/Test/RendererTest.cpp
+++ b/src/Magnum/Audio/Test/RendererTest.cpp
@@ -37,6 +37,7 @@ struct RendererTest: TestSuite::Tester {
 
     void debugError();
     void debugDistanceModel();
+    void hrtfStatus();
     void listenerOrientation();
     void listenerPosition();
     void listenerVelocity();
@@ -44,6 +45,7 @@ struct RendererTest: TestSuite::Tester {
     void speedOfSound();
     void dopplerFactor();
     void distanceModel();
+    void hrtfs();
 
     Context _context;
 };
@@ -51,13 +53,15 @@ struct RendererTest: TestSuite::Tester {
 RendererTest::RendererTest() {
     addTests({&RendererTest::debugError,
               &RendererTest::debugDistanceModel,
+              &RendererTest::hrtfStatus,
               &RendererTest::listenerOrientation,
               &RendererTest::listenerPosition,
               &RendererTest::listenerVelocity,
               &RendererTest::listenerGain,
               &RendererTest::speedOfSound,
               &RendererTest::dopplerFactor,
-              &RendererTest::distanceModel});
+              &RendererTest::distanceModel,
+              &RendererTest::hrtfs});
 }
 
 void RendererTest::debugError() {
@@ -70,6 +74,12 @@ void RendererTest::debugDistanceModel() {
     std::ostringstream out;
     Debug(&out) << Renderer::DistanceModel::Inverse;
     CORRADE_COMPARE(out.str(), "Audio::Renderer::DistanceModel::Inverse\n");
+}
+
+void RendererTest::hrtfStatus() {
+    std::ostringstream out;
+    Debug(&out) << Renderer::HrtfStatus::Denied;
+    CORRADE_COMPARE(out.str(), "Audio::Renderer::HrtfStatus::Denied\n");
 }
 
 void RendererTest::listenerOrientation() {
@@ -121,6 +131,12 @@ void RendererTest::distanceModel() {
     Renderer::setDistanceModel(model);
 
     CORRADE_COMPARE(Renderer::distanceModel(), model);
+}
+
+void RendererTest::hrtfs() {
+    /* At least test that the hrtf status is `Disabled` */
+    CORRADE_VERIFY(!Renderer::isHrtfEnabled());
+    CORRADE_COMPARE(Renderer::hrtfStatus(), Renderer::HrtfStatus::Disabled);
 }
 
 }}}

--- a/src/Magnum/DebugTools/ShapeRenderer.h
+++ b/src/Magnum/DebugTools/ShapeRenderer.h
@@ -126,7 +126,7 @@ Visualizes collision shapes using wireframe primitives. See
 Example code:
 @code
 // Create some options
-DebugTools::ResourceManager::instance()->set("red",
+DebugTools::ResourceManager::instance().set("red",
     DebugTools::ShapeRendererOptions().setColor({1.0f, 0.0f, 0.0f}));
 
 // Create debug renderer for given shape, use "red" options for it

--- a/src/Magnum/ResourceManager.h
+++ b/src/Magnum/ResourceManager.h
@@ -231,7 +231,7 @@ Resource<Mesh> cube{manager.get<Mesh>("cube")};
 if(!cube) {
     Mesh* mesh = new Mesh;
     // ...
-    manager->set(cube.key(), mesh, ResourceDataState::Final, ResourcePolicy::Resident);
+    manager.set(cube.key(), mesh, ResourceDataState::Final, ResourcePolicy::Resident);
 }
 @endcode
 -   Using the resource data.

--- a/src/MagnumExternal/OpenAL/CMakeLists.txt
+++ b/src/MagnumExternal/OpenAL/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015
 #             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -23,6 +24,4 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-add_subdirectory(OpenAL)
-add_subdirectory(OpenGL)
-add_subdirectory(Optional)
+install(FILES extensions.h DESTINATION ${MAGNUM_EXTERNAL_INCLUDE_INSTALL_DIR}/OpenAL)

--- a/src/MagnumExternal/OpenAL/extensions.h
+++ b/src/MagnumExternal/OpenAL/extensions.h
@@ -1,0 +1,65 @@
+#ifndef MagnumExternal_OpenAL_extensions_h
+#define MagnumExternal_OpenAL_extensions_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* AL_EXT_float32 */
+#ifndef AL_EXT_float32
+#define AL_EXT_float32 1
+#define AL_FORMAT_MONO_FLOAT32                   0x10010
+#define AL_FORMAT_STEREO_FLOAT32                 0x10011
+#endif
+
+/* ALC_SOFT_HRTF */
+#ifndef ALC_SOFT_HRTF
+#define ALC_SOFT_HRTF 1
+#define ALC_HRTF_SOFT                            0x1992
+
+#define ALC_HRTF_ID_SOFT                         0x1996
+
+#define ALC_DONT_CARE_SOFT                       0x0002
+
+#define ALC_HRTF_STATUS_SOFT                     0x1993
+#define ALC_NUM_HRTF_SPECIFIER_SOFT              0x1994
+#define ALC_HRTF_SPECIFIER_SOFT                  0x1995
+
+#define ALC_HRTF_DISABLED_SOFT                   0x0000
+#define ALC_HRTF_ENABLED_SOFT                    0x0001
+#define ALC_HRTF_DENIED_SOFT                     0x0002
+#define ALC_HRTF_REQUIRED_SOFT                   0x0003
+#define ALC_HRTF_HEADPHONES_DETECTED_SOFT        0x0004
+#define ALC_HRTF_UNSUPPORTED_FORMAT_SOFT         0x0005
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/MagnumExternal/OpenAL/extensions.h
+++ b/src/MagnumExternal/OpenAL/extensions.h
@@ -26,6 +26,9 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#include <al.h>
+#include <alc.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,6 +45,12 @@ extern "C" {
 #define AL_EXT_double 1
 #define AL_FORMAT_MONO_DOUBLE_EXT                0x10012
 #define AL_FORMAT_STEREO_DOUBLE_EXT              0x10013
+#endif
+
+/* ALC_SOFTX_HRTF */
+#ifndef ALC_SOFTX_HRTF
+#define ALC_SOFTX_HRTF 1
+#define ALC_HRTF_SOFT                            0x1992
 #endif
 
 /* ALC_SOFT_HRTF */
@@ -63,6 +72,9 @@ extern "C" {
 #define ALC_HRTF_REQUIRED_SOFT                   0x0003
 #define ALC_HRTF_HEADPHONES_DETECTED_SOFT        0x0004
 #define ALC_HRTF_UNSUPPORTED_FORMAT_SOFT         0x0005
+
+typedef ALCchar* (AL_APIENTRY*LPALGETSTRINGISOFT)(ALCdevice*,ALCenum,ALCsizei);
+typedef ALCboolean (AL_APIENTRY*LPALRESETDEVICESOFT)(ALCdevice*,const ALCint*);
 #endif
 
 #ifdef __cplusplus

--- a/src/MagnumExternal/OpenAL/extensions.h
+++ b/src/MagnumExternal/OpenAL/extensions.h
@@ -37,6 +37,13 @@ extern "C" {
 #define AL_FORMAT_STEREO_FLOAT32                 0x10011
 #endif
 
+/* AL_EXT_double */
+#ifndef AL_EXT_double
+#define AL_EXT_double 1
+#define AL_FORMAT_MONO_DOUBLE_EXT                0x10012
+#define AL_FORMAT_STEREO_DOUBLE_EXT              0x10013
+#endif
+
 /* ALC_SOFT_HRTF */
 #ifndef ALC_SOFT_HRTF
 #define ALC_SOFT_HRTF 1


### PR DESCRIPTION
Hi @mosra, Hi everybody!

here is a work-in-progress pullrequest for anything related to Audio and OpenAL extension support.

TODOs:
- [x] Add support for OpenAL extensions
   - [x] Finish doc
   - [x] Ensure `Format Type` parameter is a useful config setting. (format type and channels are for the loopback extension, will will not be supported for now.)
   - [x] Tests
- [x] Implement `AL_EXT_float32` and `AL_EXT_double`
   - Not really anything to test.
- [x] Add support for the OpenAL soft hrtfs
   - [x] Tests

Greetings, Squareys