### PR TITLE
Fix framebuffer binding on WebGL and GLES

### DIFF
--- a/src/Magnum/AbstractFramebuffer.cpp
+++ b/src/Magnum/AbstractFramebuffer.cpp
@@ -105,8 +105,12 @@ void AbstractFramebuffer::bind() {
 }
 
 void AbstractFramebuffer::bindInternal(FramebufferTarget target) {
-    #if defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
+    #if defined(MAGNUM_TARGET_GLES2)
+    #if !defined(MAGNUM_TARGET_WEBGL)
     (this->*Context::current().state().framebuffer->bindImplementation)(target);
+    #else
+    bindImplementationSingle();
+    #endif
     #else
     bindImplementationDefault(target);
     #endif
@@ -146,8 +150,12 @@ void AbstractFramebuffer::bindImplementationDefault(FramebufferTarget target) {
 }
 
 FramebufferTarget AbstractFramebuffer::bindInternal() {
-    #if defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
+    #if defined(MAGNUM_TARGET_GLES2)
+    #if !defined(MAGNUM_TARGET_WEBGL)
     return (this->*Context::current().state().framebuffer->bindInternalImplementation)();
+    #else
+    return bindImplementationSingle();
+    #endif
     #else
     return bindImplementationDefault();
     #endif

--- a/src/Magnum/AbstractFramebuffer.cpp
+++ b/src/Magnum/AbstractFramebuffer.cpp
@@ -122,7 +122,7 @@ void AbstractFramebuffer::bindImplementationSingle(FramebufferTarget) {
 
     /* Binding the framebuffer finally creates it */
     _flags |= ObjectFlag::Created;
-    glBindFramebuffer(GL_FRAMEBUFFER, _id);
+    glBindFramebuffer(GLenum(FramebufferTarget::Draw), _id);
 }
 #endif
 
@@ -164,10 +164,10 @@ FramebufferTarget AbstractFramebuffer::bindImplementationSingle() {
 
         /* Binding the framebuffer finally creates it */
         _flags |= ObjectFlag::Created;
-        glBindFramebuffer(GL_FRAMEBUFFER, _id);
+        glBindFramebuffer(GLenum(FramebufferTarget::Draw), _id);
     }
 
-    return FramebufferTarget{};
+    return FramebufferTarget::Draw;
 }
 #endif
 
@@ -367,8 +367,8 @@ GLenum AbstractFramebuffer::checkStatusImplementationDefault(const FramebufferTa
 
 #ifdef MAGNUM_TARGET_GLES2
 GLenum AbstractFramebuffer::checkStatusImplementationSingle(FramebufferTarget) {
-    bindInternal(FramebufferTarget{});
-    return glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    bindInternal(FramebufferTarget::Draw);
+    return glCheckFramebufferStatus(GLenum(FramebufferTarget::Draw));
 }
 #endif
 

--- a/src/Magnum/AbstractFramebuffer.h
+++ b/src/Magnum/AbstractFramebuffer.h
@@ -117,19 +117,19 @@ enum class FramebufferTarget: GLenum {
     /** Frambebuffer reading target */
     #ifndef MAGNUM_TARGET_GLES2
     Read = GL_READ_FRAMEBUFFER,
-    #elif !defined(MAGNUM_TARGET_WEBGL)
+    #elif defined(CORRADE_TARGET_APPLE)
     Read = GL_READ_FRAMEBUFFER_APPLE,
     #else
-    Read,
+    Read = GL_FRAMEBUFFER,
     #endif
 
     /** Framebuffer drawing target */
     #ifndef MAGNUM_TARGET_GLES2
     Draw = GL_DRAW_FRAMEBUFFER,
-    #elif !defined(MAGNUM_TARGET_WEBGL)
+    #elif defined(CORRADE_TARGET_APPLE)
     Draw = GL_DRAW_FRAMEBUFFER_APPLE,
     #else
-    Draw,
+    Draw = GL_FRAMEBUFFER,
     #endif
 
     #ifdef MAGNUM_BUILD_DEPRECATED
@@ -140,10 +140,10 @@ enum class FramebufferTarget: GLenum {
     ReadDraw CORRADE_DEPRECATED_ENUM("use FramebufferTarget::Draw instead") =
         #ifndef MAGNUM_TARGET_GLES2
         GL_DRAW_FRAMEBUFFER
-        #elif !defined(MAGNUM_TARGET_WEBGL)
+        #elif defined(MAGNUM_TARGET_APPLE)
         GL_DRAW_FRAMEBUFFER_APPLE
         #else
-        1
+        GL_FRAMEBUFFER
         #endif
     #endif
 };


### PR DESCRIPTION
Framebuffer binding on WebGL was raising `GL_INVALID_ENUM` because `0` was being passed to `glBindFramebuffer`, `glCheckFramebufferStatus` and friends.

The problem mainly appears to be in `AbstractFramebuffer::FramebufferTarget`, as there was no support for the old `GL_FRAMEBUFFER` binding (or at least, an assumption that the enum value was always `1`).

WebGL builds also assumed that `GLES2` style dynamic framebuffer target picking were not supported and also defaulted to using the multi-binding code, which was unsupported.

These changes set the `Read` and `Draw` bindings in `FramebufferTarget` to `GL_FRAMEBUFFER` for compatibility with GLES and WebGL. They also make WebGL take the `bindImplementationSingle` path as that is the only sensible path for it to take.