### PR TITLE
Add `Cmd` mapping for `KMOD_GUI`

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -975,6 +975,7 @@ class Sdl2Application::InputEvent {
             Ctrl = KMOD_CTRL,           /**< Ctrl */
             Alt = KMOD_ALT,             /**< Alt */
             AltGr = KMOD_MODE,          /**< AltGr */
+            Cmd = KMOD_GUI,             /**< Cmd */
 
             CapsLock = KMOD_CAPS,       /**< Caps lock */
             NumLock = KMOD_NUM          /**< Num lock */


### PR DESCRIPTION
This maps to the Command key on MacOS machines, a very important key for those that wish to obey things like the typical close keystroke (CMD + W) or the typical save keystroke (CMD + S)