### PR TITLE
package/ci: Update openal-soft download link.

### DIFF
--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -30,9 +30,9 @@ install:
 - cinst ninja
 
 # OpenAL
-- appveyor DownloadFile http://kcat.strangesoft.net/openal-soft-1.16.0-bin.zip
-- 7z x openal-soft-1.16.0-bin.zip
-- ren openal-soft-1.16.0-bin openal
+- appveyor DownloadFile http://kcat.strangesoft.net/openal-binaries/openal-soft-1.17.0-bin.zip
+- 7z x openal-soft-1.17.0-bin.zip
+- ren openal-soft-1.17.0-bin openal
 - ren openal\bin\Win32\soft_oal.dll OpenAL32.dll
 - echo [General] > %APPDATA%/alsoft.ini
 - echo drivers=null >> %APPDATA%/alsoft.ini


### PR DESCRIPTION
Hi @mosra !

I just noticed that with the release of openal-1.17.0, the old download link for openal-1.16.0 is now
invalid. I updated the appveyor configuration to download 1.17.0.

Greetings, 
Squareys