### PR TITLE
Update Version of OpenAL Download on AppVeyor

### DIFF
--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -30,7 +30,7 @@ install:
 - cinst ninja
 
 # OpenAL
-- appveyor DownloadFile http://kcat.strangesoft.net/openal-binaries/openal-soft-1.17.0-bin.zip
+- appveyor DownloadFile http://kcat.strangesoft.net/openal-binaries/openal-soft-1.17.2-bin.zip
 - 7z x openal-soft-1.17.0-bin.zip
 - ren openal-soft-1.17.0-bin openal
 - ren openal\bin\Win32\soft_oal.dll OpenAL32.dll


### PR DESCRIPTION
Hey @mosra !

I noticed there have been two new releases of OpenAL, so here is a PR to make AppVeyor download the newest version.
Maybe this also helps with the AppVeyor hangs.

Regards, Squareys.