### PR TITLE
Allow horizontal-only scrolling

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -378,12 +378,11 @@ void Sdl2Application::mainLoop() {
                 event.type == SDL_MOUSEBUTTONDOWN ? mousePressEvent(e) : mouseReleaseEvent(e);
             } break;
 
-            case SDL_MOUSEWHEEL:
-                if(event.wheel.y != 0) {
-                    MouseEvent e(event.wheel.y > 0 ? MouseEvent::Button::WheelUp : MouseEvent::Button::WheelDown, {event.wheel.x, event.wheel.y}, 0);
-                    mousePressEvent(e);
-                } break;
-
+            case SDL_MOUSEWHEEL: {
+                MouseEvent e(event.wheel.y > 0 ? MouseEvent::Button::WheelUp : MouseEvent::Button::WheelDown, {event.wheel.x, event.wheel.y}, 0);
+                mousePressEvent(e);
+                break;
+            }
             case SDL_MOUSEMOTION: {
                 MouseMoveEvent e({event.motion.x, event.motion.y}, {event.motion.xrel, event.motion.yrel}, static_cast<MouseMoveEvent::Button>(event.motion.state));
                 mouseMoveEvent(e);


### PR DESCRIPTION
I have an app that I've been writing that makes use of two-finger scrolling on OSX using SDL.  Although SDL doesn't make it easy to do fancy things like inertial scrolling, it is still very useful to be able to scroll horizontally in user interfaces.

This API isn't perfect, as there is still a `WheelUp`/`WheelDown` flag being set.  Personally, I don't think that `WheelUp` and `WheelDown` should be part of the API, as horizontal scrolling is becoming a very common idiom in human-computer interaction, and as such the concept of the "mouse wheel" is being consumed by the more general concept of fully 2d scrolling.  I think you have a better idea of how to deal with those large API questions however, so I have only submitted a pull request to not dismiss events that have an `event.wheel.y` component of `0`.