### PR TITLE
Audio: Hrtf Extension Support Fixes

### DIFF
--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -53,6 +53,21 @@ const std::vector<Extension>& Extension::extensions() {
     return extensions;
 }
 
+Debug& operator<<(Debug& debug, const Context::HrtfStatus value) {
+    switch(value) {
+        #define _c(value) case Context::HrtfStatus::value: return debug << "Audio::Context::HrtfStatus::" #value;
+        _c(Disabled)
+        _c(Enabled)
+        _c(Denied)
+        _c(Required)
+        _c(Detected)
+        _c(UnsupportedFormat)
+        #undef _c
+    }
+
+    return debug << "Audio::Context::HrtfStatus::(invalid)";
+}
+
 Context* Context::_current = nullptr;
 
 Context::Context(): Context{Configuration{}} {}

--- a/src/Magnum/Audio/Context.h
+++ b/src/Magnum/Audio/Context.h
@@ -174,6 +174,18 @@ class MAGNUM_AUDIO_EXPORT Context {
         HrtfStatus hrtfStatus() const;
 
         /**
+         * @brief Hrtf specifier
+         *
+         * Name of the hrtf being used.
+         *
+         * @see @fn_al{GetString} with @def_alc{HRTF_SPECIFIER_SOFT}
+         * @requires_al_extension @alc_extension{SOFT,HRTF}
+         */
+        std::string hrtfSpecifier() const {
+            return alcGetString(_device, ALC_HRTF_SPECIFIER_SOFT);
+        }
+
+        /**
          * @brief Vendor string
          *
          * @see @ref rendererString(), @fn_al{GetString} with @def_al{VENDOR}

--- a/src/Magnum/Audio/Renderer.cpp
+++ b/src/Magnum/Audio/Renderer.cpp
@@ -60,19 +60,4 @@ Debug& operator<<(Debug& debug, const Renderer::DistanceModel value) {
     return debug << "Audio::Renderer::DistanceModel::(invalid)";
 }
 
-Debug& operator<<(Debug& debug, const Renderer::HrtfStatus value) {
-    switch(value) {
-        #define _c(value) case Renderer::HrtfStatus::value: return debug << "Audio::Renderer::HrtfStatus::" #value;
-        _c(Disabled)
-        _c(Enabled)
-        _c(Denied)
-        _c(Required)
-        _c(Detected)
-        _c(UnsupportedFormat)
-        #undef _c
-    }
-
-    return debug << "Audio::Renderer::HrtfStatus::(invalid)";
-}
-
 }}

--- a/src/Magnum/Audio/Renderer.h
+++ b/src/Magnum/Audio/Renderer.h
@@ -32,11 +32,9 @@
 #include <array>
 
 #include <al.h>
-#include <alc.h>
 
 #include "Magnum/Magnum.h"
 #include "Magnum/Audio/Context.h"
-#include "Magnum/Audio/Extensions.h"
 #include "Magnum/Audio/visibility.h"
 #include "Magnum/Math/Vector3.h"
 
@@ -61,84 +59,8 @@ class Renderer {
             OutOfMemory = AL_OUT_OF_MEMORY  /**< Unable to allocate memory */
         };
 
-        /**
-         * @brief HRTF status
-         *
-         * @see @ref hrtfStatus(), @ref isHrtfEnabled()
-         * @requires_al_extension Extension @alc_extension{SOFTX,HRTF} or
-         *      @alc_extension{SOFT,HRTF}
-         */
-        enum class HrtfStatus: ALenum {
-            Disabled = ALC_HRTF_DISABLED_SOFT,  /**< HRTF is disabled */
-            Enabled = ALC_HRTF_ENABLED_SOFT,    /**< HRTF is enabled */
-
-            /**
-             * HRTF is disabled because it is not allowed on the device. This
-             * may be caused by invalid resource permissions, or an other user
-             * configuration that disallows HRTF.
-             * @requires_al_extension Extension @alc_extension{SOFT,HRTF}
-             */
-            Denied = ALC_HRTF_DENIED_SOFT,
-
-            /**
-             * HRTF is enabled because it must be used on the device. This may
-             * be caused by a device that can only use HRTF, or other user
-             * configuration that forces HRTF to be used.
-             * @requires_al_extension Extension @alc_extension{SOFT,HRTF}
-             */
-            Required = ALC_HRTF_REQUIRED_SOFT,
-
-            /**
-             * HRTF is enabled automatically because the device reported
-             * headphones.
-             * @requires_al_extension Extension @alc_extension{SOFT,HRTF}
-             */
-            Detected = ALC_HRTF_HEADPHONES_DETECTED_SOFT,
-
-            /**
-             * The device does not support HRTF with the current format.
-             * Typically this is caused by non-stereo output or an incompatible
-             * output frequency.
-             * @requires_al_extension Extension @alc_extension{SOFT,HRTF}
-             */
-            UnsupportedFormat = ALC_HRTF_UNSUPPORTED_FORMAT_SOFT
-        };
-
         /** @brief Error status */
         static Error error() { return Error(alGetError()); }
-
-        /**
-         * @brief Whether HRTFs (Head Related Transfer Functions) are enabled
-         *
-         * HRFTs may not be enabled/disabled in a running context. Instead
-         * create a new @ref Context with HRFTs enabled or disabled.
-         * @see @ref hrtfStatus(), @ref Audio::Context::Configuration::setHrtf(),
-         *      @fn_al{GetIntegerv} with @def_alc{HRTF_SOFT}
-         * @requires_al_extension Extension @alc_extension{SOFTX,HRTF} or
-         *      @alc_extension{SOFT,HRTF}
-         */
-        static bool isHrtfEnabled() {
-            Int enabled = ALC_FALSE;
-            alGetIntegerv(ALC_HRTF_SOFT, &enabled);
-            return enabled == ALC_TRUE;
-        }
-
-        /**
-         * @brief HRTF status
-         *
-         * @see @ref isHrtfEnabled(), @fn_al{GetIntegerv} with
-         *      @def_alc{HRTF_STATUS_SOFT}
-         * @requires_al_extension Extension @alc_extension{SOFTX,HRTF} or
-         *      @alc_extension{SOFT,HRTF}
-         */
-        static HrtfStatus hrtfStatus() {
-            if(!Context::current()->isExtensionSupported<Extensions::ALC::SOFT::HRTF>())
-                return isHrtfEnabled() ? HrtfStatus::Enabled : HrtfStatus::Disabled;
-
-            Int status = ALC_HRTF_DISABLED_SOFT;
-            alGetIntegerv(ALC_HRTF_STATUS_SOFT, &status);
-            return HrtfStatus(status);
-        }
 
         /** @{ @name Listener positioning */
 
@@ -343,9 +265,6 @@ MAGNUM_AUDIO_EXPORT Debug& operator<<(Debug& debug, Renderer::Error value);
 
 /** @debugoperatorclassenum{Magnum::Audio::Renderer,Magnum::Audio::Renderer::DistanceModel} */
 MAGNUM_AUDIO_EXPORT Debug& operator<<(Debug& debug, Renderer::DistanceModel value);
-
-/** @debugoperatorclassenum{Magnum::Audio::Renderer,Magnum::Audio::Renderer::HrtfStatus} */
-MAGNUM_AUDIO_EXPORT Debug& operator<<(Debug& debug, Renderer::HrtfStatus value);
 
 }}
 

--- a/src/Magnum/Audio/Test/ContextTest.cpp
+++ b/src/Magnum/Audio/Test/ContextTest.cpp
@@ -37,13 +37,17 @@ struct ContextTest: TestSuite::Tester {
 
     void extensionsString();
     void isExtensionEnabled();
+    void hrtfStatus();
+    void hrtfs();
 
     Context _context;
 };
 
 ContextTest::ContextTest() {
     addTests({&ContextTest::extensionsString,
-              &ContextTest::isExtensionEnabled});
+              &ContextTest::isExtensionEnabled,
+              &ContextTest::hrtfStatus,
+              &ContextTest::hrtfs});
 }
 
 void ContextTest::extensionsString() {
@@ -54,6 +58,18 @@ void ContextTest::extensionsString() {
 
 void ContextTest::isExtensionEnabled() {
     CORRADE_VERIFY(Context::current()->isExtensionSupported<Extensions::ALC::EXT::ENUMERATION>());
+}
+
+void ContextTest::hrtfStatus() {
+    std::ostringstream out;
+    Debug(&out) << Context::HrtfStatus::Denied;
+    CORRADE_COMPARE(out.str(), "Audio::Context::HrtfStatus::Denied\n");
+}
+
+void ContextTest::hrtfs() {
+    /* At least test that the hrtf status is `Disabled` */
+    CORRADE_VERIFY(!_context.isHrtfEnabled());
+    CORRADE_COMPARE(_context.hrtfStatus(), Context::HrtfStatus::Disabled);
 }
 
 }}}

--- a/src/Magnum/Audio/Test/ContextTest.cpp
+++ b/src/Magnum/Audio/Test/ContextTest.cpp
@@ -46,8 +46,7 @@ struct ContextTest: TestSuite::Tester {
 ContextTest::ContextTest() {
     addTests({&ContextTest::extensionsString,
               &ContextTest::isExtensionEnabled,
-              &ContextTest::hrtfStatus,
-              &ContextTest::hrtfs});
+              &ContextTest::hrtfStatus});
 }
 
 void ContextTest::extensionsString() {
@@ -64,12 +63,6 @@ void ContextTest::hrtfStatus() {
     std::ostringstream out;
     Debug(&out) << Context::HrtfStatus::Denied;
     CORRADE_COMPARE(out.str(), "Audio::Context::HrtfStatus::Denied\n");
-}
-
-void ContextTest::hrtfs() {
-    /* At least test that the hrtf status is `Disabled` */
-    CORRADE_VERIFY(!_context.isHrtfEnabled());
-    CORRADE_COMPARE(_context.hrtfStatus(), Context::HrtfStatus::Disabled);
 }
 
 }}}

--- a/src/Magnum/Audio/Test/RendererTest.cpp
+++ b/src/Magnum/Audio/Test/RendererTest.cpp
@@ -37,7 +37,6 @@ struct RendererTest: TestSuite::Tester {
 
     void debugError();
     void debugDistanceModel();
-    void hrtfStatus();
     void listenerOrientation();
     void listenerPosition();
     void listenerVelocity();
@@ -45,7 +44,6 @@ struct RendererTest: TestSuite::Tester {
     void speedOfSound();
     void dopplerFactor();
     void distanceModel();
-    void hrtfs();
 
     Context _context;
 };
@@ -53,15 +51,13 @@ struct RendererTest: TestSuite::Tester {
 RendererTest::RendererTest() {
     addTests({&RendererTest::debugError,
               &RendererTest::debugDistanceModel,
-              &RendererTest::hrtfStatus,
               &RendererTest::listenerOrientation,
               &RendererTest::listenerPosition,
               &RendererTest::listenerVelocity,
               &RendererTest::listenerGain,
               &RendererTest::speedOfSound,
               &RendererTest::dopplerFactor,
-              &RendererTest::distanceModel,
-              &RendererTest::hrtfs});
+              &RendererTest::distanceModel});
 }
 
 void RendererTest::debugError() {
@@ -74,12 +70,6 @@ void RendererTest::debugDistanceModel() {
     std::ostringstream out;
     Debug(&out) << Renderer::DistanceModel::Inverse;
     CORRADE_COMPARE(out.str(), "Audio::Renderer::DistanceModel::Inverse\n");
-}
-
-void RendererTest::hrtfStatus() {
-    std::ostringstream out;
-    Debug(&out) << Renderer::HrtfStatus::Denied;
-    CORRADE_COMPARE(out.str(), "Audio::Renderer::HrtfStatus::Denied\n");
 }
 
 void RendererTest::listenerOrientation() {
@@ -131,12 +121,6 @@ void RendererTest::distanceModel() {
     Renderer::setDistanceModel(model);
 
     CORRADE_COMPARE(Renderer::distanceModel(), model);
-}
-
-void RendererTest::hrtfs() {
-    /* At least test that the hrtf status is `Disabled` */
-    CORRADE_VERIFY(!Renderer::isHrtfEnabled());
-    CORRADE_COMPARE(Renderer::hrtfStatus(), Renderer::HrtfStatus::Disabled);
 }
 
 }}}


### PR DESCRIPTION
Hi @mosra !

As promised on https://github.com/mosra/magnum/commit/fd624d605e417317976ce5d8aa44b1dca0013f58, here are the changed required for fixing the `hrtfStatus()` and `isHrtfEnabled()` methods, which have now moved to `Audio::Context`.

I also added a method to query the name of the hrtf in use.

Greetings,
Squareys