### PR TITLE
Multi-window support in Sdl2Application and GlfwApplication

### DIFF
--- a/doc/changelog-old.dox
+++ b/doc/changelog-old.dox
@@ -108,7 +108,7 @@ Released 2018-05-01, tagged as
 
 -   Ability to create @ref Platform::Sdl2Application and
     @ref Platform::GlfwApplication classes without implicitly created OpenGL
-    context by passing @ref Platform::Sdl2Application::Configuration::WindowFlag::Contextless "Configuration::WindowFlag::Contextless"
+    context by passing @cpp Configuration::WindowFlag::Contextless @ce
     to them. These two can be now also built completely without the GL library.
 -   Added @ref Platform::AndroidApplication::windowSize()
 -   Added @ref Platform::AndroidApplication::nativeActivity() to access
@@ -157,10 +157,9 @@ Released 2018-05-01, tagged as
 
 @subsubsection changelog-2018-04-changes-platform Platform libraries
 
--   Separated @ref Platform::Sdl2Application::Configuration "Platform::*Application::Configuration"
-    into @ref Platform::Sdl2Application::Configuration "Configuration" and
-    @ref Platform::Sdl2Application::GLConfiguration "GLConfiguration" to allow
-    creation of non-GL application instances in the future
+-   Separated @cpp Platform::*Application::Configuration @ce
+    into @cpp Configuration @ce and @cpp GLConfiguration @ce to allow creation
+    of non-GL application instances in the future
 
 @subsubsection changelog-2018-04-changes-plugins Plugins
 
@@ -753,10 +752,10 @@ a high-level overview.
     possible
 -   Ported @ref magnum-gl-info "magnum-info" to Emscripten
 -   First-class support for scroll events in
-    @ref Platform::Sdl2Application::MouseScrollEvent (see
-    [mosra/magnum#157](https://github.com/mosra/magnum/pull/157))
--   Added @ref Platform::Sdl2Application::MouseEvent::clickCount()
--   Added @ref Platform::Sdl2Application::multiGestureEvent()
+    @cpp Platform::Sdl2Application::MouseScrollEvent @ce
+    (see [mosra/magnum#157](https://github.com/mosra/magnum/pull/157))
+-   Added @cpp Platform::Sdl2Application::MouseEvent::clickCount() @ce
+-   Added @cpp Platform::Sdl2Application::multiGestureEvent() @ce
 -   Exposing key repeat in
     @ref Platform::Sdl2Application::KeyEvent::isRepeated() "Platform::*Application::KeyEvent::isRepeated()"
     (see [mosra/magnum#161](https://github.com/mosra/magnum/issues/161),
@@ -773,8 +772,8 @@ a high-level overview.
     version is not what the application wants (as opposed to just aborting the
     application) (see [mosra/magnum#105](https://github.com/mosra/magnum/issues/105))
 -   Added @cpp Platform::Sdl2Application::Configuration::setSRGBCapable() @ce
--   Added @ref Platform::Sdl2Application::Configuration::WindowFlag::Borderless
-    and `Platform::Sdl2Application::Configuration::WindowFlag::AllowHighDpi`
+-   Added @cpp Platform::Sdl2Application::Configuration::WindowFlag::Borderless @ce
+    and @cpp Platform::Sdl2Application::Configuration::WindowFlag::AllowHighDpi @ce
     for iOS and macOS
 -   Added @ref Platform::WindowlessGlxApplication::Configuration::setFlags() "Platform::Windowless*Application::Configuration::setFlags()" with
     @ref Platform::WindowlessGlxApplication::Configuration::Flag::Debug "Flag::Debug"
@@ -786,7 +785,7 @@ a high-level overview.
     with @ref Platform::GlfwApplication
 -   Added modifier keys to
     @ref Platform::Sdl2Application::KeyEvent::Key "Platform::*Application::KeyEvent::Key"
--   Added @ref Platform::Sdl2Application::InputEvent::Modifier::Super to be
+-   Added @cpp Platform::Sdl2Application::InputEvent::Modifier::Super @ce to be
     consistent with @ref Platform::GlfwApplication (see
     [mosra/magnum#159](https://github.com/mosra/magnum/pull/159))
 -   Added @ref Platform::Sdl2Application::KeyEvent::keyName() "Platform::*Application::KeyEvent::keyName()"
@@ -1102,10 +1101,10 @@ a high-level overview.
     `Platform::GlfwApplication::MouseEvent::Button::WheelDown` mouse events are
     deprecated, use @ref Platform::Sdl2Application::mouseScrollEvent() /
     @ref Platform::GlfwApplication::mouseScrollEvent() and
-    @ref Platform::Sdl2Application::MouseScrollEvent /
+    @cpp Platform::Sdl2Application::MouseScrollEvent @ce /
     @ref Platform::GlfwApplication::MouseScrollEvent instead
--   @ref Platform::Sdl2Application::Sdl2Application() "Platform::*Application::*Application()"
-    and @ref Platform::WindowlessGlxApplication::WindowlessGlxApplication() "Platform::Windowless*Application::Windowless*Application()"
+-   @cpp Platform::*Application::*Application() @ce and
+    @ref Platform::WindowlessGlxApplication::WindowlessGlxApplication() "Platform::Windowless*Application::Windowless*Application()"
     constructors taking @cpp nullptr @ce are deprecated, use constructors
     taking @ref NoCreateT instead to create an application without creating
     OpenGL context
@@ -1844,7 +1843,7 @@ for a high-level overview.
     purely integral coordinates, useful e.g. for UI or 2D platformers.
 -   Detailed collision queries and new `InvertedSphere` shape in Shapes library
 -   Texture support in @cpp Shaders::Flat @ce
--   Mouse button queries in @ref Platform::Sdl2Application::MouseMoveEvent "Platform::*Application::MouseMoveEvent"
+-   Mouse button queries in @cpp Platform::*Application::MouseMoveEvent @ce
 
 @subsection changelog-2013-10-changes Changes
 

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -732,13 +732,13 @@ See also:
 -   Added @ref Platform::EmscriptenApplication::Configuration::addWindowFlags()
     and @ref Platform::EmscriptenApplication::Configuration::clearWindowFlags()
     for consistency with other application implementations
--   Added @ref Platform::Sdl2Application::KeyEvent::Key::CapsLock,
-    @relativeref{Platform::Sdl2Application::KeyEvent::Key,ScrollLock},
-    @relativeref{Platform::Sdl2Application::KeyEvent::Key,NumLock},
-    @relativeref{Platform::Sdl2Application::KeyEvent::Key,PrintScreen},
-    @relativeref{Platform::Sdl2Application::KeyEvent::Key,Pause} and
-    @relativeref{Platform::Sdl2Application::KeyEvent::Key,Menu} for consistency
-    with @ref Platform::EmscriptenApplication and
+-   Added @ref Platform::Sdl2ApplicationWindow::KeyEvent::Key::CapsLock,
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent::Key,ScrollLock},
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent::Key,NumLock},
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent::Key,PrintScreen},
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent::Key,Pause} and
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent::Key,Menu} for
+    consistency with @ref Platform::EmscriptenApplication and
     @ref Platform::GlfwApplication (see [mosra/magnum#547](https://github.com/mosra/magnum/pull/547))
 -   @ref Platform::Sdl2Application now overrides SDL's default behavior that
     prevents computer from entering a power-saving mode while the application
@@ -1103,9 +1103,9 @@ See also:
     destroyed could fail with an error saying "cannot make the previous context
     current" on certain system. This was due to EGL not destroying the context
     if it's still made current.
--   Fixed handling of @ref Platform::Sdl2Application::InputEvent::Modifier::Super,
-    which was misreported as @relativeref{Platform::Sdl2Application::InputEvent::Modifier,Alt} (see
-    [mosra/magnum#547](https://github.com/mosra/magnum/pull/547))
+-   Fixed handling of @ref Platform::Sdl2ApplicationWindow::InputEvent::Modifier::Super,
+    which was misreported as @relativeref{Platform::Sdl2ApplicationWindow::InputEvent::Modifier,Alt}
+    (see [mosra/magnum#547](https://github.com/mosra/magnum/pull/547))
 -   For meshes with multiple sets of vertex attributes (such as texture
     coordinates), @ref MeshTools::compile() should be using only the first set
     but it wasn't.
@@ -1969,12 +1969,12 @@ Released 2020-06-27, tagged as
     @ref Platform::AbstractXApplication::mainLoopIteration() for consistency
     with @ref Platform::Sdl2Application (see
     [mosra/magnum#387](https://github.com/mosra/magnum/pull/387))
--   Added @ref Platform::Sdl2Application::KeyEvent::Key::Quote "Key::Quote",
-    @ref Platform::Sdl2Application::KeyEvent::Key::LeftBracket "Key::LeftBracket",
-    @ref Platform::Sdl2Application::KeyEvent::Key::RightBracket "Key::RightBracket",
-    @ref Platform::Sdl2Application::KeyEvent::Key::Backslash "Key::Backslash" and
-    @ref Platform::Sdl2Application::KeyEvent::Key::Backquote "Key::Backquote"
-    keys to @ref Platform::Sdl2Application::KeyEvent and
+-   Added @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent,Key::Quote},
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent,Key::LeftBracket},
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent,Key::RightBracket},
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent,Key::Backslash} and
+    @relativeref{Platform::Sdl2ApplicationWindow::KeyEvent,Key::Backquote}
+    keys to @cpp Platform::Sdl2Application::KeyEvent @ce and
     @ref Platform::GlfwApplication::KeyEvent
 -   Added @ref Platform::GlfwApplication::KeyEvent::Key::World1 and
     @ref Platform::GlfwApplication::KeyEvent::Key::World2
@@ -1992,12 +1992,9 @@ Released 2020-06-27, tagged as
 -   CUDA device selection in @ref Platform::WindowlessEglApplication (see
     [mosra/magnum#449](https://github.com/mosra/magnum/pull/449))
 -   Added @ref Platform::GlfwApplication::Configuration::WindowFlag::Borderless
--   Added @ref Platform::Sdl2Application::Configuration::WindowFlag::FullscreenDesktop,
-    @ref Platform::Sdl2Application::Configuration::WindowFlag::AlwaysOnTop "AlwaysOnTop",
-    @ref Platform::Sdl2Application::Configuration::WindowFlag::SkipTaskbar "SkipTaskbar",
-    @ref Platform::Sdl2Application::Configuration::WindowFlag::Utility "Utility",
-    @ref Platform::Sdl2Application::Configuration::WindowFlag::Tooltip "Tooltip"
-    and @ref Platform::Sdl2Application::Configuration::WindowFlag::PopupMenu "PopupMenu"
+-   Added @cpp  Platform::Sdl2Application::Configuration::WindowFlag::FullscreenDesktop @ce,
+    @cpp AlwaysOnTop @ce, @cpp SkipTaskbar @ce, @cpp Utility @ce,
+    @cpp Tooltip @ce and @cpp PopupMenu @ce
 -   Added @ref Platform::Sdl2Application::Configuration::addWindowFlags() and
     @ref Platform::Sdl2Application::Configuration::clearWindowFlags() "clearWindowFlags()"
     for consistency with similar functions in
@@ -2299,7 +2296,7 @@ Released 2020-06-27, tagged as
 -   The @ref Primitives::cylinderSolid() and @ref Primitives::coneSolid()
     primitives were missing a face when both caps and texture coordinates were
     enabled (see [mosra/magnum#386](https://github.com/mosra/magnum/issues/386))
--   @ref Platform::Sdl2Application::Configuration::WindowFlag::Vulkan was
+-   @cpp Platform::Sdl2Application::Configuration::WindowFlag::Vulkan @ce was
     enabled conditionally only for SDL >= 2.0.6, but the version defines were
     never included so it was always disabled
 -   Fixed missing handling of
@@ -2330,7 +2327,7 @@ Released 2020-06-27, tagged as
     caused @ref Platform::Sdl2Application::setMinimalLoopPeriod() "setMinimalLoopPeriod()"
     to be ignored even though Vsync was in fact not enabled.
 -   It was not possible to override DPI scaling using
-    @ref Platform::Sdl2Application::Configuration as command-line arguments
+    @cpp Platform::Sdl2Application::Configuration @ce as command-line arguments
     always got a priority (see [mosra/magnum#416](https://github.com/mosra/magnum/issues/416))
 -   Fixed an otherwise harmless OOB access in @ref MeshTools::tipsifyInPlace()
     that could trigger ASan or debug iterator errors
@@ -2832,10 +2829,10 @@ Released 2019-10-24, tagged as
     in @ref Platform::GlfwApplication and @ref Platform::EmscriptenApplication)
     for changing window title at runtime as opposed to setting them on
     application startup
--   Added @ref Platform::Sdl2Application::Configuration::WindowFlag::OpenGL and
-    @ref Platform::Sdl2Application::Configuration::WindowFlag::Vulkan "WindowFlag::Vulkan",
-    meant to be used together with @ref Platform::Sdl2Application::Configuration::WindowFlag::Contextless for
-    manual creation of OpenGL contexts and Vulkan instances
+-   Added @cpp Platform::Sdl2Application::Configuration::WindowFlag::OpenGL @ce
+    and @cpp WindowFlag::Vulkan @ce, meant to be used together with
+    @cpp Platform::Sdl2Application::Configuration::WindowFlag::Contextless @ce
+    for manual creation of OpenGL contexts and Vulkan instances
 -   @ref Platform::WindowlessEglApplication now uses the
     @m_class{m-doc-external} [EGL_EXT_device_enumeration](https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_device_enumeration.txt),
     @m_class{m-doc-external} [EGL_EXT_platform_base](https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_base.txt) and

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -1273,6 +1273,10 @@ See also:
     performance and a default, use @relativeref{Platform::EmscriptenApplication::GLConfiguration,Flag::PowerPreferenceLowPower}
     or @relativeref{Platform::EmscriptenApplication::GLConfiguration,Flag::PowerPreferenceHighPerformance}
     instead
+-   GPU-context-related flags were moved from
+    @ref Platform::Sdl2Application::Configuration::WindowFlag to a new
+    @ref Platform::Sdl2Application::Configuration::Flag enum, as they're set
+    globally for all application windows and can't differ per-window
 -   @cpp Shaders::DistanceFieldVector @ce, @cpp Shaders::Flat @ce,
     @cpp Shaders::Generic @ce, @cpp Shaders::MeshVisualizer2D @ce,
     @cpp Shaders::MeshVisualizer3D @ce, @cpp Shaders::Phong @ce,

--- a/doc/platform.dox
+++ b/doc/platform.dox
@@ -136,8 +136,8 @@ target_link_libraries(myapplication
 @section platform-configuration Specifying configuration
 
 By default the application is created with some reasonable defaults (e.g.
-window size 800x600 pixels). If you want something else, you can pass
-@ref Platform::Sdl2Application::Configuration "Configuration" instance to
+window size 800x600 pixels). If you want something else, you can pass a
+@relativeref{Platform::Sdl2ApplicationWindow,Configuration} instance to the
 application constructor. Using method chaining it can be done conveniently like
 this:
 
@@ -148,7 +148,7 @@ this:
 Sometimes you may want to set up the application based on a configuration file
 or system introspection, which can't really be done inside the base class
 initializer. You can specify @ref NoCreate in the constructor instead and pass
-the @relativeref{Platform::Sdl2Application,Configuration} later to a
+the @relativeref{Platform::Sdl2ApplicationWindow,Configuration} later to a
 @relativeref{Platform::Sdl2Application,create()} function:
 
 @snippet MagnumPlatform.cpp createcontext

--- a/doc/snippets/MagnumTextureTools.cpp
+++ b/doc/snippets/MagnumTextureTools.cpp
@@ -57,7 +57,7 @@ atlas.add(stridedArrayView(images).slice(&ImageView2D::size), offsets, rotations
 
 /* Copy the image data to the atlas, assuming all are RGBA8Unorm as well */
 Image2D output{PixelFormat::RGBA8Unorm, atlas.filledSize().xy(),
-    Containers::Array<char>{ValueInit, std::size_t(atlas.filledSize().product())}};
+    Containers::Array<char>{ValueInit, std::size_t(atlas.filledSize().product()*4)}};
 Containers::StridedArrayView2D<Color4ub> dst = output.pixels<Color4ub>();
 for(std::size_t i = 0; i != images.size(); ++i) {
     /* Rotate 90° counterclockwise if the image is rotated in the atlas */
@@ -82,7 +82,7 @@ atlas.clearFlags(TextureTools::AtlasLandfillFlag::RotatePortrait|
 
 /* Copy the image data to the atlas, assuming all are RGBA8Unorm as well */
 Image2D output{PixelFormat::RGBA8Unorm, atlas.filledSize().xy(),
-    Containers::Array<char>{ValueInit, std::size_t(atlas.filledSize().product())}};
+    Containers::Array<char>{ValueInit, std::size_t(atlas.filledSize().product()*4)}};
 Containers::StridedArrayView2D<Color4ub> dst = output.pixels<Color4ub>();
 for(std::size_t i = 0; i != images.size(); ++i) {
     Containers::StridedArrayView2D<const Color4ub> src = images[i].pixels<Color4ub>();
@@ -104,9 +104,8 @@ TextureTools::AtlasLandfill atlas{{1024, 1024, 0}};
 atlas.add(stridedArrayView(images).slice(&ImageView2D::size), offsets, rotations);
 
 /* Copy the image data to the atlas, assuming all are RGBA8Unorm as well */
-Vector3i outputSize = atlas.filledSize();
-Image3D output{PixelFormat::RGBA8Unorm, outputSize,
-    Containers::Array<char>{ValueInit, std::size_t(outputSize.product())}};
+Image3D output{PixelFormat::RGBA8Unorm, atlas.filledSize(),
+    Containers::Array<char>{ValueInit, std::size_t(atlas.filledSize().product()*4)}};
 Containers::StridedArrayView3D<Color4ub> dst = output.pixels<Color4ub>();
 for(std::size_t i = 0; i != images.size(); ++i) {
     /* Rotate 90° counterclockwise if the image is rotated in the atlas */
@@ -135,7 +134,7 @@ Int layerCount = TextureTools::atlasArrayPowerOfTwo(layerSize, sizes, offsets);
 /* Copy the image data to the atlas, assuming all are RGBA8Unorm as well */
 Vector3i outputSize{layerSize, layerCount};
 Image3D output{PixelFormat::RGBA8Unorm, outputSize,
-    Containers::Array<char>{ValueInit, std::size_t(outputSize.product())}};
+    Containers::Array<char>{ValueInit, std::size_t(outputSize.product()*4)}};
 Containers::StridedArrayView3D<Color4ub> dst = output.pixels<Color4ub>();
 for(std::size_t i = 0; i != input.size(); ++i) {
     Containers::StridedArrayView3D<const Color4ub> src = input[i].pixels<Color4ub>();

--- a/src/Magnum/Platform/AndroidApplication.h
+++ b/src/Magnum/Platform/AndroidApplication.h
@@ -189,7 +189,7 @@ class AndroidApplication {
         #endif
 
         /**
-         * @brief Construct with given configuration for OpenGL context
+         * @brief Construct with an OpenGL context
          * @param arguments         Application arguments
          * @param configuration     Application configuration
          * @param glConfiguration   OpenGL context configuration
@@ -202,20 +202,17 @@ class AndroidApplication {
         explicit AndroidApplication(const Arguments& arguments, const Configuration& configuration, const GLConfiguration& glConfiguration);
 
         /**
-         * @brief Construct with given configuration
+         * @brief Construct without explicit GPU context configuration
          *
          * Equivalent to calling @ref AndroidApplication(const Arguments&, const Configuration&, const GLConfiguration&)
          * with default-constructed @ref GLConfiguration.
          */
+        #ifdef DOXYGEN_GENERATING_OUTPUT
+        explicit AndroidApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
+        #else
         explicit AndroidApplication(const Arguments& arguments, const Configuration& configuration);
-
-        /**
-         * @brief Construct with default configuration
-         *
-         * Equivalent to calling @ref AndroidApplication(const Arguments&, const Configuration&)
-         * with default-constructed @ref Configuration.
-         */
         explicit AndroidApplication(const Arguments& arguments);
+        #endif
 
         /**
          * @brief Construct without creating a window

--- a/src/Magnum/Platform/AndroidApplication.h
+++ b/src/Magnum/Platform/AndroidApplication.h
@@ -149,8 +149,8 @@ to simplify porting.
 @section Platform-AndroidApplication-resizing Responding to viewport events
 
 Unlike in desktop application implementations, where this is controlled via
-@ref Sdl2Application::Configuration::WindowFlag::Resizable, for example, on
-Android you have to describe this in the `AndroidManifest.xml` file, as by
+@ref Sdl2ApplicationWindow::Configuration::WindowFlag::Resizable, for example,
+on Android you have to describe this in the `AndroidManifest.xml` file, as by
 default the application gets killed and relaunched on screen orientation
 change. See the @ref platforms-android-apps-manifest-screen-resize "manifest file docs"
 for more information.

--- a/src/Magnum/Platform/EmscriptenApplication.cpp
+++ b/src/Magnum/Platform/EmscriptenApplication.cpp
@@ -343,7 +343,10 @@ bool EmscriptenApplication::tryCreate(const Configuration& configuration) {
 
 #ifdef MAGNUM_TARGET_GL
 bool EmscriptenApplication::tryCreate(const Configuration& configuration, const GLConfiguration& glConfiguration) {
-    CORRADE_ASSERT(_context->version() == GL::Version::None, "Platform::EmscriptenApplication::tryCreate(): window with OpenGL context already created", false);
+    CORRADE_ASSERT(!(configuration.windowFlags() & Configuration::WindowFlag::Contextless),
+        "Platform::EmscriptenApplication::tryCreate(): cannot pass Configuration::WindowFlag::Contextless when creating an OpenGL context", false);
+    CORRADE_ASSERT(_context->version() == GL::Version::None,
+        "Platform::EmscriptenApplication::tryCreate(): window with OpenGL context already created", false);
 
     /* Create emscripten WebGL context */
     EmscriptenWebGLContextAttributes attrs;

--- a/src/Magnum/Platform/EmscriptenApplication.h
+++ b/src/Magnum/Platform/EmscriptenApplication.h
@@ -302,7 +302,7 @@ class EmscriptenApplication {
 
         #ifdef MAGNUM_TARGET_GL
         /**
-         * @brief Construct with given configuration for WebGL context
+         * @brief Construct with a WebGL context
          * @param arguments         Application arguments
          * @param configuration     Application configuration
          * @param glConfiguration   WebGL context configuration
@@ -320,7 +320,7 @@ class EmscriptenApplication {
         #endif
 
         /**
-         * @brief Construct with given configuration
+         * @brief Construct without explicit GPU context configuration
          *
          * If @ref Configuration::WindowFlag::Contextless is present or Magnum
          * was not built with @ref MAGNUM_TARGET_GL, this creates a window
@@ -333,15 +333,13 @@ class EmscriptenApplication {
          *
          * See also @ref building-features for more information.
          */
+        #ifdef DOXYGEN_GENERATING_OUTPUT
+        explicit EmscriptenApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
+        #else
+        /* Configuration is only forward-declared at this point */
         explicit EmscriptenApplication(const Arguments& arguments, const Configuration& configuration);
-
-        /**
-         * @brief Construct with default configuration
-         *
-         * Equivalent to calling @ref EmscriptenApplication(const Arguments&, const Configuration&)
-         * with default-constructed @ref Configuration.
-         */
         explicit EmscriptenApplication(const Arguments& arguments);
+        #endif
 
         /**
          * @brief Construct without setting up a canvas
@@ -1215,7 +1213,6 @@ class EmscriptenApplication::Configuration {
         enum class WindowFlag: UnsignedShort {
             /**
              * Do not create any GPU context. Use together with
-             * @ref EmscriptenApplication(const Arguments&),
              * @ref EmscriptenApplication(const Arguments&, const Configuration&),
              * @ref create(const Configuration&) or
              * @ref tryCreate(const Configuration&) to prevent implicit

--- a/src/Magnum/Platform/EmscriptenApplication.h
+++ b/src/Magnum/Platform/EmscriptenApplication.h
@@ -1216,7 +1216,10 @@ class EmscriptenApplication::Configuration {
              * @ref EmscriptenApplication(const Arguments&, const Configuration&),
              * @ref create(const Configuration&) or
              * @ref tryCreate(const Configuration&) to prevent implicit
-             * creation of an WebGL context.
+             * creation of an WebGL context. Can't be used with
+             * @ref EmscriptenApplication(const Arguments&, const Configuration&, const GLConfiguration&),
+             * @ref create(const Configuration&, const GLConfiguration&) or
+             * @ref tryCreate(const Configuration&, const GLConfiguration&).
              */
             Contextless = 1 << 0,
 

--- a/src/Magnum/Platform/GlfwApplication.cpp
+++ b/src/Magnum/Platform/GlfwApplication.cpp
@@ -409,7 +409,10 @@ GlfwApplication::InputEvent::Modifiers currentGlfwModifiers(GLFWwindow* window) 
 
 #ifdef MAGNUM_TARGET_GL
 bool GlfwApplication::tryCreate(const Configuration& configuration, const GLConfiguration& glConfiguration) {
-    CORRADE_ASSERT(!_window && _context->version() == GL::Version::None, "Platform::GlfwApplication::tryCreate(): window with OpenGL context already created", false);
+    CORRADE_ASSERT(!(configuration.windowFlags() & Configuration::WindowFlag::Contextless),
+        "Platform::GlfwApplication::tryCreate(): cannot pass Configuration::WindowFlag::Contextless when creating an OpenGL context", false);
+    CORRADE_ASSERT(!_window && _context->version() == GL::Version::None,
+        "Platform::GlfwApplication::tryCreate(): window with OpenGL context already created", false);
 
     /* Save DPI scaling values from configuration for future use, scale window
        based on those */

--- a/src/Magnum/Platform/GlfwApplication.h
+++ b/src/Magnum/Platform/GlfwApplication.h
@@ -1113,7 +1113,10 @@ class GlfwApplication::Configuration {
              * @ref GlfwApplication(const Arguments&, const Configuration&),
              * @ref create(const Configuration&) or
              * @ref tryCreate(const Configuration&) to prevent implicit
-             * creation of an OpenGL context.
+             * creation of an OpenGL context. Can't be used with
+             * @ref GlfwApplication(const Arguments&, const Configuration&, const GLConfiguration&),
+             * @ref create(const Configuration&, const GLConfiguration&) or
+             * @ref tryCreate(const Configuration&, const GLConfiguration&).
              *
              * @note Supported since GLFW 3.2.
              */

--- a/src/Magnum/Platform/GlfwApplication.h
+++ b/src/Magnum/Platform/GlfwApplication.h
@@ -185,7 +185,7 @@ class GlfwApplication {
 
         #ifdef MAGNUM_TARGET_GL
         /**
-         * @brief Construct with given configuration for OpenGL context
+         * @brief Construct with an OpenGL context
          * @param arguments         Application arguments
          * @param configuration     Application configuration
          * @param glConfiguration   OpenGL context configuration
@@ -203,7 +203,7 @@ class GlfwApplication {
         #endif
 
         /**
-         * @brief Construct with given configuration
+         * @brief Construct without explicit GPU context configuration
          *
          * If @ref Configuration::WindowFlag::Contextless is present or Magnum
          * was not built with @ref MAGNUM_TARGET_GL, this creates a window
@@ -216,15 +216,13 @@ class GlfwApplication {
          *
          * See also @ref building-features for more information.
          */
+        #ifdef DOXYGEN_GENERATING_OUTPUT
+        explicit GlfwApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
+        #else
+        /* Configuration is only forward-declared at this point */
         explicit GlfwApplication(const Arguments& arguments, const Configuration& configuration);
-
-        /**
-         * @brief Construct with default configuration
-         *
-         * Equivalent to calling @ref GlfwApplication(const Arguments&, const Configuration&)
-         * with default-constructed @ref Configuration.
-         */
         explicit GlfwApplication(const Arguments& arguments);
+        #endif
 
         /**
          * @brief Construct without creating a window
@@ -1112,7 +1110,6 @@ class GlfwApplication::Configuration {
             #if defined(DOXYGEN_GENERATING_OUTPUT) || defined(GLFW_NO_API)
             /**
              * Do not create any GPU context. Use together with
-             * @ref GlfwApplication(const Arguments&),
              * @ref GlfwApplication(const Arguments&, const Configuration&),
              * @ref create(const Configuration&) or
              * @ref tryCreate(const Configuration&) to prevent implicit

--- a/src/Magnum/Platform/GlxApplication.h
+++ b/src/Magnum/Platform/GlxApplication.h
@@ -100,7 +100,7 @@ If no other application header is included, this class is also aliased to
 class GlxApplication: public AbstractXApplication {
     public:
         /**
-         * @brief Construct with given configuration for OpenGL context
+         * @brief Construct with an OpenGL context
          * @param arguments         Application arguments
          * @param configuration     Application configuration
          * @param glConfiguration   OpenGL context configuration

--- a/src/Magnum/Platform/Screen.h
+++ b/src/Magnum/Platform/Screen.h
@@ -175,7 +175,7 @@ template<class Application> class BasicScreen:
          * @brief Key event
          *
          * Defined only if the application has a
-         * @ref Sdl2Application::KeyEvent "KeyEvent".
+         * @relativeref{Sdl2ApplicationWindow,KeyEvent}.
          */
         typedef typename BasicScreenedApplication<Application>::KeyEvent KeyEvent;
         #endif
@@ -192,7 +192,7 @@ template<class Application> class BasicScreen:
          * @m_since{2019,10}
          *
          * Defined only if the application has a
-         * @ref Sdl2Application::MouseScrollEvent "MouseScrollEvent".
+         * @relativeref{Sdl2ApplicationWindow,MouseScrollEvent}.
          */
         typedef typename BasicScreenedApplication<Application>::MouseScrollEvent MouseScrollEvent;
 
@@ -201,7 +201,7 @@ template<class Application> class BasicScreen:
          * @m_since{2019,10}
          *
          * Defined only if the application has a
-         * @ref Sdl2Application::TextInputEvent "TextInputEvent".
+         * @relativeref{Sdl2ApplicationWindow,TextInputEvent}.
          */
         typedef typename BasicScreenedApplication<Application>::TextInputEvent TextInputEvent;
 
@@ -210,7 +210,7 @@ template<class Application> class BasicScreen:
          * @m_since{2019,10}
          *
          * Defined only if the application has a
-         * @ref Sdl2Application::TextEditingEvent "TextEditingEvent".
+         * @relativeref{Sdl2ApplicationWindow,TextEditingEvent}.
          */
         typedef typename BasicScreenedApplication<Application>::TextEditingEvent TextEditingEvent;
         #endif
@@ -379,7 +379,7 @@ template<class Application> class BasicScreen:
          * Called when @ref PropagatedEvent::Input is enabled and an key is
          * pressed. See @ref Sdl2Application::keyPressEvent() "*Application::keyPressEvent()"
          * for more information. Defined only if the application has a
-         * @ref Sdl2Application::KeyEvent "KeyEvent".
+         * @relativeref{Sdl2ApplicationWindow,KeyEvent}.
          */
         virtual void keyPressEvent(KeyEvent& event);
 
@@ -389,7 +389,7 @@ template<class Application> class BasicScreen:
          * Called when @ref PropagatedEvent::Input is enabled and an key is
          * released. See @ref Sdl2Application::keyReleaseEvent() "*Application::keyReleaseEvent()"
          * for more information. Defined only if the application has a
-         * @ref Sdl2Application::KeyEvent "KeyEvent".
+         * @relativeref{Sdl2ApplicationWindow,KeyEvent}.
          */
         virtual void keyReleaseEvent(KeyEvent& event);
         #endif
@@ -437,7 +437,7 @@ template<class Application> class BasicScreen:
          * Called when @ref PropagatedEvent::Input is enabled and mouse wheel
          * is rotated. See @ref Sdl2Application::mouseScrollEvent() "*Application::mouseScrollEvent()"
          * for more information. Defined only if the application has a
-         * @ref Sdl2Application::MouseScrollEvent "MouseScrollEvent".
+         * @relativeref{Sdl2ApplicationWindow,MouseScrollEvent}.
          */
         virtual void mouseScrollEvent(MouseScrollEvent& event);
         #endif
@@ -457,7 +457,7 @@ template<class Application> class BasicScreen:
          *
          * Called when @ref PropagatedEvent::Input is enabled and text is being
          * input. Defined only if the application has a
-         * @ref Sdl2Application::TextInputEvent "TextInputEvent".
+         * @relativeref{Sdl2ApplicationWindow,TextInputEvent}.
          */
         virtual void textInputEvent(TextInputEvent& event);
 
@@ -467,7 +467,7 @@ template<class Application> class BasicScreen:
          *
          * Called when @ref PropagatedEvent::Input and the text is being
          * edited. Defined only if the application has a
-         * @ref Sdl2Application::TextEditingEvent "TextEditingEvent".
+         * @relativeref{Sdl2ApplicationWindow,TextEditingEvent}.
          */
         virtual void textEditingEvent(TextEditingEvent& event);
         #endif

--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -470,7 +470,10 @@ bool Sdl2Application::tryCreate(const Configuration& configuration) {
 
 #ifdef MAGNUM_TARGET_GL
 bool Sdl2Application::tryCreate(const Configuration& configuration, const GLConfiguration& glConfiguration) {
-    CORRADE_ASSERT(_context->version() == GL::Version::None, "Platform::Sdl2Application::tryCreate(): context already created", false);
+    CORRADE_ASSERT(!(configuration.windowFlags() & Configuration::WindowFlag::Contextless),
+        "Platform::Sdl2Application::tryCreate(): cannot pass Configuration::WindowFlag::Contextless when creating an OpenGL context", false);
+    CORRADE_ASSERT(_context->version() == GL::Version::None,
+        "Platform::Sdl2Application::tryCreate(): context already created", false);
 
     /* Enable double buffering, set up buffer sizes */
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
@@ -621,7 +624,7 @@ bool Sdl2Application::tryCreate(const Configuration& configuration, const GLConf
         if(!(_window = SDL_CreateWindow(configuration.title().data(),
             SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
             scaledWindowSize.x(), scaledWindowSize.y(),
-            SDL_WINDOW_OPENGL|SDL_WINDOW_HIDDEN|SDL_WINDOW_ALLOW_HIGHDPI|Uint32(configuration.windowFlags()&~Configuration::WindowFlag::Contextless))))
+            SDL_WINDOW_OPENGL|SDL_WINDOW_HIDDEN|SDL_WINDOW_ALLOW_HIGHDPI|Uint32(configuration.windowFlags()))))
         {
             Error() << "Platform::Sdl2Application::tryCreate(): cannot create window:" << SDL_GetError();
             return false;

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -1726,7 +1726,10 @@ class Sdl2Application::Configuration {
              * @ref Sdl2Application(const Arguments&, const Configuration&),
              * @ref create(const Configuration&) or
              * @ref tryCreate(const Configuration&) to prevent implicit
-             * creation of an OpenGL context.
+             * creation of an OpenGL context. Can't be used with
+             * @ref Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
+             * @ref create(const Configuration&, const GLConfiguration&) or
+             * @ref tryCreate(const Configuration&, const GLConfiguration&).
              */
             Contextless = 1u << 31, /* Hope this won't ever conflict with anything */
 

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -95,6 +95,430 @@ namespace Implementation {
     enum class Sdl2DpiScalingPolicy: UnsignedByte;
 }
 
+class Sdl2Application;
+
+/**
+@brief SDL2 application window
+@m_since_latest
+
+@ref TODOTODO document
+
+See @ref Sdl2Application for more information.
+*/
+class Sdl2ApplicationWindow {
+    public:
+        class Configuration;
+        class ViewportEvent;
+        class InputEvent;
+        class KeyEvent;
+        class MouseEvent;
+        class MouseMoveEvent;
+        class MouseScrollEvent;
+        class MultiGestureEvent;
+        class TextInputEvent;
+        class TextEditingEvent;
+
+        /** @brief Copying is not allowed */
+        Sdl2ApplicationWindow(const Sdl2ApplicationWindow&) = delete;
+
+        /** @brief Moving is not allowed */
+        Sdl2ApplicationWindow(Sdl2ApplicationWindow&&) = delete;
+
+        /** @brief Copying is not allowed */
+        Sdl2ApplicationWindow& operator=(const Sdl2ApplicationWindow&) = delete;
+
+        /** @brief Moving is not allowed */
+        Sdl2ApplicationWindow& operator=(Sdl2ApplicationWindow&&) = delete;
+
+        /* Compared to the top-level application which is never deleted through
+           a pointer, standalone windows most likely will, so the destructor is
+           virtual */
+        virtual ~Sdl2ApplicationWindow();
+
+        #ifndef CORRADE_TARGET_EMSCRIPTEN
+        /**
+         * @brief Underlying window handle
+         *
+         * Use in case you need to call SDL functionality directly. Returns
+         * @cpp nullptr @ce in case the window was not created yet.
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         */
+        SDL_Window* window() { return _window; }
+        #endif
+
+        /** @{ @name Window handling */
+
+        /**
+         * @brief Window size
+         *
+         * Window size to which all input event coordinates can be related.
+         * Note that, especially on HiDPI systems, it may be different from
+         * @ref framebufferSize(). Expects that a window is already created.
+         * See @ref Platform-Sdl2Application-dpi for more information.
+         * @see @ref dpiScaling()
+         */
+        Vector2i windowSize() const;
+
+        #if !defined(CORRADE_TARGET_EMSCRIPTEN) || defined(DOXYGEN_GENERATING_OUTPUT)
+        /**
+         * @brief Set window size
+         * @param size    The size, in screen coordinates
+         * @m_since{2020,06}
+         *
+         * To make the sizing work independently of the display DPI, @p size is
+         * internally multiplied with @ref dpiScaling() before getting applied.
+         * Expects that a window is already created.
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         * @see @ref setMinWindowSize(), @ref setMaxWindowSize()
+         */
+        void setWindowSize(const Vector2i& size);
+
+        /**
+         * @brief Set minimum window size
+         * @param size    The minimum size, in screen coordinates
+         * @m_since{2019,10}
+         *
+         * Note that, unlike in @ref GlfwApplication, SDL2 doesn't have a way
+         * to disable/remove a size limit. To make the sizing work
+         * independently of the display DPI, @p size is internally multiplied
+         * with @ref dpiScaling() before getting applied. Expects that a window
+         * is already created.
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         * @see @ref setMaxWindowSize(), @ref setWindowSize()
+         */
+        void setMinWindowSize(const Vector2i& size);
+
+        /**
+         * @brief Set maximal window size
+         * @param size    The maximum size, in screen coordinates
+         * @m_since{2019,10}
+         *
+         * Note that, unlike in @ref GlfwApplication, SDL2 doesn't have a way
+         * to disable/remove a size limit. To make the sizing work
+         * independently of the display DPI, @p size is internally multiplied
+         * with @ref dpiScaling() before getting applied. Expects that a window
+         * is already created.
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         * @see @ref setMinWindowSize(), @ref setMaxWindowSize()
+         */
+        void setMaxWindowSize(const Vector2i& size);
+        #endif
+
+        #if defined(MAGNUM_TARGET_GL) || defined(DOXYGEN_GENERATING_OUTPUT)
+        /**
+         * @brief Framebuffer size
+         *
+         * Size of the default framebuffer. Note that, especially on HiDPI
+         * systems, it may be different from @ref windowSize(). Expects that a
+         * window is already created. See @ref Platform-Sdl2Application-dpi for
+         * more information.
+         *
+         * @note This function is available only if Magnum is compiled with
+         *      @ref MAGNUM_TARGET_GL enabled (done by default). See
+         *      @ref building-features for more information.
+         *
+         * @see @ref Sdl2Application::framebufferSize(), @ref dpiScaling()
+         */
+        Vector2i framebufferSize() const;
+        #endif
+
+        /**
+         * @brief DPI scaling
+         *
+         * How the content should be scaled relative to system defaults for
+         * given @ref windowSize(). If a window is not created yet, returns
+         * zero vector, use @ref dpiScaling(const Configuration&) for
+         * calculating a value independently. See @ref Platform-Sdl2Application-dpi
+         * for more information.
+         * @see @ref framebufferSize()
+         */
+        Vector2 dpiScaling() const;
+
+        /**
+         * @brief DPI scaling for given configuration
+         *
+         * Calculates DPI scaling that would be used when creating a window
+         * with given @p configuration. Takes into account DPI scaling policy
+         * and custom scaling specified on the command-line. See
+         * @ref Platform-Sdl2Application-dpi for more information.
+         */
+        Vector2 dpiScaling(const Configuration& configuration);
+
+        /**
+         * @brief Set window title
+         * @m_since{2019,10}
+         *
+         * The @p title is expected to be encoded in UTF-8.
+         */
+        void setWindowTitle(Containers::StringView title);
+
+        #if !defined(CORRADE_TARGET_EMSCRIPTEN) && (SDL_MAJOR_VERSION*1000 + SDL_MINOR_VERSION*100 + SDL_PATCHLEVEL >= 2005 || defined(DOXYGEN_GENERATING_OUTPUT))
+        /**
+         * @brief Set window icon
+         * @m_since{2020,06}
+         *
+         * The @p image is expected to be with origin at bottom left (which is
+         * the default for imported images) and in one of
+         * @ref PixelFormat::RGB8Unorm, @ref PixelFormat::RGB8Srgb,
+         * @ref PixelFormat::RGBA8Unorm or @ref PixelFormat::RGBA8Srgb formats.
+         * Unlike @ref GlfwApplication::setWindowIcon(), SDL doesn't provide a
+         * way to supply multiple images in different sizes.
+         * @note Available since SDL 2.0.5. Not available on
+         *      @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten", use
+         *      @cb{.html} <link rel="icon"> @ce in your HTML markup instead.
+         *      Although it's not documented in SDL itself, the function might
+         *      have no effect on macOS / Wayland, similarly to how
+         *      @ref GlfwApplication::setWindowIcon() behaves on those
+         *      platforms.
+         * @see @ref platform-windows-icon "Excecutable icon on Windows",
+         *      @ref Trade::IcoImporter "IcoImporter"
+         */
+        void setWindowIcon(const ImageView2D& image);
+        #endif
+
+        /**
+         * @brief Swap buffers
+         *
+         * Paints currently rendered framebuffer on screen.
+         * @see @ref Sdl2Application::setSwapInterval()
+         */
+        void swapBuffers();
+
+        /**
+         * @brief Redraw immediately
+         *
+         * Marks the window for redrawing, resulting in call to @ref drawEvent()
+         * in the next iteration. You can call it from @ref drawEvent() itself
+         * to redraw immediately without waiting for user input.
+         */
+        void redraw();
+
+    private:
+        /**
+         * @brief Viewport event
+         *
+         * Called when window size changes. The default implementation does
+         * nothing. If you want to respond to size changes, you should pass the
+         * new *framebuffer* size to @ref GL::DefaultFramebuffer::setViewport()
+         * (if using OpenGL) and possibly elsewhere (to
+         * @ref SceneGraph::Camera::setViewport(), other framebuffers...) and
+         * the new *window* size and DPI scaling to APIs that respond to user
+         * events or scale UI elements.
+         *
+         * Note that this function might not get called at all if the window
+         * size doesn't change. You should configure the initial state of your
+         * cameras, framebuffers etc. in application constructor rather than
+         * relying on this function to be called. Size of the window can be
+         * retrieved using @ref windowSize(), size of the backing framebuffer
+         * via @ref framebufferSize() and DPI scaling using @ref dpiScaling().
+         * See @ref Platform-Sdl2Application-dpi for detailed info about these
+         * values.
+         */
+        virtual void viewportEvent(ViewportEvent& event);
+
+        /**
+         * @brief Draw event
+         *
+         * Called when the screen is redrawn. You should clean the framebuffer
+         * using @ref GL::DefaultFramebuffer::clear() (if using OpenGL) and
+         * then add your own drawing functions. After drawing is finished, call
+         * @ref swapBuffers(). If you want to draw immediately again, call also
+         * @ref redraw().
+         */
+        virtual void drawEvent() = 0;
+
+        /* Since 1.8.17, the original short-hand group closing doesn't work
+           anymore. FFS. */
+        /**
+         * @}
+         */
+
+        /** @{ @name Keyboard handling */
+
+        /**
+         * @brief Key press event
+         *
+         * Called when an key is pressed. Default implementation does nothing.
+         */
+        virtual void keyPressEvent(KeyEvent& event);
+
+        /**
+         * @brief Key release event
+         *
+         * Called when an key is released. Default implementation does nothing.
+         */
+        virtual void keyReleaseEvent(KeyEvent& event);
+
+        /* Since 1.8.17, the original short-hand group closing doesn't work
+           anymore. FFS. */
+        /**
+         * @}
+         */
+
+        /** @{ @name Mouse handling */
+
+    public:
+        /**
+         * @brief Cursor type
+         * @m_since{2020,06}
+         *
+         * @see @ref setCursor()
+         */
+        enum class Cursor: UnsignedInt {
+            Arrow,          /**< Arrow */
+            TextInput,      /**< Text input */
+            Wait,           /**< Wait */
+            Crosshair,      /**< Crosshair */
+            WaitArrow,      /**< Small wait cursor */
+            ResizeNWSE,     /**< Double arrow pointing northwest and southeast */
+            ResizeNESW,     /**< Double arrow pointing northeast and southwest */
+            ResizeWE,       /**< Double arrow pointing west and east */
+            ResizeNS,       /**< Double arrow pointing north and south */
+            ResizeAll,      /**< Four pointed arrow pointing north, south, east, and west */
+            No,             /**< Slashed circle or crossbones */
+            Hand,           /**< Hand */
+            Hidden,         /**< Hidden */
+
+            #ifndef CORRADE_TARGET_EMSCRIPTEN
+            /**
+             * Hidden and locked. When the mouse is locked, only
+             * @ref MouseMoveEvent::relativePosition() is changing, absolute
+             * position stays the same.
+             * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+             */
+            HiddenLocked
+            #endif
+        };
+
+        /**
+         * @brief Set cursor type
+         * @m_since{2020,06}
+         *
+         * Expects that a window is already created. Default is
+         * @ref Cursor::Arrow.
+         * @ref TODOTODO uhh clean up the docs to say "that the window is", not "a"
+         */
+        void setCursor(Cursor cursor);
+
+        /**
+         * @brief Get current cursor type
+         * @m_since{2020,06}
+         */
+        Cursor cursor();
+
+        #ifndef CORRADE_TARGET_EMSCRIPTEN
+        /**
+         * @brief Warp mouse cursor to given coordinates
+         *
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         */
+        void warpCursor(const Vector2i& position) {
+            SDL_WarpMouseInWindow(_window, position.x(), position.y());
+        }
+        #endif
+
+    private:
+        /**
+         * @brief Mouse press event
+         *
+         * Called when mouse button is pressed. Default implementation does
+         * nothing.
+         */
+        virtual void mousePressEvent(MouseEvent& event);
+
+        /**
+         * @brief Mouse release event
+         *
+         * Called when mouse button is released. Default implementation does
+         * nothing.
+         */
+        virtual void mouseReleaseEvent(MouseEvent& event);
+
+        /**
+         * @brief Mouse move event
+         *
+         * Called when mouse is moved. Default implementation does nothing.
+         */
+        virtual void mouseMoveEvent(MouseMoveEvent& event);
+
+        /**
+         * @brief Mouse scroll event
+         *
+         * Called when a scrolling device is used (mouse wheel or scrolling
+         * area on a touchpad). Default implementation does nothing.
+         */
+        virtual void mouseScrollEvent(MouseScrollEvent& event);
+
+        /* Since 1.8.17, the original short-hand group closing doesn't work
+           anymore. FFS. */
+        /**
+         * @}
+         */
+
+        /** @{ @name Touch gesture handling */
+
+        /**
+         * @brief Multi gesture event
+         *
+         * Called when the user performs a gesture using multiple fingers.
+         * Default implementation does nothing.
+         * @experimental
+         */
+        virtual void multiGestureEvent(MultiGestureEvent& event);
+
+        /* Since 1.8.17, the original short-hand group closing doesn't work
+           anymore. FFS. */
+        /**
+         * @}
+         */
+
+        /** @{ @name Text input handling */
+
+        /**
+         * @brief Text input event
+         *
+         * Called when text input is active and the text is being input.
+         * @see @ref Sdl2Application::isTextInputActive()
+         */
+        virtual void textInputEvent(TextInputEvent& event);
+
+        /**
+         * @brief Text editing event
+         *
+         * Called when text input is active and the text is being edited.
+         */
+        virtual void textEditingEvent(TextEditingEvent& event);
+
+        /* Since 1.8.17, the original short-hand group closing doesn't work
+           anymore. FFS. */
+        /**
+         * @}
+         */
+
+    private:
+        friend Sdl2Application;
+
+        enum class WindowFlag: UnsignedByte;
+        typedef Containers::EnumSet<WindowFlag> WindowFlags;
+        CORRADE_ENUMSET_FRIEND_OPERATORS(WindowFlags)
+
+        /* Used by Sdl2Application(NoCreateT) */
+        explicit Sdl2ApplicationWindow(Sdl2Application& application, NoCreateT);
+
+        Vector2 dpiScalingInternal(Implementation::Sdl2DpiScalingPolicy configurationDpiScalingPolicy, const Vector2& configurationDpiScaling) const;
+
+        Sdl2Application& _application;
+
+        #ifndef CORRADE_TARGET_EMSCRIPTEN
+        SDL_Window* _window{};
+        #else
+        SDL_Surface* _surface{};
+        Vector2i _lastKnownCanvasSize;
+        #endif
+
+        WindowFlags _windowFlags;
+};
+
 /** @nosubgrouping
 @brief SDL2 application
 
@@ -339,8 +763,9 @@ the compositor in system-wide KWin settings.
 
 @subsection Platform-Sdl2Application-usage-ios iOS specifics
 
-Leaving a default (zero) window size in @ref Configuration will cause the app
-to autodetect it based on the actual device screen size. This also depends on
+Leaving a default (zero) window size in
+@relativeref{Sdl2ApplicationWindow,Configuration} will cause the app to
+autodetect it based on the actual device screen size. This also depends on
 @ref Platform-Sdl2Application-dpi "DPI awareness", see below for details.
 
 As noted in the @ref platforms-ios-bundle "iOS platform guide", a lot of
@@ -348,20 +773,22 @@ options needs to be set via a `*.plist` file. Some options can be configured
 from runtime when creating the SDL2 application window, see documentation of
 a particular value for details:
 
--   @ref Configuration::WindowFlag::Borderless hides the menu bar
--   @ref Configuration::WindowFlag::Resizable makes the application respond to
-    device orientation changes
+-   @relativeref{Sdl2ApplicationWindow,Configuration::WindowFlag::Borderless}
+    hides the menu bar
+-   @relativeref{Sdl2ApplicationWindow,Configuration::WindowFlag::Resizable}
+    makes the application respond to device orientation changes
 
 @subsection Platform-Sdl2Application-usage-emscripten Emscripten specifics
 
-Leaving a default (zero) window size in @ref Configuration will cause the app
-to use a window size that corresponds to *CSS pixel size* of the
-@cb{.html} <canvas> @ce element. The size is then multiplied by DPI scaling
+Leaving a default (zero) window size in @relativeref{Sdl2ApplicationWindow,Configuration}
+will cause the app to use a window size that corresponds to *CSS pixel size* of
+the @cb{.html} <canvas> @ce element. The size is then multiplied by DPI scaling
 value, see @ref Platform-Sdl2Application-dpi "DPI awareness" below for details.
 
-If you enable @ref Configuration::WindowFlag::Resizable, the canvas will be
-resized when size of the canvas changes and you get @ref viewportEvent(). If
-the flag is not enabled, no canvas resizing is performed.
+If you enable @relativeref{Sdl2ApplicationWindow,Configuration::WindowFlag::Resizable},
+the canvas will be resized when size of the canvas changes and you get
+@ref viewportEvent(). If the flag is not enabled, no canvas resizing is
+performed.
 
 @note While this implementation supports Esmcripten and is going to continue
     supporting it for the foreseeable future, @ref EmscriptenApplication is now
@@ -395,8 +822,8 @@ variable).
     However, the window backing framebuffer has a different size. This is only
     supported on macOS and iOS. See @ref platforms-macos-hidpi for details how
     to enable it. Equivalent to passing
-    @ref Configuration::DpiScalingPolicy::Framebuffer to
-    @ref Configuration::setSize() or `framebuffer` via command line /
+    @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Framebuffer}
+    to @ref Configuration::setSize() or `framebuffer` via command line /
     environment.
 -   Virtual DPI scaling. Scales the window based on DPI scaling setting in the
     system. For example if a 800x600 window is requested and DPI scaling is set
@@ -405,8 +832,8 @@ variable).
     Windows; on Windows the application is first checked for DPI awareness
     as described in @ref platforms-windows-hidpi and if the application is not
     DPI-aware, 1:1 scaling is used. Equivalent to passing
-    @ref Configuration::DpiScalingPolicy::Virtual to
-    @ref Configuration::setSize() or `virtual` on command line.
+    @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Virtual}
+    to @ref Configuration::setSize() or `virtual` on command line.
 -   Physical DPI scaling. Takes the requested window size as a physical size
     that a window would have on platform's default DPI and scales it to have
     the same physical size on given display physical DPI. So, for example on a
@@ -418,8 +845,9 @@ variable).
     This is supported on Linux and all mobile platforms (except iOS) and
     Emscripten. On Windows this is equivalent to virtual DPI scaling but
     without doing an explicit check for DPI awareness first. Equivalent to
-    passing @ref Configuration::DpiScalingPolicy::Physical to
-    @ref Configuration::setSize() or `physical` via command line / environment.
+    passing @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Physical}
+    to @ref Configuration::setSize() or `physical` via command line /
+    environment.
 
 Besides the above, it's possible to supply a custom DPI scaling value to
 @ref Configuration::setSize() or the `--magnum-dpi-scaling` command-line
@@ -433,24 +861,25 @@ affect sharpness of the contents.
 The default is depending on the platform:
 
 -   On macOS and iOS, the default and only supported option is
-    @ref Configuration::DpiScalingPolicy::Framebuffer. On this platform,
-    @ref windowSize() and @ref framebufferSize() will differ depending on
-    whether `NSHighResolutionCapable` is enabled in the `*.plist` file or not.
-    By default, @ref dpiScaling() is @cpp 1.0f @ce in both dimensions but it
-    can be overridden using custom DPI scaling.
--   On Windows, the default is @ref Configuration::DpiScalingPolicy::Framebuffer.
+    @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Framebuffer}.
+    On this platform, @ref windowSize() and @ref framebufferSize() will differ
+    depending on whether `NSHighResolutionCapable` is enabled in the `*.plist`
+    file or not. By default, @ref dpiScaling() is @cpp 1.0f @ce in both
+    dimensions but it can be overridden using custom DPI scaling.
+-   On Windows, the default is @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Framebuffer}.
     The @ref windowSize() and @ref framebufferSize() is always the same.
     Depending on whether the DPI awareness was enabled in the manifest file or
     set by the `SetProcessDpiAwareness()` API, @ref dpiScaling() is either
     @cpp 1.0f @ce in both dimensions, indicating a low-DPI screen or a
     non-DPI-aware app, or some other value for HiDPI screens. In both cases the
     value can be overridden using custom DPI scaling.
--   On Linux, the default is @ref Configuration::DpiScalingPolicy::Virtual,
+-   On Linux, the default is @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Virtual},
     taken from the `Xft.dpi` property. If the property is not available, it
-    falls back to @ref Configuration::DpiScalingPolicy::Physical, querying the
-    monitor DPI value. The @ref windowSize() and @ref framebufferSize() is
-    always the same, @ref dpiScaling() contains the queried DPI scaling value.
-    The value can be overridden using custom DPI scaling.
+    falls back to @relativeref{Sdl2ApplicationWindow,Configuration::DpiScalingPolicy::Physical},
+    querying the monitor DPI value. The @ref windowSize() and
+    @ref framebufferSize() is always the same, @ref dpiScaling() contains the
+    queried DPI scaling value. The value can be overridden using custom DPI
+    scaling.
 -   On @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten", the default is physical DPI
     scaling, taken from [Window.getDevicePixelRatio()](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio). The
     @ref windowSize() and @ref framebufferSize() is always the same,
@@ -480,7 +909,7 @@ If your application is saving and restoring window size, it's advisable to take
     properly handle cases where the window is opened on a display with
     different DPI.
 */
-class Sdl2Application {
+class Sdl2Application: public Sdl2ApplicationWindow {
     public:
         /** @brief Application arguments */
         struct Arguments {
@@ -491,20 +920,10 @@ class Sdl2Application {
             char** argv;    /**< @brief Argument values */
         };
 
-        class Configuration;
         #ifdef MAGNUM_TARGET_GL
         class GLConfiguration;
         #endif
         class ExitEvent;
-        class ViewportEvent;
-        class InputEvent;
-        class KeyEvent;
-        class MouseEvent;
-        class MouseMoveEvent;
-        class MouseScrollEvent;
-        class MultiGestureEvent;
-        class TextInputEvent;
-        class TextEditingEvent;
 
         #ifdef MAGNUM_TARGET_GL
         /**
@@ -514,9 +933,9 @@ class Sdl2Application {
          * @param glConfiguration   OpenGL context configuration
          *
          * Creates application with default or user-specified configuration.
-         * See @ref Configuration for more information. The program exits if
-         * the context cannot be created, see @ref tryCreate() for an
-         * alternative.
+         * See @relativeref{Sdl2ApplicationWindow,Configuration} for more
+         * information. The program exits if the context cannot be created, see
+         * @ref tryCreate() for an alternative.
          *
          * @note This function is available only if Magnum is compiled with
          *      @ref MAGNUM_TARGET_GL enabled (done by default). See
@@ -528,9 +947,10 @@ class Sdl2Application {
         /**
          * @brief Construct without explicit GPU context configuration
          *
-         * If @ref Configuration::WindowFlag::Contextless is present or Magnum
-         * was not built with @ref MAGNUM_TARGET_GL, this creates a window
-         * without any GPU context attached, leaving that part on the user.
+         * If @relativeref{Sdl2ApplicationWindow,Configuration::WindowFlag::Contextless}
+         * is present or Magnum was not built with @ref MAGNUM_TARGET_GL, this
+         * creates a window without any GPU context attached, leaving that part
+         * on the user.
          *
          * If none of the flags is present and Magnum was built with
          * @ref MAGNUM_TARGET_GL, this is equivalent to calling
@@ -615,17 +1035,6 @@ class Sdl2Application {
          */
         void exit(int exitCode = 0);
 
-        #ifndef CORRADE_TARGET_EMSCRIPTEN
-        /**
-         * @brief Underlying window handle
-         *
-         * Use in case you need to call SDL functionality directly. Returns
-         * @cpp nullptr @ce in case the window was not created yet.
-         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
-         */
-        SDL_Window* window() { return _window; }
-        #endif
-
         #if defined(MAGNUM_TARGET_GL) && !defined(CORRADE_TARGET_EMSCRIPTEN)
         /**
          * @brief Underlying OpenGL context
@@ -672,9 +1081,10 @@ class Sdl2Application {
         /**
          * @brief Create a window with given configuration
          *
-         * If @ref Configuration::WindowFlag::Contextless is present or Magnum
-         * was not built with @ref MAGNUM_TARGET_GL, this creates a window
-         * without any GPU context attached, leaving that part on the user.
+         * If @relativeref{Sdl2ApplicationWindow,Configuration::WindowFlag::Contextless}
+         * is present or Magnum was not built with @ref MAGNUM_TARGET_GL, this
+         * creates a window without any GPU context attached, leaving that part
+         * on the user.
          *
          * If none of the flags is present and Magnum was built with
          * @ref MAGNUM_TARGET_GL, this is equivalent to calling
@@ -689,7 +1099,7 @@ class Sdl2Application {
          * @brief Create a window with default configuration and OpenGL context
          *
          * Equivalent to calling @ref create(const Configuration&) with
-         * default-constructed @ref Configuration.
+         * default-constructed @relativeref{Sdl2ApplicationWindow,Configuration}.
          */
         void create();
 
@@ -719,134 +1129,6 @@ class Sdl2Application {
         /** @{ @name Screen handling */
 
     public:
-        /**
-         * @brief Window size
-         *
-         * Window size to which all input event coordinates can be related.
-         * Note that, especially on HiDPI systems, it may be different from
-         * @ref framebufferSize(). Expects that a window is already created.
-         * See @ref Platform-Sdl2Application-dpi for more information.
-         * @see @ref dpiScaling()
-         */
-        Vector2i windowSize() const;
-
-        #if !defined(CORRADE_TARGET_EMSCRIPTEN) || defined(DOXYGEN_GENERATING_OUTPUT)
-        /**
-         * @brief Set window size
-         * @param size    The size, in screen coordinates
-         * @m_since{2020,06}
-         *
-         * To make the sizing work independently of the display DPI, @p size is
-         * internally multiplied with @ref dpiScaling() before getting applied.
-         * Expects that a window is already created.
-         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
-         * @see @ref setMinWindowSize(), @ref setMaxWindowSize()
-         */
-        void setWindowSize(const Vector2i& size);
-
-        /**
-         * @brief Set minimum window size
-         * @param size    The minimum size, in screen coordinates
-         * @m_since{2019,10}
-         *
-         * Note that, unlike in @ref GlfwApplication, SDL2 doesn't have a way
-         * to disable/remove a size limit. To make the sizing work
-         * independently of the display DPI, @p size is internally multiplied
-         * with @ref dpiScaling() before getting applied. Expects that a window
-         * is already created.
-         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
-         * @see @ref setMaxWindowSize(), @ref setWindowSize()
-         */
-        void setMinWindowSize(const Vector2i& size);
-
-        /**
-         * @brief Set maximal window size
-         * @param size    The maximum size, in screen coordinates
-         * @m_since{2019,10}
-         *
-         * Note that, unlike in @ref GlfwApplication, SDL2 doesn't have a way
-         * to disable/remove a size limit. To make the sizing work
-         * independently of the display DPI, @p size is internally multiplied
-         * with @ref dpiScaling() before getting applied. Expects that a window
-         * is already created.
-         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
-         * @see @ref setMinWindowSize(), @ref setMaxWindowSize()
-         */
-        void setMaxWindowSize(const Vector2i& size);
-        #endif
-
-        #if defined(MAGNUM_TARGET_GL) || defined(DOXYGEN_GENERATING_OUTPUT)
-        /**
-         * @brief Framebuffer size
-         *
-         * Size of the default framebuffer. Note that, especially on HiDPI
-         * systems, it may be different from @ref windowSize(). Expects that a
-         * window is already created. See @ref Platform-Sdl2Application-dpi for
-         * more information.
-         *
-         * @note This function is available only if Magnum is compiled with
-         *      @ref MAGNUM_TARGET_GL enabled (done by default). See
-         *      @ref building-features for more information.
-         *
-         * @see @ref Sdl2Application::framebufferSize(), @ref dpiScaling()
-         */
-        Vector2i framebufferSize() const;
-        #endif
-
-        /**
-         * @brief DPI scaling
-         *
-         * How the content should be scaled relative to system defaults for
-         * given @ref windowSize(). If a window is not created yet, returns
-         * zero vector, use @ref dpiScaling(const Configuration&) for
-         * calculating a value independently. See @ref Platform-Sdl2Application-dpi
-         * for more information.
-         * @see @ref framebufferSize()
-         */
-        Vector2 dpiScaling() const;
-
-        /**
-         * @brief DPI scaling for given configuration
-         *
-         * Calculates DPI scaling that would be used when creating a window
-         * with given @p configuration. Takes into account DPI scaling policy
-         * and custom scaling specified on the command-line. See
-         * @ref Platform-Sdl2Application-dpi for more information.
-         */
-        Vector2 dpiScaling(const Configuration& configuration);
-
-        /**
-         * @brief Set window title
-         * @m_since{2019,10}
-         *
-         * The @p title is expected to be encoded in UTF-8.
-         */
-        void setWindowTitle(Containers::StringView title);
-
-        #if !defined(CORRADE_TARGET_EMSCRIPTEN) && (SDL_MAJOR_VERSION*1000 + SDL_MINOR_VERSION*100 + SDL_PATCHLEVEL >= 2005 || defined(DOXYGEN_GENERATING_OUTPUT))
-        /**
-         * @brief Set window icon
-         * @m_since{2020,06}
-         *
-         * The @p image is expected to be with origin at bottom left (which is
-         * the default for imported images) and in one of
-         * @ref PixelFormat::RGB8Unorm, @ref PixelFormat::RGB8Srgb,
-         * @ref PixelFormat::RGBA8Unorm or @ref PixelFormat::RGBA8Srgb formats.
-         * Unlike @ref GlfwApplication::setWindowIcon(), SDL doesn't provide a
-         * way to supply multiple images in different sizes.
-         * @note Available since SDL 2.0.5. Not available on
-         *      @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten", use
-         *      @cb{.html} <link rel="icon"> @ce in your HTML markup instead.
-         *      Although it's not documented in SDL itself, the function might
-         *      have no effect on macOS / Wayland, similarly to how
-         *      @ref GlfwApplication::setWindowIcon() behaves on those
-         *      platforms.
-         * @see @ref platform-windows-icon "Excecutable icon on Windows",
-         *      @ref Trade::IcoImporter "IcoImporter"
-         */
-        void setWindowIcon(const ImageView2D& image);
-        #endif
-
         #if defined(CORRADE_TARGET_EMSCRIPTEN) || defined(DOXYGEN_GENERATING_OUTPUT)
         /**
          * @brief Set container CSS class
@@ -871,14 +1153,6 @@ class Sdl2Application {
          */
         void setContainerCssClass(Containers::StringView cssClass);
         #endif
-
-        /**
-         * @brief Swap buffers
-         *
-         * Paints currently rendered framebuffer on screen.
-         * @see @ref setSwapInterval()
-         */
-        void swapBuffers();
 
         /** @brief Swap interval */
         Int swapInterval() const;
@@ -912,71 +1186,6 @@ class Sdl2Application {
         }
         #endif
 
-        /**
-         * @brief Redraw immediately
-         *
-         * Marks the window for redrawing, resulting in call to @ref drawEvent()
-         * in the next iteration. You can call it from @ref drawEvent() itself
-         * to redraw immediately without waiting for user input.
-         */
-        void redraw();
-
-    private:
-        /**
-         * @brief Viewport event
-         *
-         * Called when window size changes. The default implementation does
-         * nothing. If you want to respond to size changes, you should pass the
-         * new *framebuffer* size to @ref GL::DefaultFramebuffer::setViewport()
-         * (if using OpenGL) and possibly elsewhere (to
-         * @ref SceneGraph::Camera::setViewport(), other framebuffers...) and
-         * the new *window* size and DPI scaling to APIs that respond to user
-         * events or scale UI elements.
-         *
-         * Note that this function might not get called at all if the window
-         * size doesn't change. You should configure the initial state of your
-         * cameras, framebuffers etc. in application constructor rather than
-         * relying on this function to be called. Size of the window can be
-         * retrieved using @ref windowSize(), size of the backing framebuffer
-         * via @ref framebufferSize() and DPI scaling using @ref dpiScaling().
-         * See @ref Platform-Sdl2Application-dpi for detailed info about these
-         * values.
-         */
-        virtual void viewportEvent(ViewportEvent& event);
-
-        /**
-         * @brief Draw event
-         *
-         * Called when the screen is redrawn. You should clean the framebuffer
-         * using @ref GL::DefaultFramebuffer::clear() (if using OpenGL) and
-         * then add your own drawing functions. After drawing is finished, call
-         * @ref swapBuffers(). If you want to draw immediately again, call also
-         * @ref redraw().
-         */
-        virtual void drawEvent() = 0;
-
-        /* Since 1.8.17, the original short-hand group closing doesn't work
-           anymore. FFS. */
-        /**
-         * @}
-         */
-
-        /** @{ @name Keyboard handling */
-
-        /**
-         * @brief Key press event
-         *
-         * Called when an key is pressed. Default implementation does nothing.
-         */
-        virtual void keyPressEvent(KeyEvent& event);
-
-        /**
-         * @brief Key release event
-         *
-         * Called when an key is released. Default implementation does nothing.
-         */
-        virtual void keyReleaseEvent(KeyEvent& event);
-
         /* Since 1.8.17, the original short-hand group closing doesn't work
            anymore. FFS. */
         /**
@@ -984,65 +1193,6 @@ class Sdl2Application {
          */
 
         /** @{ @name Mouse handling */
-
-    public:
-        /**
-         * @brief Cursor type
-         * @m_since{2020,06}
-         *
-         * @see @ref setCursor()
-         */
-        enum class Cursor: UnsignedInt {
-            Arrow,          /**< Arrow */
-            TextInput,      /**< Text input */
-            Wait,           /**< Wait */
-            Crosshair,      /**< Crosshair */
-            WaitArrow,      /**< Small wait cursor */
-            ResizeNWSE,     /**< Double arrow pointing northwest and southeast */
-            ResizeNESW,     /**< Double arrow pointing northeast and southwest */
-            ResizeWE,       /**< Double arrow pointing west and east */
-            ResizeNS,       /**< Double arrow pointing north and south */
-            ResizeAll,      /**< Four pointed arrow pointing north, south, east, and west */
-            No,             /**< Slashed circle or crossbones */
-            Hand,           /**< Hand */
-            Hidden,         /**< Hidden */
-
-            #ifndef CORRADE_TARGET_EMSCRIPTEN
-            /**
-             * Hidden and locked. When the mouse is locked, only
-             * @ref MouseMoveEvent::relativePosition() is changing, absolute
-             * position stays the same.
-             * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
-             */
-            HiddenLocked
-            #endif
-        };
-
-        /**
-         * @brief Set cursor type
-         * @m_since{2020,06}
-         *
-         * Expects that a window is already created. Default is
-         * @ref Cursor::Arrow.
-         */
-        void setCursor(Cursor cursor);
-
-        /**
-         * @brief Get current cursor type
-         * @m_since{2020,06}
-         */
-        Cursor cursor();
-
-        #ifndef CORRADE_TARGET_EMSCRIPTEN
-        /**
-         * @brief Warp mouse cursor to given coordinates
-         *
-         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
-         */
-        void warpCursor(const Vector2i& position) {
-            SDL_WarpMouseInWindow(_window, position.x(), position.y());
-        }
-        #endif
 
         #ifdef MAGNUM_BUILD_DEPRECATED
         /**
@@ -1062,55 +1212,6 @@ class Sdl2Application {
         CORRADE_DEPRECATED("use setCursor() together with Cursor::HiddenLocked instead") void setMouseLocked(bool enabled);
         #endif
 
-    private:
-        /**
-         * @brief Mouse press event
-         *
-         * Called when mouse button is pressed. Default implementation does
-         * nothing.
-         */
-        virtual void mousePressEvent(MouseEvent& event);
-
-        /**
-         * @brief Mouse release event
-         *
-         * Called when mouse button is released. Default implementation does
-         * nothing.
-         */
-        virtual void mouseReleaseEvent(MouseEvent& event);
-
-        /**
-         * @brief Mouse move event
-         *
-         * Called when mouse is moved. Default implementation does nothing.
-         */
-        virtual void mouseMoveEvent(MouseMoveEvent& event);
-
-        /**
-         * @brief Mouse scroll event
-         *
-         * Called when a scrolling device is used (mouse wheel or scrolling
-         * area on a touchpad). Default implementation does nothing.
-         */
-        virtual void mouseScrollEvent(MouseScrollEvent& event);
-
-        /* Since 1.8.17, the original short-hand group closing doesn't work
-           anymore. FFS. */
-        /**
-         * @}
-         */
-
-        /** @{ @name Touch gesture handling */
-
-        /**
-         * @brief Multi gesture event
-         *
-         * Called when the user performs a gesture using multiple fingers.
-         * Default implementation does nothing.
-         * @experimental
-         */
-        virtual void multiGestureEvent(MultiGestureEvent& event);
-
         /* Since 1.8.17, the original short-hand group closing doesn't work
            anymore. FFS. */
         /**
@@ -1118,7 +1219,7 @@ class Sdl2Application {
          */
 
         /** @{ @name Text input handling */
-    public:
+
         /**
          * @brief Whether text input is active
          *
@@ -1159,22 +1260,6 @@ class Sdl2Application {
          */
         void setTextInputRect(const Range2Di& rect);
 
-    private:
-        /**
-         * @brief Text input event
-         *
-         * Called when text input is active and the text is being input.
-         * @see @ref isTextInputActive()
-         */
-        virtual void textInputEvent(TextInputEvent& event);
-
-        /**
-         * @brief Text editing event
-         *
-         * Called when text input is active and the text is being edited.
-         */
-        virtual void textEditingEvent(TextEditingEvent& event);
-
         /* Since 1.8.17, the original short-hand group closing doesn't work
            anymore. FFS. */
         /**
@@ -1183,6 +1268,7 @@ class Sdl2Application {
 
         /** @{ @name Special events */
 
+    private:
         /**
          * @brief Exit event
          *
@@ -1234,11 +1320,11 @@ class Sdl2Application {
          */
 
     private:
+        friend Sdl2ApplicationWindow;
+
         enum class Flag: UnsignedByte;
         typedef Containers::EnumSet<Flag> Flags;
         CORRADE_ENUMSET_FRIEND_OPERATORS(Flags)
-
-        Vector2 dpiScalingInternal(Implementation::Sdl2DpiScalingPolicy configurationDpiScalingPolicy, const Vector2& configurationDpiScaling) const;
 
         #ifndef CORRADE_TARGET_EMSCRIPTEN
         SDL_Cursor* _cursors[12]{};
@@ -1253,11 +1339,7 @@ class Sdl2Application {
         Vector2 _commandLineDpiScaling, _configurationDpiScaling;
 
         #ifndef CORRADE_TARGET_EMSCRIPTEN
-        SDL_Window* _window{};
         UnsignedInt _minimalLoopPeriod;
-        #else
-        SDL_Surface* _surface{};
-        Vector2i _lastKnownCanvasSize;
         #endif
 
         #ifdef MAGNUM_TARGET_GL
@@ -1285,7 +1367,7 @@ The created window is always with a double-buffered OpenGL context.
     @ref MAGNUM_TARGET_GL enabled (done by default). See @ref building-features
     for more information.
 
-@see @ref Sdl2Application(), @ref create(), @ref tryCreate()
+@see @ref Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&), @ref create(), @ref tryCreate()
 */
 class Sdl2Application::GLConfiguration: public GL::Context::Configuration {
     public:
@@ -1587,10 +1669,12 @@ namespace Implementation {
 /**
 @brief Configuration
 
-@see @ref Sdl2Application(), @ref GLConfiguration, @ref create(),
-    @ref tryCreate()
+@see @ref Sdl2ApplicationWindow(),
+    @ref Sdl2Application::Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
+    @ref Sdl2Application::GLConfiguration, @ref Sdl2Application::create(),
+    @ref Sdl2Application::tryCreate()
 */
-class Sdl2Application::Configuration {
+class Sdl2ApplicationWindow::Configuration {
     public:
         /**
          * @brief Window flag
@@ -1723,13 +1807,13 @@ class Sdl2Application::Configuration {
 
             /**
              * Do not create any GPU context. Use together with
-             * @ref Sdl2Application(const Arguments&, const Configuration&),
-             * @ref create(const Configuration&) or
-             * @ref tryCreate(const Configuration&) to prevent implicit
-             * creation of an OpenGL context. Can't be used with
-             * @ref Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
-             * @ref create(const Configuration&, const GLConfiguration&) or
-             * @ref tryCreate(const Configuration&, const GLConfiguration&).
+             * @ref Sdl2Application::Sdl2Application(const Arguments&, const Configuration&),
+             * @ref Sdl2Application::create(const Configuration&) or
+             * @ref Sdl2Application::tryCreate(const Configuration&) to prevent
+             * implicit creation of an OpenGL context. Can't be used with
+             * @ref Sdl2Application::Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
+             * @ref Sdl2Application::create(const Configuration&, const GLConfiguration&) or
+             * @ref Sdl2Application::tryCreate(const Configuration&, const GLConfiguration&).
              */
             Contextless = 1u << 31, /* Hope this won't ever conflict with anything */
 
@@ -1737,9 +1821,9 @@ class Sdl2Application::Configuration {
              * Request a window for use with OpenGL. Useful in combination with
              * @ref WindowFlag::Contextless, otherwise enabled implicitly when
              * creating an OpenGL context using
-             * @ref Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
-             * @ref create(const Configuration&, const GLConfiguration&) or
-             * @ref tryCreate(const Configuration&, const GLConfiguration&).
+             * @ref Sdl2Application::Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
+             * @ref Sdl2Application::create(const Configuration&, const GLConfiguration&)
+             * or @ref Sdl2Application::tryCreate(const Configuration&, const GLConfiguration&).
              * @m_since{2019,10}
              */
             OpenGL = SDL_WINDOW_OPENGL,
@@ -2025,7 +2109,7 @@ class Sdl2Application::ExitEvent {
 
 @see @ref viewportEvent()
 */
-class Sdl2Application::ViewportEvent {
+class Sdl2ApplicationWindow::ViewportEvent {
     public:
         /** @brief Copying is not allowed */
         ViewportEvent(const ViewportEvent&) = delete;
@@ -2126,7 +2210,7 @@ class Sdl2Application::ViewportEvent {
     @ref keyReleaseEvent(), @ref mousePressEvent(), @ref mouseReleaseEvent(),
     @ref mouseMoveEvent()
 */
-class Sdl2Application::InputEvent {
+class Sdl2ApplicationWindow::InputEvent {
     public:
         /**
          * @brief Modifier
@@ -2235,7 +2319,7 @@ class Sdl2Application::InputEvent {
 
 @see @ref keyPressEvent(), @ref keyReleaseEvent()
 */
-class Sdl2Application::KeyEvent: public Sdl2Application::InputEvent {
+class Sdl2ApplicationWindow::KeyEvent: public InputEvent {
     public:
         /**
          * @brief Key
@@ -2533,7 +2617,7 @@ class Sdl2Application::KeyEvent: public Sdl2Application::InputEvent {
 @see @ref MouseMoveEvent, @ref MouseScrollEvent, @ref mousePressEvent(),
     @ref mouseReleaseEvent()
 */
-class Sdl2Application::MouseEvent: public Sdl2Application::InputEvent {
+class Sdl2ApplicationWindow::MouseEvent: public InputEvent {
     public:
         /**
          * @brief Mouse button
@@ -2600,7 +2684,7 @@ class Sdl2Application::MouseEvent: public Sdl2Application::InputEvent {
 
 @see @ref MouseEvent, @ref MouseScrollEvent, @ref mouseMoveEvent()
 */
-class Sdl2Application::MouseMoveEvent: public Sdl2Application::InputEvent {
+class Sdl2ApplicationWindow::MouseMoveEvent: public InputEvent {
     public:
         /**
          * @brief Mouse button
@@ -2661,7 +2745,7 @@ class Sdl2Application::MouseMoveEvent: public Sdl2Application::InputEvent {
 
 @see @ref MouseEvent, @ref MouseMoveEvent, @ref mouseScrollEvent()
 */
-class Sdl2Application::MouseScrollEvent: public Sdl2Application::InputEvent {
+class Sdl2ApplicationWindow::MouseScrollEvent: public InputEvent {
     public:
         /** @brief Scroll offset */
         Vector2 offset() const { return _offset; }
@@ -2696,7 +2780,7 @@ class Sdl2Application::MouseScrollEvent: public Sdl2Application::InputEvent {
 @experimental
 @see @ref multiGestureEvent()
 */
-class Sdl2Application::MultiGestureEvent {
+class Sdl2ApplicationWindow::MultiGestureEvent {
     public:
         /** @brief Copying is not allowed */
         MultiGestureEvent(const MultiGestureEvent&) = delete;
@@ -2773,7 +2857,7 @@ class Sdl2Application::MultiGestureEvent {
 
 @see @ref TextEditingEvent, @ref textInputEvent()
 */
-class Sdl2Application::TextInputEvent {
+class Sdl2ApplicationWindow::TextInputEvent {
     public:
         /** @brief Copying is not allowed */
         TextInputEvent(const TextInputEvent&) = delete;
@@ -2831,7 +2915,7 @@ class Sdl2Application::TextInputEvent {
 
 @see @ref textEditingEvent()
 */
-class Sdl2Application::TextEditingEvent {
+class Sdl2ApplicationWindow::TextEditingEvent {
     public:
         /** @brief Copying is not allowed */
         TextEditingEvent(const TextEditingEvent&) = delete;
@@ -2939,6 +3023,7 @@ When no other application header is included this macro is also aliased to
 #ifndef DOXYGEN_GENERATING_OUTPUT
 #ifndef MAGNUM_APPLICATION_MAIN
 typedef Sdl2Application Application;
+typedef Sdl2ApplicationWindow ApplicationWindow;
 typedef BasicScreen<Sdl2Application> Screen;
 typedef BasicScreenedApplication<Sdl2Application> ScreenedApplication;
 #define MAGNUM_APPLICATION_MAIN(className) MAGNUM_SDL2APPLICATION_MAIN(className)
@@ -2947,9 +3032,9 @@ typedef BasicScreenedApplication<Sdl2Application> ScreenedApplication;
 #endif
 #endif
 
-CORRADE_ENUMSET_OPERATORS(Sdl2Application::Configuration::WindowFlags)
-CORRADE_ENUMSET_OPERATORS(Sdl2Application::InputEvent::Modifiers)
-CORRADE_ENUMSET_OPERATORS(Sdl2Application::MouseMoveEvent::Buttons)
+CORRADE_ENUMSET_OPERATORS(Sdl2ApplicationWindow::Configuration::WindowFlags)
+CORRADE_ENUMSET_OPERATORS(Sdl2ApplicationWindow::InputEvent::Modifiers)
+CORRADE_ENUMSET_OPERATORS(Sdl2ApplicationWindow::MouseMoveEvent::Buttons)
 
 }}
 

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -508,7 +508,7 @@ class Sdl2Application {
 
         #ifdef MAGNUM_TARGET_GL
         /**
-         * @brief Construct with given configuration for OpenGL context
+         * @brief Construct with an OpenGL context
          * @param arguments         Application arguments
          * @param configuration     Application configuration
          * @param glConfiguration   OpenGL context configuration
@@ -526,7 +526,7 @@ class Sdl2Application {
         #endif
 
         /**
-         * @brief Construct with given configuration
+         * @brief Construct without explicit GPU context configuration
          *
          * If @ref Configuration::WindowFlag::Contextless is present or Magnum
          * was not built with @ref MAGNUM_TARGET_GL, this creates a window
@@ -539,15 +539,13 @@ class Sdl2Application {
          *
          * See also @ref building-features for more information.
          */
+        #ifdef DOXYGEN_GENERATING_OUTPUT
+        explicit Sdl2Application(const Arguments& arguments, const Configuration& configuration = Configuration{});
+        #else
+        /* Configuration is only forward-declared at this point */
         explicit Sdl2Application(const Arguments& arguments, const Configuration& configuration);
-
-        /**
-         * @brief Construct with default configuration
-         *
-         * Equivalent to calling @ref Sdl2Application(const Arguments&, const Configuration&)
-         * with default-constructed @ref Configuration.
-         */
         explicit Sdl2Application(const Arguments& arguments);
+        #endif
 
         /**
          * @brief Construct without creating a window
@@ -1735,7 +1733,7 @@ class Sdl2Application::Configuration {
             /**
              * Request a window for use with OpenGL. Useful in combination with
              * @ref WindowFlag::Contextless, otherwise enabled implicitly when
-             * creating an OpenGL context using @ref Sdl2Application(const Arguments&),
+             * creating an OpenGL context using
              * @ref Sdl2Application(const Arguments&, const Configuration&, const GLConfiguration&),
              * @ref create(const Configuration&, const GLConfiguration&) or
              * @ref tryCreate(const Configuration&, const GLConfiguration&).

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -1761,20 +1761,7 @@ class Sdl2Application::Configuration {
          *
          * @see @ref setWindowFlags()
          */
-        #ifndef DOXYGEN_GENERATING_OUTPUT
-        typedef Containers::EnumSet<WindowFlag, SDL_WINDOW_RESIZABLE|
-            #ifndef CORRADE_TARGET_EMSCRIPTEN
-            SDL_WINDOW_FULLSCREEN|SDL_WINDOW_BORDERLESS|SDL_WINDOW_HIDDEN|
-            SDL_WINDOW_MAXIMIZED|SDL_WINDOW_MINIMIZED|SDL_WINDOW_INPUT_GRABBED|
-            #endif
-            Uint32(WindowFlag::Contextless)|SDL_WINDOW_OPENGL
-            #if !defined(CORRADE_TARGET_EMSCRIPTEN) && SDL_MAJOR_VERSION*1000 + SDL_MINOR_VERSION*100 + SDL_PATCHLEVEL >= 2006
-            |SDL_WINDOW_VULKAN
-            #endif
-            > WindowFlags;
-        #else
         typedef Containers::EnumSet<WindowFlag> WindowFlags;
-        #endif
 
         /**
          * @brief DPI scaling policy

--- a/src/Magnum/Platform/WindowlessCglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessCglApplication.cpp
@@ -109,10 +109,6 @@ WindowlessCglContext::Configuration::Configuration() {
     GL::Context::Configuration::addFlags(GL::Context::Configuration::Flag::Windowless);
 }
 
-#ifndef DOXYGEN_GENERATING_OUTPUT
-WindowlessCglApplication::WindowlessCglApplication(const Arguments& arguments): WindowlessCglApplication{arguments, Configuration{}} {}
-#endif
-
 WindowlessCglApplication::WindowlessCglApplication(const Arguments& arguments, const Configuration& configuration): WindowlessCglApplication{arguments, NoCreate} {
     createContext(configuration);
 }

--- a/src/Magnum/Platform/WindowlessCglApplication.h
+++ b/src/Magnum/Platform/WindowlessCglApplication.h
@@ -390,13 +390,7 @@ class WindowlessCglApplication {
          * alternative.
          * @see @ref WindowlessCglContext
          */
-        #ifdef DOXYGEN_GENERATING_OUTPUT
-        explicit WindowlessCglApplication(const Arguments& arguments, const Configuration& configuration = Configuration());
-        #else
-        /* To avoid "invalid use of incomplete type" */
-        explicit WindowlessCglApplication(const Arguments& arguments, const Configuration& configuration);
-        explicit WindowlessCglApplication(const Arguments& arguments);
-        #endif
+        explicit WindowlessCglApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
 
         /**
          * @brief Construct without creating the context

--- a/src/Magnum/Platform/WindowlessEglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessEglApplication.cpp
@@ -686,10 +686,6 @@ WindowlessEglContext::Configuration::Configuration()
     #endif
 }
 
-#ifndef DOXYGEN_GENERATING_OUTPUT
-WindowlessEglApplication::WindowlessEglApplication(const Arguments& arguments): WindowlessEglApplication{arguments, Configuration{}} {}
-#endif
-
 WindowlessEglApplication::WindowlessEglApplication(const Arguments& arguments, const Configuration& configuration): WindowlessEglApplication{arguments, NoCreate} {
     createContext(configuration);
 }

--- a/src/Magnum/Platform/WindowlessEglApplication.h
+++ b/src/Magnum/Platform/WindowlessEglApplication.h
@@ -637,13 +637,7 @@ class WindowlessEglApplication {
          * alternative.
          * @see @ref WindowlessEglContext
          */
-        #ifdef DOXYGEN_GENERATING_OUTPUT
-        explicit WindowlessEglApplication(const Arguments& arguments, const Configuration& configuration = Configuration());
-        #else
-        /* To avoid "invalid use of incomplete type" */
-        explicit WindowlessEglApplication(const Arguments& arguments, const Configuration& configuration);
-        explicit WindowlessEglApplication(const Arguments& arguments);
-        #endif
+        explicit WindowlessEglApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
 
         /**
          * @brief Constructor

--- a/src/Magnum/Platform/WindowlessGlxApplication.cpp
+++ b/src/Magnum/Platform/WindowlessGlxApplication.cpp
@@ -323,10 +323,6 @@ WindowlessGlxContext::Configuration::Configuration() {
     #endif
 }
 
-#ifndef DOXYGEN_GENERATING_OUTPUT
-WindowlessGlxApplication::WindowlessGlxApplication(const Arguments& arguments): WindowlessGlxApplication{arguments, Configuration{}}  {}
-#endif
-
 WindowlessGlxApplication::WindowlessGlxApplication(const Arguments& arguments, const Configuration& configuration): WindowlessGlxApplication{arguments, NoCreate} {
     createContext(configuration);
 }

--- a/src/Magnum/Platform/WindowlessGlxApplication.h
+++ b/src/Magnum/Platform/WindowlessGlxApplication.h
@@ -448,13 +448,7 @@ class WindowlessGlxApplication {
          * alternative.
          * @see @ref WindowlessGlxContext
          */
-        #ifdef DOXYGEN_GENERATING_OUTPUT
-        explicit WindowlessGlxApplication(const Arguments& arguments, const Configuration& configuration = Configuration());
-        #else
-        /* To avoid "invalid use of incomplete type" */
-        explicit WindowlessGlxApplication(const Arguments& arguments, const Configuration& configuration);
-        explicit WindowlessGlxApplication(const Arguments& arguments);
-        #endif
+        explicit WindowlessGlxApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
 
         /**
          * @brief Constructor

--- a/src/Magnum/Platform/WindowlessIosApplication.h
+++ b/src/Magnum/Platform/WindowlessIosApplication.h
@@ -356,13 +356,7 @@ class WindowlessIosApplication {
          * alternative.
          * @see @ref WindowlessIosContext
          */
-        #ifdef DOXYGEN_GENERATING_OUTPUT
-        explicit WindowlessIosApplication(const Arguments& arguments, const Configuration& configuration = Configuration());
-        #else
-        /* To avoid "invalid use of incomplete type" */
-        explicit WindowlessIosApplication(const Arguments& arguments, const Configuration& configuration);
-        explicit WindowlessIosApplication(const Arguments& arguments);
-        #endif
+        explicit WindowlessIosApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
 
         /**
          * @brief Constructor

--- a/src/Magnum/Platform/WindowlessIosApplication.mm
+++ b/src/Magnum/Platform/WindowlessIosApplication.mm
@@ -87,10 +87,6 @@ WindowlessIosContext::Configuration::Configuration() {
     GL::Context::Configuration::addFlags(GL::Context::Configuration::Flag::Windowless);
 }
 
-#ifndef DOXYGEN_GENERATING_OUTPUT
-WindowlessIosApplication::WindowlessIosApplication(const Arguments& arguments): WindowlessIosApplication{arguments, Configuration{}} {}
-#endif
-
 WindowlessIosApplication::WindowlessIosApplication(const Arguments& arguments, const Configuration& configuration): WindowlessIosApplication{arguments, NoCreate} {
     createContext(configuration);
 }

--- a/src/Magnum/Platform/WindowlessWglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessWglApplication.cpp
@@ -308,10 +308,6 @@ WindowlessWglContext::Configuration::Configuration() {
     #endif
 }
 
-#ifndef DOXYGEN_GENERATING_OUTPUT
-WindowlessWglApplication::WindowlessWglApplication(const Arguments& arguments): WindowlessWglApplication{arguments, Configuration{}} {}
-#endif
-
 WindowlessWglApplication::WindowlessWglApplication(const Arguments& arguments, const Configuration& configuration): WindowlessWglApplication{arguments, NoCreate} {
     createContext(configuration);
 }

--- a/src/Magnum/Platform/WindowlessWglApplication.h
+++ b/src/Magnum/Platform/WindowlessWglApplication.h
@@ -434,13 +434,7 @@ class WindowlessWglApplication {
          * alternative.
          * @see @ref WindowlessWglContext
          */
-        #ifdef DOXYGEN_GENERATING_OUTPUT
-        explicit WindowlessWglApplication(const Arguments& arguments, const Configuration& configuration = Configuration());
-        #else
-        /* To avoid "invalid use of incomplete type" */
-        explicit WindowlessWglApplication(const Arguments& arguments, const Configuration& configuration);
-        explicit WindowlessWglApplication(const Arguments& arguments);
-        #endif
+        explicit WindowlessWglApplication(const Arguments& arguments, const Configuration& configuration = Configuration{});
 
         /**
          * @brief Constructor

--- a/src/Magnum/Platform/XEglApplication.h
+++ b/src/Magnum/Platform/XEglApplication.h
@@ -104,7 +104,7 @@ If no other application header is included, this class is also aliased to
 class XEglApplication: public AbstractXApplication {
     public:
         /**
-         * @brief Construct with given configuration for OpenGL context
+         * @brief Construct with an OpenGL context
          * @param arguments         Application arguments
          * @param configuration     Application configuration
          * @param glConfiguration   OpenGL context configuration

--- a/src/Magnum/SceneGraph/Camera.h
+++ b/src/Magnum/SceneGraph/Camera.h
@@ -156,7 +156,7 @@ template<UnsignedInt dimensions, class T> class Camera: public AbstractFeature<d
          *
          * Conversion from integer window-space coordinates with origin in top
          * left corner and Y down (e.g. from
-         * @ref Platform::Sdl2Application::MouseEvent "Platform::*Application::MouseEvent")
+         * @ref Platform::Sdl2ApplicationWindow::MouseEvent "Platform::*Application::MouseEvent")
          * to floating-point coordinates on near XY plane with origin at camera
          * position and Y up can be done using the following snippet:
          *


### PR DESCRIPTION
Work-in-progress implementation of #124, option 3. 

There's no backwards-incompatible change, except for `Configuration::WindowFlag::Contextless` and related flags, which are now application-global as supporting some windows with GL, some with Vulkan and some with nothing at all seems like a very rare use case that'd add a lot of implementation pain.

A new `Sdl2ApplicationWindow` class allows you to create another window for your application. Just creating the instance pops up a new window and all events that happen on it are transferred to events in that window.

Things left to do:

- [ ] `Sdl2Window` is probably a better name than `Sdl2ApplicationWindow`
- [x] Per-window event handling
  - [ ] `SDL_WINDOWEVENT_CLOSE` for closing the window itself -- there's a conflict between leaving window lifetime management in users hands and "the close button just working", currently clicking the close button does nothing
    - maybe just have a `closeEvent()` which implicitly deletes the window but leaves the instance alive, which will make it no longer respond to events, and then the user is responsible for deleting the instance?
      - that also means all cases that now check for `_windows[i]` have to check for `_windows[i]->_window` too, the Application destructor also needs to verify not just that the SDL windows are deleted but that the Window wrapper instances are gone too so they don't access the Application after ... hmm but what if SDL would then reuse window IDs??
      - this could also be (ab)used for recreating the window later, i.e. the window-specific data being always there but the actual window only sometimes
  - [ ] Why there's no `windowID` for multi-gesture events? -- https://discourse.libsdl.org/t/how-to-get-the-origin-window-of-a-touch-event/19499/10, "impossible", move the event handler back to the app and document that
- [x] Properly making GL context current for window that received the event
  - [ ] is the context switch expensive even if it's just the surface being changed?
  - [ ] do it only for `drawEvent()`, i.e. accessing the default framebuffer outside of it has unspecified behavior
    - [ ] and `viewportEvent()`? and `tickEvent()`? or not that one
- [x] Figure out how to implicitly share some properties (like all windows being GL-enabled / Vk-enabled... by default if the main one was)
- [ ] Properly tracking framebuffer viewport state
- [ ] Properly handle events that don't belong to any window (e.g. mouse drag out) -- currently crashes or is ignored
- [ ] Figure out behavior with VSync (especially avoiding the refresh rate halving when another window gets opened)
  - would drawing all windows first and then calling the `swapBuffers()` only for the main one solve this?
  - is it still a problem with a single context?
  - https://stackoverflow.com/questions/29617370/multiple-opengl-contexts-multiple-windows-multithreading-and-vsync
- [ ] Ensure nothing breaks for GL-less builds
- [ ] Documentation
  - [ ] A new section in the Sdl2Application class docs
  - [ ] Documenting the `ApplicationWindow` typedef
  - [ ] Documenting shortcomings and bugs (one window has to be primary, the other windows not shown in taskbar, obviously no support on iOS/Emscripten)
  - [ ] Windows that don't belong to any window
  - [ ] Example -- mosra/magnum-examples#25
- [ ] Test on Windows & OSX
- [ ] Test that single-window apps are not affected by any of these changes
- [ ] Ability to show/hide/raise the windows
  - [ ] And a `WindowEvent` to allow tracking this? Currently this all falls back to `anyEvent()`.
- [ ] Ability to minimize/maximize them
- [ ] Ability to set and/query window positions
- [ ] Assert that additional windows are not created before the main window context is created
- [ ] All this for GLFW as well
- [ ] Is there something like multi-canvas for WebGL?
- [ ] Ensure assertions mention `Sdl2ApplicationWindow` instead of `Sdl2Application` where appropriate