### PR TITLE
Fix 'zero as null pointer constant' warning

### DIFF
--- a/src/Magnum/Platform/WindowlessWglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessWglApplication.cpp
@@ -121,7 +121,7 @@ bool WindowlessWglApplication::tryCreateContext(const Configuration& configurati
        with it */
     typedef HGLRC(WINAPI*PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC, HGLRC, const int*);
     const PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribsARB = reinterpret_cast<PFNWGLCREATECONTEXTATTRIBSARBPROC>( wglGetProcAddress(reinterpret_cast<LPCSTR>("wglCreateContextAttribsARB")));
-    _renderingContext = wglCreateContextAttribsARB(_deviceContext, 0, attributes);
+    _renderingContext = wglCreateContextAttribsARB(_deviceContext, nullptr, attributes);
 
     /* Delete the temporary context */
     wglMakeCurrent(_deviceContext, nullptr);


### PR DESCRIPTION
I was getting this warning:
```plain
Scanning dependencies of target MagnumWindowlessWglApplication
[ 30%] Building CXX object src/Magnum/Platform/CMakeFiles/MagnumWindowlessWglApplication.dir/WindowlessWglApplication.cpp.obj
C:\Users\LB\Code\Magnum\build\Magnum-prefix\src\Magnum\src\Magnum\Platform\WindowlessWglApplication.cpp: In member function 'bool Magnum::Platform::WindowlessWglApplication::tryCreateContext(const Magnum::Platform::WindowlessWglApplication::Configuration&)':
C:\Users\LB\Code\Magnum\build\Magnum-prefix\src\Magnum\src\Magnum\Platform\WindowlessWglApplication.cpp:124:81: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
     _renderingContext = wglCreateContextAttribsARB(_deviceContext, 0, attributes);
                                                                                 ^
[ 30%] Linking CXX static library libMagnumWindowlessWglApplication.a
[ 30%] Built target MagnumWindowlessWglApplication
```
The code in question seems to have been introduced [here](https://github.com/mosra/magnum/commit/c36573934fbce62d7737dbe8fb13f69851f835bb#diff-44d292a9abb291752cb5ec0370ac9aa9R114), but I don't remember when I started seeing the warning.