### PR TITLE
Ignore .DS_Store files for those on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg
 *.kate-swp
 *.pkg.tar.xz
 CMakeLists.txt.user*
+.DS_Store


### PR DESCRIPTION
These files get littered around by Finder, make git output annoying when they're not ignored. :)