### PR TITLE
Fixes to recent PlayableGroup and Listener

### DIFF
--- a/src/Magnum/Audio/Listener.cpp
+++ b/src/Magnum/Audio/Listener.cpp
@@ -88,7 +88,7 @@ template<UnsignedInt dimensions> void Listener<dimensions>::update(std::initiali
 
     objects.push_back(this->object());
     for(PlayableGroup<dimensions>& group : groups) {
-        for(UnsignedInt i = 0; i < groups.size(); ++i) {
+        for(UnsignedInt i = 0; i < group.size(); ++i) {
             objects.push_back(group[i].object());
         }
     }

--- a/src/Magnum/Audio/PlayableGroup.h
+++ b/src/Magnum/Audio/PlayableGroup.h
@@ -39,6 +39,7 @@
 #include <Magnum/SceneGraph/FeatureGroup.h>
 
 #include "Magnum/Audio/Audio.h"
+#include "Magnum/Audio/Playable.h"
 #include "Magnum/Audio/Source.h"
 #include "Magnum/Audio/visibility.h"
 

--- a/src/Magnum/Audio/Test/ListenerTest.cpp
+++ b/src/Magnum/Audio/Test/ListenerTest.cpp
@@ -89,6 +89,7 @@ void ListenerTest::testUpdateGroups() {
     Object3D sourceObject{&scene};
     Object3D object{&scene};
     PlayableGroup3D group;
+    PlayableGroup3D emptyGroup;
     Playable3D playable{sourceObject, &group};
     Listener3D listener{object};
 
@@ -97,7 +98,7 @@ void ListenerTest::testUpdateGroups() {
     object.translate(offset);
     sourceObject.translate(offset*13.0f);
 
-    listener.update({group});
+    listener.update({group, emptyGroup});
 
     CORRADE_COMPARE(Renderer::listenerPosition(), offset);
     constexpr Vector3 rotatedFwd{-1.0f, 0.0f, 0.0f};


### PR DESCRIPTION
Hi @mosra !

I just started using my recent contribution to MagnumAudio myself and immediately found two bugs (very bad omen): Listener would crash if passed a empty playable group on update and PlayableGroup.h produces some weird compile errors when Playable.h is not included aswell.

This PR provides fixes for both issues.

Greetings, Squareys