### PR TITLE
Dual Quternion Screw Linear Interpolation

### DIFF
--- a/src/Magnum/Math/DualQuaternion.h
+++ b/src/Magnum/Math/DualQuaternion.h
@@ -66,20 +66,20 @@ template<class T> inline DualQuaternion<T> sclerp(const DualQuaternion<T>& from,
 
     const T dotResult = dot(from.real().vector(), to.real().vector());
 
-    /* Multiplying with -1.0f ensures shortest path when dot < 0. */
+    /* Multiplying with -1 ensures shortest path when dot < 0 */
     /* diff = \hat d = p^*q */
-    const DualQuaternion<T> diff = from.quaternionConjugated()*((dotResult < .0) ? -to : to);
+    const DualQuaternion<T> diff = from.quaternionConjugated()*((dotResult < T(0)) ? -to : to);
 
     /* angle = t \hat a_D */
-    const T angle = acos(diff.real().scalar())*t;
+    const T angle = std::acos(diff.real().scalar())*t;
     /* precompute sin/cos for manifold use */
-    const T sinAngle = sin(angle);
-    const T cosAngle = cos(angle);
+    const T sinAngle = std::sin(angle);
+    const T cosAngle = std::cos(angle);
 
     /* merely a shortcut */
     const Vector3<T>& m = diff.real().vector();
     /* invr = \frac 1 {|l_V|} */
-    const T invr = 1/m.length();
+    const T invr = m.lengthInverted();
     /* direction = \hat {\boldsymbol n} = \hat l_V \frac 1 {|l_V|} */
     const Vector3<T> direction = m*invr;
 
@@ -88,14 +88,14 @@ template<class T> inline DualQuaternion<T> sclerp(const DualQuaternion<T>& from,
     const Vector3<T> v = direction*sinAngle;
 
     /* pitch = \frac {\hat a_D} 2 = m_S \frac 1 {|l_V|} */
-    T pitch = -diff.dual().scalar()*invr;
+    const T pitch = -diff.dual().scalar()*invr;
     /* moment = \hat {\boldsymbol n}_D */
     const Vector3<T> moment = (diff.dual().vector() - (direction*(pitch*diff.real().scalar())))*invr;
-    pitch *= t;
+    const T pitchT = pitch*t;
     /* Vector of dual part of q_{ScLERP} */
-    const Vector3<T> v2 = moment*sinAngle + direction*(pitch*cosAngle);
+    const Vector3<T> v2 = moment*sinAngle + direction*(pitchT*cosAngle);
 
-    return from*DualQuaternion<T>{Quaternion<T>{v, cosAngle}, Quaternion<T>{v2, -pitch*sinAngle}};
+    return from*DualQuaternion<T>{Quaternion<T>{v, cosAngle}, Quaternion<T>{v2, -pitchT*sinAngle}};
 }
 
 /**

--- a/src/Magnum/Math/DualQuaternion.h
+++ b/src/Magnum/Math/DualQuaternion.h
@@ -69,26 +69,22 @@ template<class T> inline DualQuaternion<T> sclerp(const DualQuaternion<T>& from,
     /* Multiplying with -1.0f ensures shortest path when dot < 0. */
     const DualQuaternion<T> diff = from.quaternionConjugated()*((dotResult < .0) ? -to : to);
 
-    const Vector3<T> diffReal = diff.real().vector();
-    const Vector3<T> diffDual = diff.dual().vector();
+    const T angle = acos(diff.real().scalar())*t;
+    const T sinAngle = sin(angle);
+    const T cosAngle = cos(angle);
 
+    const Vector3<T>& diffReal = diff.real().vector();
     const T invr = 1/std::sqrt(diffReal.dot());
-
-    T angle = 2*acos(diff.real().scalar());
-    T pitch = -2*diff.dual().scalar()*invr;
     const Vector3<T> direction = diffReal*invr;
-    const Vector3<T> moment = (diffDual - (direction*(pitch*diff.real().scalar()*.5f)))*invr;
-
-    angle *= t;
-    pitch *= t;
-
-    const T sinAngle = sin(.5f*angle);
-    const T cosAngle = cos(.5f*angle);
 
     const Vector3<T> v = direction*sinAngle;
-    const Vector3<T> v2 = moment*sinAngle + direction*(pitch*.5f*cosAngle);
 
-    return from*DualQuaternion<T>{Quaternion<T>{v, cosAngle}, Quaternion<T>{v2, -pitch*.5f*sinAngle}};
+    T pitch = -diff.dual().scalar()*invr;
+    const Vector3<T> moment = (diff.dual().vector() - (direction*(pitch*diff.real().scalar())))*invr;
+    pitch *= t;
+    const Vector3<T> v2 = moment*sinAngle + direction*(pitch*cosAngle);
+
+    return from*DualQuaternion<T>{Quaternion<T>{v, cosAngle}, Quaternion<T>{v2, -pitch*sinAngle}};
 }
 
 /**

--- a/src/Magnum/Math/DualQuaternion.h
+++ b/src/Magnum/Math/DualQuaternion.h
@@ -67,29 +67,28 @@ template<class T> inline DualQuaternion<T> sclerp(const DualQuaternion<T>& from,
     const T dotResult = dot(from.real().vector(), to.real().vector());
 
     /* Multiplying with -1 ensures shortest path when dot < 0 */
-    /* diff = \hat d = p^*q */
+    /* diff = d = p^*q */
     const DualQuaternion<T> diff = from.quaternionConjugated()*((dotResult < T(0)) ? -to : to);
 
-    /* angle = t \hat a_D */
+    /* angle = t*a_D */
     const T angle = std::acos(diff.real().scalar())*t;
-    /* precompute sin/cos for manifold use */
+    /* Precompute sin/cos for manifold use */
     const T sinAngle = std::sin(angle);
     const T cosAngle = std::cos(angle);
 
-    /* merely a shortcut */
+    /* Merely a shortcut */
     const Vector3<T>& m = diff.real().vector();
     /* invr = \frac 1 {|l_V|} */
     const T invr = m.lengthInverted();
-    /* direction = \hat {\boldsymbol n} = \hat l_V \frac 1 {|l_V|} */
+    /* direction = n = l_V * 1/|l_V| */
     const Vector3<T> direction = m*invr;
 
-    /* Vector of real part of q_{ScLERP}
-       = \hat {\boldsymbol n}_R \cdot sin \left( t \frac {\hat a_R} 2 \right)*/
+    /* Vector of real part of q_{ScLERP} = n_R*sin(t*a_R/2)*/
     const Vector3<T> v = direction*sinAngle;
 
-    /* pitch = \frac {\hat a_D} 2 = m_S \frac 1 {|l_V|} */
+    /* pitch = a_D/2 = m_S*1/|l_V| */
     const T pitch = -diff.dual().scalar()*invr;
-    /* moment = \hat {\boldsymbol n}_D */
+    /* moment = n_D */
     const Vector3<T> moment = (diff.dual().vector() - (direction*(pitch*diff.real().scalar())))*invr;
     const T pitchT = pitch*t;
     /* Vector of dual part of q_{ScLERP} */

--- a/src/Magnum/Math/Quaternion.h
+++ b/src/Magnum/Math/Quaternion.h
@@ -89,7 +89,7 @@ Expects that both quaternions are normalized. @f[
 @f]
 @see @ref Quaternion::isNormalized(), @ref slerp(const Quaternion<T>&, const Quaternion<T>&, T),
     @ref lerp(const T&, const T&, U)
- */
+*/
 template<class T> inline Quaternion<T> lerp(const Quaternion<T>& normalizedA, const Quaternion<T>& normalizedB, T t) {
     CORRADE_ASSERT(normalizedA.isNormalized() && normalizedB.isNormalized(),
         "Math::lerp(): quaternions must be normalized", {});

--- a/src/Magnum/Math/Test/DualQuaternionTest.cpp
+++ b/src/Magnum/Math/Test/DualQuaternionTest.cpp
@@ -86,6 +86,8 @@ struct DualQuaternionTest: Corrade::TestSuite::Tester {
     void transformPoint();
     void transformPointNormalized();
 
+    void sclerp();
+
     void debug();
 };
 
@@ -124,6 +126,8 @@ DualQuaternionTest::DualQuaternionTest() {
               &DualQuaternionTest::matrix,
               &DualQuaternionTest::transformPoint,
               &DualQuaternionTest::transformPointNormalized,
+
+              &DualQuaternionTest::sclerp,
 
               &DualQuaternionTest::debug});
 }
@@ -381,6 +385,27 @@ void DualQuaternionTest::debug() {
 
     Debug(&o) << DualQuaternion({{1.0f, 2.0f, 3.0f}, -4.0f}, {{0.5f, -3.1f, 3.3f}, 2.0f});
     CORRADE_COMPARE(o.str(), "DualQuaternion({{1, 2, 3}, -4}, {{0.5, -3.1, 3.3}, 2})\n");
+}
+
+void DualQuaternionTest::sclerp() {
+
+    const DualQuaternion from = DualQuaternion::translation(Vector3{20.0f, .0f, .0f})*DualQuaternion::rotation(180.0_degf, Vector3{.0f, 1.0f, .0f});
+    const DualQuaternion to = DualQuaternion::translation(Vector3{42.0f, 42.0f, 42.0f})*DualQuaternion::rotation(75.0_degf, Vector3{1.0f, .0f, .0f});
+
+    constexpr DualQuaternion expected1{Quaternion{{.23296291314453416f, .9238795325112867f, .0f}, .303603179340959f},
+                                       Quaternion{{2.235619101917766f, 2.8169719855488395f, 10.722240915237789f}, -10.287636336847847f}};
+    constexpr DualQuaternion expected2{Quaternion{{.4437679833315842f, .6845471059286887f, .0f}, .5783296955322937f},
+                                       Quaternion{{5.764394870292371f, 11.161306653193549f, 9.671267015501789f}, -17.634394590712066f}};
+    constexpr DualQuaternion expected3{Quaternion{{.5979785904506439f, .18738131458572468f, .0f}, .7793008714910992f},
+                                       Quaternion{{13.409627907069353f, 25.452124456683414f, 5.681581047706807f}, -16.409481115504978f}};
+
+    const DualQuaternion interp1 = Math::sclerp(from, to, 0.25f);
+    const DualQuaternion interp2 = Math::sclerp(from, to, 0.52f);
+    const DualQuaternion interp3 = Math::sclerp(from, to, 0.88f);
+
+    CORRADE_COMPARE(interp1, expected1);
+    CORRADE_COMPARE(interp2, expected2);
+    CORRADE_COMPARE(interp3, expected3);
 }
 
 }}}


### PR DESCRIPTION
Hi @mosra !

Late, but finally, a pullrequest for the ScLERP implementation I worked on the last few days. A few things that may be important:

- I based my work upon these papers:
   - [Dual Quternions for Rigid Transformation Blending](http://dcgi.felk.cvut.cz/home/zara/papers/TCD-CS-2006-46.pdf), Kavan et al., 2006
   - [Dual Quaternions](http://www.xbdev.net/misc_demos/demos/dual_quaternions_beyond/paper.pdf), Kenweight, 2012
- The test values were computed using [this javascript implementation](http://laht.info/WebGL/test.html), the code also served as reference.
- ~~The PR contains an "Optimize" commit, which makes the code a little harder to read. I could rework that, if that is too much of a tradeoff.~~ I added a "inline comments" commit, which helps connect portions of the formula with the code. Although reading TeX code in the comments may not help alot, I think it is enough to justify leaving the optimize commit as is.
- ~~The TeX code has only been partially tested. Also it's a mess in general and the resulting formulas could probably be improved in readability by defining vars for dual/real parts of those dual variables.~~ Now successfully compiled in an external tool and cleaned up the formulas not only for readability, but also found some missing/wrong `\hat`s.

TODOs:
 - [x] Remove the TODO comment which was not supposed to be in the commits ever.
 - [x] Remove the angle method which was added but never used

I'm really interested to read what you think of this!
Greetings, 
Squareys