### PR TITLE
Fix issue in Primitives::Cylinder::solid() with cap ends

### DIFF
--- a/src/Magnum/Primitives/Cylinder.cpp
+++ b/src/Magnum/Primitives/Cylinder.cpp
@@ -59,7 +59,7 @@ Trade::MeshData3D Cylinder::solid(const UnsignedInt rings, const UnsignedInt seg
 
     /* Faces */
     if(flags & Flag::CapEnds) cylinder.bottomFaceRing();
-    cylinder.faceRings(rings, flags & Flag::CapEnds ? 1 : 0);
+    cylinder.faceRings(rings, flags & Flag::CapEnds ? (1 + segments) : 0);
     if(flags & Flag::CapEnds) cylinder.topFaceRing();
 
     return cylinder.finalize();


### PR DESCRIPTION
Fixed issue in Primitives::Cylinder::solid() where the last ring of faces wouldn't be created when using cap ends because of wrong offset.

See discussion here: https://gitter.im/mosra/magnum/archives/2017/03/23