### PR TITLE
Modernize Magnum

### DIFF
--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -80,7 +80,7 @@ std::vector<std::string> Context::deviceSpecifierStrings() {
     std::vector<std::string> list;
     const char* const devices = alcGetString(nullptr, ALC_DEVICE_SPECIFIER);
     for(const char* device = devices; *device; device += std::strlen(device) + 1)
-        list.push_back(device);
+        list.emplace_back(device);
 
     return list;
 }

--- a/src/Magnum/Context.cpp
+++ b/src/Magnum/Context.cpp
@@ -736,7 +736,7 @@ std::vector<std::string> Context::shadingLanguageVersionStrings() const {
     std::vector<std::string> versions;
     versions.reserve(versionCount);
     for(GLint i = 0; i != versionCount; ++i)
-        versions.push_back(reinterpret_cast<const char*>(glGetStringi(GL_SHADING_LANGUAGE_VERSION, i)));
+        versions.emplace_back(reinterpret_cast<const char*>(glGetStringi(GL_SHADING_LANGUAGE_VERSION, i)));
     return versions;
     #else
     return {shadingLanguageVersionString()};
@@ -755,7 +755,7 @@ std::vector<std::string> Context::extensionStrings() const {
     {
         extensions.reserve(extensionCount);
         for(GLint i = 0; i != extensionCount; ++i)
-            extensions.push_back(reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i)));
+            extensions.emplace_back(reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i)));
     }
     #ifndef MAGNUM_TARGET_GLES3
     else

--- a/src/Magnum/Context.cpp
+++ b/src/Magnum/Context.cpp
@@ -453,14 +453,14 @@ Context::Context(NoCreateT, Int argc, const char** argv, void functionLoader()):
         _disabledExtensions.push_back(extension);
 }
 
-Context::Context(Context&& other): _version{std::move(other._version)},
+Context::Context(Context&& other): _version{other._version},
     #ifndef MAGNUM_TARGET_WEBGL
-    _flags{std::move(other._flags)},
+    _flags{other._flags},
     #endif
-    _extensionRequiredVersion(std::move(other._extensionRequiredVersion)),
-    _extensionStatus{std::move(other._extensionStatus)},
+    _extensionRequiredVersion(other._extensionRequiredVersion),
+    _extensionStatus{other._extensionStatus},
     _supportedExtensions{std::move(other._supportedExtensions)},
-    _state{std::move(other._state)},
+    _state{other._state},
     _detectedDrivers{std::move(other._detectedDrivers)}
 {
     other._state = nullptr;

--- a/src/Magnum/DebugTools/Implementation/AbstractShapeRenderer.cpp
+++ b/src/Magnum/DebugTools/Implementation/AbstractShapeRenderer.cpp
@@ -120,7 +120,7 @@ template<UnsignedInt dimensions> AbstractShapeRenderer<dimensions>::AbstractShap
         new Shaders::Flat<dimensions>, ResourceDataState::Final, ResourcePolicy::Resident);
 }
 
-template<UnsignedInt dimensions> AbstractShapeRenderer<dimensions>::~AbstractShapeRenderer() {}
+template<UnsignedInt dimensions> AbstractShapeRenderer<dimensions>::~AbstractShapeRenderer() = default;
 
 template<UnsignedInt dimensions> void AbstractShapeRenderer<dimensions>::createResources(typename MeshData<dimensions>::Type data) {
     create<dimensions>(data, wireframeMesh, vertexBuffer, indexBuffer);

--- a/src/Magnum/DebugTools/ResourceManager.cpp
+++ b/src/Magnum/DebugTools/ResourceManager.cpp
@@ -48,6 +48,6 @@ ResourceManager::ResourceManager() {
     setFallback(new ShapeRendererOptions);
 }
 
-ResourceManager::~ResourceManager() {}
+ResourceManager::~ResourceManager() = default;
 
 }}

--- a/src/Magnum/Implementation/BufferState.cpp
+++ b/src/Magnum/Implementation/BufferState.cpp
@@ -96,7 +96,7 @@ BufferState::BufferState(Context& context, std::vector<std::string>& extensions)
     /* Create implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
         createImplementation = &Buffer::createImplementationDSA;
 
     } else
@@ -107,7 +107,7 @@ BufferState::BufferState(Context& context, std::vector<std::string>& extensions)
 
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
 
         copyImplementation = &Buffer::copyImplementationDSA;
         getParameterImplementation = &Buffer::getParameterImplementationDSA;
@@ -119,7 +119,7 @@ BufferState::BufferState(Context& context, std::vector<std::string>& extensions)
         flushMappedRangeImplementation = &Buffer::flushMappedRangeImplementationDSA;
         unmapImplementation = &Buffer::unmapImplementationDSA;
     } else if(context.isExtensionSupported<Extensions::GL::EXT::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::EXT::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::EXT::direct_state_access::string());
 
         copyImplementation = &Buffer::copyImplementationDSAEXT;
         getParameterImplementation = &Buffer::getParameterImplementationDSAEXT;
@@ -152,7 +152,7 @@ BufferState::BufferState(Context& context, std::vector<std::string>& extensions)
 
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::invalidate_subdata>()) {
-        extensions.push_back(Extensions::GL::ARB::invalidate_subdata::string());
+        extensions.emplace_back(Extensions::GL::ARB::invalidate_subdata::string());
 
         invalidateImplementation = &Buffer::invalidateImplementationARB;
         invalidateSubImplementation = &Buffer::invalidateSubImplementationARB;
@@ -166,7 +166,7 @@ BufferState::BufferState(Context& context, std::vector<std::string>& extensions)
     #ifndef MAGNUM_TARGET_GLES2
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::multi_bind>()) {
-        extensions.push_back(Extensions::GL::ARB::multi_bind::string());
+        extensions.emplace_back(Extensions::GL::ARB::multi_bind::string());
 
         bindBasesImplementation = &Buffer::bindImplementationMulti;
         bindRangesImplementation = &Buffer::bindImplementationMulti;

--- a/src/Magnum/Implementation/DebugState.cpp
+++ b/src/Magnum/Implementation/DebugState.cpp
@@ -39,7 +39,7 @@ DebugState::DebugState(Context& context, std::vector<std::string>& extensions):
     messageCallback(nullptr)
 {
     if(context.isExtensionSupported<Extensions::GL::KHR::debug>()) {
-        extensions.push_back(Extensions::GL::KHR::debug::string());
+        extensions.emplace_back(Extensions::GL::KHR::debug::string());
 
         getLabelImplementation = &AbstractObject::getLabelImplementationKhr;
         labelImplementation = &AbstractObject::labelImplementationKhr;
@@ -51,7 +51,7 @@ DebugState::DebugState(Context& context, std::vector<std::string>& extensions):
 
     } else {
         if(context.isExtensionSupported<Extensions::GL::EXT::debug_label>()) {
-            extensions.push_back(Extensions::GL::EXT::debug_label::string());
+            extensions.emplace_back(Extensions::GL::EXT::debug_label::string());
 
             getLabelImplementation = &AbstractObject::getLabelImplementationExt;
             labelImplementation = &AbstractObject::labelImplementationExt;
@@ -61,14 +61,14 @@ DebugState::DebugState(Context& context, std::vector<std::string>& extensions):
         }
 
         if(context.isExtensionSupported<Extensions::GL::EXT::debug_marker>()) {
-            extensions.push_back(Extensions::GL::EXT::debug_marker::string());
+            extensions.emplace_back(Extensions::GL::EXT::debug_marker::string());
 
             pushGroupImplementation = &DebugGroup::pushImplementationExt;
             popGroupImplementation = &DebugGroup::popImplementationExt;
             messageInsertImplementation = &DebugMessage::insertImplementationExt;
         #ifndef MAGNUM_TARGET_GLES
         } else if(context.isExtensionSupported<Extensions::GL::GREMEDY::string_marker>()) {
-            extensions.push_back(Extensions::GL::GREMEDY::string_marker::string());
+            extensions.emplace_back(Extensions::GL::GREMEDY::string_marker::string());
 
             pushGroupImplementation = &DebugGroup::pushImplementationNoOp;
             popGroupImplementation = &DebugGroup::popImplementationNoOp;

--- a/src/Magnum/Implementation/FramebufferState.cpp
+++ b/src/Magnum/Implementation/FramebufferState.cpp
@@ -47,7 +47,7 @@ FramebufferState::FramebufferState(Context& context, std::vector<std::string>& e
     /* Create implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
         createImplementation = &Framebuffer::createImplementationDSA;
         createRenderbufferImplementation = &Renderbuffer::createImplementationDSA;
 
@@ -86,7 +86,7 @@ FramebufferState::FramebufferState(Context& context, std::vector<std::string>& e
         renderbufferStorageImplementation = &Renderbuffer::storageImplementationDSA;
 
     } else if(context.isExtensionSupported<Extensions::GL::EXT::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::EXT::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::EXT::direct_state_access::string());
 
         checkStatusImplementation = &AbstractFramebuffer::checkStatusImplementationDSAEXT;
         drawBuffersImplementation = &AbstractFramebuffer::drawBuffersImplementationDSAEXT;
@@ -211,7 +211,7 @@ FramebufferState::FramebufferState(Context& context, std::vector<std::string>& e
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::ARB::robustness::string());
+        extensions.emplace_back(Extensions::GL::ARB::robustness::string());
         #else
         extensions.push_back(Extensions::GL::EXT::robustness::string());
         #endif
@@ -256,7 +256,7 @@ FramebufferState::FramebufferState(Context& context, std::vector<std::string>& e
     /* Framebuffer invalidation implementation on desktop GL */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::invalidate_subdata>()) {
-        extensions.push_back(Extensions::GL::ARB::invalidate_subdata::string());
+        extensions.emplace_back(Extensions::GL::ARB::invalidate_subdata::string());
 
         if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
             /* Extension added above */

--- a/src/Magnum/Implementation/MeshState.cpp
+++ b/src/Magnum/Implementation/MeshState.cpp
@@ -48,7 +48,7 @@ MeshState::MeshState(Context& context, std::vector<std::string>& extensions): cu
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::ARB::vertex_array_object::string());
+        extensions.emplace_back(Extensions::GL::ARB::vertex_array_object::string());
         #elif defined(MAGNUM_TARGET_GLES2)
         extensions.push_back(Extensions::GL::OES::vertex_array_object::string());
         #endif
@@ -58,7 +58,7 @@ MeshState::MeshState(Context& context, std::vector<std::string>& extensions): cu
 
         #ifndef MAGNUM_TARGET_GLES
         if(context.isExtensionSupported<Extensions::GL::EXT::direct_state_access>()) {
-            extensions.push_back(Extensions::GL::EXT::direct_state_access::string());
+            extensions.emplace_back(Extensions::GL::EXT::direct_state_access::string());
 
             attributePointerImplementation = &Mesh::attributePointerImplementationDSAEXT;
         } else
@@ -85,7 +85,7 @@ MeshState::MeshState(Context& context, std::vector<std::string>& extensions): cu
     #ifndef MAGNUM_TARGET_GLES
     /* DSA create implementation (other cases handled above) */
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
         createImplementation = &Mesh::createImplementationVAODSA;
     }
     #endif

--- a/src/Magnum/Implementation/QueryState.cpp
+++ b/src/Magnum/Implementation/QueryState.cpp
@@ -35,7 +35,7 @@ QueryState::QueryState(Context& context, std::vector<std::string>& extensions) {
     /* Create implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
         createImplementation = &AbstractQuery::createImplementationDSA;
 
     } else

--- a/src/Magnum/Implementation/RendererState.cpp
+++ b/src/Magnum/Implementation/RendererState.cpp
@@ -41,7 +41,7 @@ RendererState::RendererState(Context& context, std::vector<std::string>& extensi
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::ARB::ES2_compatibility::string());
+        extensions.emplace_back(Extensions::GL::ARB::ES2_compatibility::string());
         #endif
 
         clearDepthfImplementation = &Renderer::clearDepthfImplementationES;
@@ -59,7 +59,7 @@ RendererState::RendererState(Context& context, std::vector<std::string>& extensi
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::ARB::robustness::string());
+        extensions.emplace_back(Extensions::GL::ARB::robustness::string());
         #else
         extensions.push_back(Extensions::GL::EXT::robustness::string());
         #endif

--- a/src/Magnum/Implementation/ShaderProgramState.cpp
+++ b/src/Magnum/Implementation/ShaderProgramState.cpp
@@ -68,7 +68,7 @@ ShaderProgramState::ShaderProgramState(Context& context, std::vector<std::string
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::ARB::separate_shader_objects::string());
+        extensions.emplace_back(Extensions::GL::ARB::separate_shader_objects::string());
         #endif
 
         uniform1fvImplementation = &AbstractShaderProgram::uniformImplementationSSO;
@@ -121,7 +121,7 @@ ShaderProgramState::ShaderProgramState(Context& context, std::vector<std::string
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::EXT::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::EXT::direct_state_access::string());
         #else
         extensions.push_back(Extensions::GL::EXT::separate_shader_objects::string());
         #endif

--- a/src/Magnum/Implementation/TextureState.cpp
+++ b/src/Magnum/Implementation/TextureState.cpp
@@ -65,7 +65,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
     /* Create implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
         createImplementation = &AbstractTexture::createImplementationDSA;
 
     } else
@@ -103,7 +103,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
     /* Multi bind implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::multi_bind>()) {
-        extensions.push_back(Extensions::GL::ARB::multi_bind::string());
+        extensions.emplace_back(Extensions::GL::ARB::multi_bind::string());
 
         bindMultiImplementation = &AbstractTexture::bindImplementationMulti;
 
@@ -116,7 +116,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
     /* DSA/non-DSA implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
 
         parameteriImplementation = &AbstractTexture::parameterImplementationDSA;
         parameterfImplementation = &AbstractTexture::parameterImplementationDSA;
@@ -141,7 +141,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
         cubeCompressedSubImageImplementation = &CubeMapTexture::compressedSubImageImplementationDSA;
 
     } else if(context.isExtensionSupported<Extensions::GL::EXT::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::EXT::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::EXT::direct_state_access::string());
 
         parameteriImplementation = &AbstractTexture::parameterImplementationDSAEXT;
         parameterfImplementation = &AbstractTexture::parameterImplementationDSAEXT;
@@ -208,7 +208,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
     /* Data invalidation implementation */
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::invalidate_subdata>()) {
-        extensions.push_back(Extensions::GL::ARB::invalidate_subdata::string());
+        extensions.emplace_back(Extensions::GL::ARB::invalidate_subdata::string());
 
         invalidateImageImplementation = &AbstractTexture::invalidateImageImplementationARB;
         invalidateSubImageImplementation = &AbstractTexture::invalidateSubImageImplementationARB;
@@ -244,7 +244,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
         getCompressedImageImplementation = &AbstractTexture::getCompressedImageImplementationDSA;
 
     } else if(context.isExtensionSupported<Extensions::GL::ARB::robustness>()) {
-        extensions.push_back(Extensions::GL::ARB::robustness::string());
+        extensions.emplace_back(Extensions::GL::ARB::robustness::string());
         getImageImplementation = &AbstractTexture::getImageImplementationRobustness;
         getCompressedImageImplementation = &AbstractTexture::getCompressedImageImplementationRobustness;
 
@@ -260,7 +260,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
 
     /* Image retrieval implementation for cube map */
     if(context.isExtensionSupported<Extensions::GL::ARB::get_texture_sub_image>()) {
-        extensions.push_back(Extensions::GL::ARB::get_texture_sub_image::string());
+        extensions.emplace_back(Extensions::GL::ARB::get_texture_sub_image::string());
         getCubeImageImplementation = &CubeMapTexture::getImageImplementationDSA;
         getCompressedCubeImageImplementation = &CubeMapTexture::getCompressedImageImplementationDSA;
 
@@ -298,7 +298,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
     #endif
     {
         #ifndef MAGNUM_TARGET_GLES
-        extensions.push_back(Extensions::GL::ARB::texture_storage::string());
+        extensions.emplace_back(Extensions::GL::ARB::texture_storage::string());
         #elif defined(MAGNUM_TARGET_GLES2)
         extensions.push_back(Extensions::GL::EXT::texture_storage::string());
         #endif
@@ -347,7 +347,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
     /* Storage implementation for multisample textures. The fallback doesn't
        have DSA alternative, so it must be handled specially. */
     if(context.isExtensionSupported<Extensions::GL::ARB::texture_storage_multisample>()) {
-        extensions.push_back(Extensions::GL::ARB::texture_storage_multisample::string());
+        extensions.emplace_back(Extensions::GL::ARB::texture_storage_multisample::string());
 
         if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
             storage2DMultisampleImplementation = &AbstractTexture::storageMultisampleImplementationDSA;
@@ -370,7 +370,7 @@ TextureState::TextureState(Context& context, std::vector<std::string>& extension
 
     /* Anisotropic filter implementation */
     if(context.isExtensionSupported<Extensions::GL::EXT::texture_filter_anisotropic>()) {
-        extensions.push_back(Extensions::GL::EXT::texture_filter_anisotropic::string());
+        extensions.emplace_back(Extensions::GL::EXT::texture_filter_anisotropic::string());
 
         setMaxAnisotropyImplementation = &AbstractTexture::setMaxAnisotropyImplementationExt;
     } else setMaxAnisotropyImplementation = &AbstractTexture::setMaxAnisotropyImplementationNoOp;

--- a/src/Magnum/Implementation/TransformFeedbackState.cpp
+++ b/src/Magnum/Implementation/TransformFeedbackState.cpp
@@ -15,7 +15,7 @@ TransformFeedbackState::TransformFeedbackState(Context& context, std::vector<std
 {
     #ifndef MAGNUM_TARGET_GLES
     if(context.isExtensionSupported<Extensions::GL::ARB::direct_state_access>()) {
-        extensions.push_back(Extensions::GL::ARB::direct_state_access::string());
+        extensions.emplace_back(Extensions::GL::ARB::direct_state_access::string());
 
         createImplementation = &TransformFeedback::createImplementationDSA;
         attachRangeImplementation = &TransformFeedback::attachImplementationDSA;

--- a/src/Magnum/Primitives/Implementation/Spheroid.cpp
+++ b/src/Magnum/Primitives/Implementation/Spheroid.cpp
@@ -35,11 +35,11 @@ namespace Magnum { namespace Primitives { namespace Implementation {
 Spheroid::Spheroid(UnsignedInt segments, TextureCoords textureCoords): segments(segments), textureCoords(textureCoords) {}
 
 void Spheroid::capVertex(Float y, Float normalY, Float textureCoordsV) {
-    positions.push_back({0.0f, y, 0.0f});
-    normals.push_back({0.0f, normalY, 0.0f});
+    positions.emplace_back(0.0f, y, 0.0f);
+    normals.emplace_back(0.0f, normalY, 0.0f);
 
     if(textureCoords == TextureCoords::Generate)
-        textureCoords2D.push_back({0.5, textureCoordsV});
+        textureCoords2D.emplace_back(0.5, textureCoordsV);
 }
 
 void Spheroid::hemisphereVertexRings(UnsignedInt count, Float centerY, Rad startRingAngle, Rad ringAngleIncrement, Float startTextureCoordsV, Float textureCoordsVIncrement) {
@@ -52,18 +52,18 @@ void Spheroid::hemisphereVertexRings(UnsignedInt count, Float centerY, Rad start
 
         for(UnsignedInt j = 0; j != segments; ++j) {
             Rad segmentAngle = Float(j)*segmentAngleIncrement;
-            positions.push_back({x*Math::sin(segmentAngle), centerY+y, z*Math::cos(segmentAngle)});
-            normals.push_back({x*Math::sin(segmentAngle), y, z*Math::cos(segmentAngle)});
+            positions.emplace_back(x*Math::sin(segmentAngle), centerY+y, z*Math::cos(segmentAngle));
+            normals.emplace_back(x*Math::sin(segmentAngle), y, z*Math::cos(segmentAngle));
 
             if(textureCoords == TextureCoords::Generate)
-                textureCoords2D.push_back({j*1.0f/segments, startTextureCoordsV + i*textureCoordsVIncrement});
+                textureCoords2D.emplace_back(j*1.0f/segments, startTextureCoordsV + i*textureCoordsVIncrement);
         }
 
         /* Duplicate first segment in the ring for additional vertex for texture coordinate */
         if(textureCoords == TextureCoords::Generate) {
             positions.push_back(positions[positions.size()-segments]);
             normals.push_back(normals[normals.size()-segments]);
-            textureCoords2D.push_back({1.0f, startTextureCoordsV + i*textureCoordsVIncrement});
+            textureCoords2D.emplace_back(1.0f, startTextureCoordsV + i*textureCoordsVIncrement);
         }
     }
 }
@@ -73,18 +73,18 @@ void Spheroid::cylinderVertexRings(UnsignedInt count, Float startY, Float yIncre
     for(UnsignedInt i = 0; i != count; ++i) {
         for(UnsignedInt j = 0; j != segments; ++j) {
             Rad segmentAngle = Float(j)*segmentAngleIncrement;
-            positions.push_back({Math::sin(segmentAngle), startY, Math::cos(segmentAngle)});
-            normals.push_back({Math::sin(segmentAngle), 0.0f, Math::cos(segmentAngle)});
+            positions.emplace_back(Math::sin(segmentAngle), startY, Math::cos(segmentAngle));
+            normals.emplace_back(Math::sin(segmentAngle), 0.0f, Math::cos(segmentAngle));
 
             if(textureCoords == TextureCoords::Generate)
-                textureCoords2D.push_back({j*1.0f/segments, startTextureCoordsV + i*textureCoordsVIncrement});
+                textureCoords2D.emplace_back(j*1.0f/segments, startTextureCoordsV + i*textureCoordsVIncrement);
         }
 
         /* Duplicate first segment in the ring for additional vertex for texture coordinate */
         if(textureCoords == TextureCoords::Generate) {
             positions.push_back(positions[positions.size()-segments]);
             normals.push_back(normals[normals.size()-segments]);
-            textureCoords2D.push_back({1.0f, startTextureCoordsV + i*textureCoordsVIncrement});
+            textureCoords2D.emplace_back(1.0f, startTextureCoordsV + i*textureCoordsVIncrement);
         }
 
         startY += yIncrement;
@@ -147,18 +147,18 @@ void Spheroid::capVertexRing(Float y, Float textureCoordsV, const Vector3& norma
 
     for(UnsignedInt i = 0; i != segments; ++i) {
         Rad segmentAngle = Float(i)*segmentAngleIncrement;
-        positions.push_back({Math::sin(segmentAngle), y, Math::cos(segmentAngle)});
+        positions.emplace_back(Math::sin(segmentAngle), y, Math::cos(segmentAngle));
         normals.push_back(normal);
 
         if(textureCoords == TextureCoords::Generate)
-            textureCoords2D.push_back({i*1.0f/segments, textureCoordsV});
+            textureCoords2D.emplace_back(i*1.0f/segments, textureCoordsV);
     }
 
     /* Duplicate first segment in the ring for additional vertex for texture coordinate */
     if(textureCoords == TextureCoords::Generate) {
         positions.push_back(positions[positions.size()-segments]);
         normals.push_back(normal);
-        textureCoords2D.push_back({1.0f, textureCoordsV});
+        textureCoords2D.emplace_back(1.0f, textureCoordsV);
     }
 }
 

--- a/src/Magnum/Shader.cpp
+++ b/src/Magnum/Shader.cpp
@@ -722,23 +722,23 @@ Shader::Shader(const Version version, const Type type): _type(type), _id(0) {
 
     switch(version) {
         #ifndef MAGNUM_TARGET_GLES
-        case Version::GL210: _sources.push_back("#version 120\n"); return;
-        case Version::GL300: _sources.push_back("#version 130\n"); return;
-        case Version::GL310: _sources.push_back("#version 140\n"); return;
-        case Version::GL320: _sources.push_back("#version 150\n"); return;
-        case Version::GL330: _sources.push_back("#version 330\n"); return;
-        case Version::GL400: _sources.push_back("#version 400\n"); return;
-        case Version::GL410: _sources.push_back("#version 410\n"); return;
-        case Version::GL420: _sources.push_back("#version 420\n"); return;
-        case Version::GL430: _sources.push_back("#version 430\n"); return;
-        case Version::GL440: _sources.push_back("#version 440\n"); return;
-        case Version::GL450: _sources.push_back("#version 450\n"); return;
+        case Version::GL210: _sources.emplace_back("#version 120\n"); return;
+        case Version::GL300: _sources.emplace_back("#version 130\n"); return;
+        case Version::GL310: _sources.emplace_back("#version 140\n"); return;
+        case Version::GL320: _sources.emplace_back("#version 150\n"); return;
+        case Version::GL330: _sources.emplace_back("#version 330\n"); return;
+        case Version::GL400: _sources.emplace_back("#version 400\n"); return;
+        case Version::GL410: _sources.emplace_back("#version 410\n"); return;
+        case Version::GL420: _sources.emplace_back("#version 420\n"); return;
+        case Version::GL430: _sources.emplace_back("#version 430\n"); return;
+        case Version::GL440: _sources.emplace_back("#version 440\n"); return;
+        case Version::GL450: _sources.emplace_back("#version 450\n"); return;
         #endif
         /* `#version 100` really is GLSL ES 1.00 and *not* GLSL 1.00. What a mess. */
-        case Version::GLES200: _sources.push_back("#version 100\n"); return;
-        case Version::GLES300: _sources.push_back("#version 300 es\n"); return;
+        case Version::GLES200: _sources.emplace_back("#version 100\n"); return;
+        case Version::GLES300: _sources.emplace_back("#version 300 es\n"); return;
         #ifndef MAGNUM_TARGET_WEBGL
-        case Version::GLES310: _sources.push_back("#version 310 es\n"); return;
+        case Version::GLES310: _sources.emplace_back("#version 310 es\n"); return;
         #endif
 
         /* The user is responsible for (not) adding #version directive */

--- a/src/Magnum/Text/AbstractFont.cpp
+++ b/src/Magnum/Text/AbstractFont.cpp
@@ -165,7 +165,7 @@ std::unique_ptr<AbstractLayouter> AbstractFont::layout(const GlyphCache& cache, 
 
 AbstractLayouter::AbstractLayouter(UnsignedInt glyphCount): _glyphCount(glyphCount) {}
 
-AbstractLayouter::~AbstractLayouter() {}
+AbstractLayouter::~AbstractLayouter() = default;
 
 std::pair<Range2D, Range2D> AbstractLayouter::renderGlyph(const UnsignedInt i, Vector2& cursorPosition, Range2D& rectangle) {
     CORRADE_ASSERT(i < glyphCount(), "Text::AbstractLayouter::renderGlyph(): glyph index out of bounds", {});

--- a/src/Magnum/Text/Renderer.cpp
+++ b/src/Magnum/Text/Renderer.cpp
@@ -330,7 +330,7 @@ AbstractRenderer::AbstractRenderer(AbstractFont& font, const GlyphCache& cache, 
     _mesh.setPrimitive(MeshPrimitive::Triangles);
 }
 
-AbstractRenderer::~AbstractRenderer() {}
+AbstractRenderer::~AbstractRenderer() = default;
 
 template<UnsignedInt dimensions> Renderer<dimensions>::Renderer(AbstractFont& font, const GlyphCache& cache, const Float size, const Alignment alignment): AbstractRenderer(font, cache, size, alignment) {
     /* Finalize mesh configuration */

--- a/src/Magnum/TextureArray.cpp
+++ b/src/Magnum/TextureArray.cpp
@@ -40,8 +40,8 @@ namespace Magnum {
 
 namespace {
     template<UnsignedInt> struct VectorOrScalar;
-    template<> struct VectorOrScalar<1> { typedef Int Type; };
-    template<> struct VectorOrScalar<2> { typedef Vector2i Type; };
+    template<> struct VectorOrScalar<1> { using Type = Int; };
+    template<> struct VectorOrScalar<2> { using Type = Vector2i; };
 }
 
 template<UnsignedInt dimensions> VectorTypeFor<dimensions+1, Int> TextureArray<dimensions>::maxSize() {

--- a/src/Magnum/TextureTools/DistanceField.cpp
+++ b/src/Magnum/TextureTools/DistanceField.cpp
@@ -77,12 +77,12 @@ class DistanceFieldShader: public AbstractShaderProgram {
     private:
         enum: Int { TextureUnit = 8 };
 
-        Int radiusUniform,
-            scalingUniform,
+        Int radiusUniform{0},
+            scalingUniform{1},
             imageSizeInvertedUniform;
 };
 
-DistanceFieldShader::DistanceFieldShader(): radiusUniform(0), scalingUniform(1) {
+DistanceFieldShader::DistanceFieldShader() {
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
     if(!Utility::Resource::hasGroup("MagnumTextureTools"))

--- a/src/Magnum/Trade/AbstractMaterialData.cpp
+++ b/src/Magnum/Trade/AbstractMaterialData.cpp
@@ -31,7 +31,7 @@ namespace Magnum { namespace Trade {
 
 AbstractMaterialData::AbstractMaterialData(const MaterialType type, const void* const importerState) noexcept: _type{type}, _importerState{importerState} {}
 
-AbstractMaterialData::~AbstractMaterialData() {}
+AbstractMaterialData::~AbstractMaterialData() = default;
 
 Debug& operator<<(Debug& debug, const MaterialType value) {
     switch(value) {

--- a/src/Magnum/Trade/PhongMaterialData.cpp
+++ b/src/Magnum/Trade/PhongMaterialData.cpp
@@ -27,7 +27,7 @@
 
 namespace Magnum { namespace Trade {
 
-PhongMaterialData::PhongMaterialData(PhongMaterialData&& other) noexcept: AbstractMaterialData{std::move(other)}, _flags{std::move(other._flags)}, _shininess{std::move(other._shininess)} {
+PhongMaterialData::PhongMaterialData(PhongMaterialData&& other) noexcept: AbstractMaterialData{std::move(other)}, _flags{other._flags}, _shininess{other._shininess} {
     if(_flags & Flag::AmbientTexture)
         _ambient.texture = other._ambient.texture;
     else

--- a/src/Magnum/Version.cpp
+++ b/src/Magnum/Version.cpp
@@ -33,7 +33,7 @@ namespace Magnum {
 Debug& operator<<(Debug& debug, Version value) {
     switch(value) {
         /* LCOV_EXCL_START */
-        #define _c(value, string) case Version::value: return debug << string;
+        #define _c(value, string) case Version::value: return debug << (string);
         _c(None, "None")
         #ifndef MAGNUM_TARGET_GLES
         _c(GL210, "OpenGL 2.1")

--- a/src/MagnumExternal/OpenGL/GL/flextGL.cpp
+++ b/src/MagnumExternal/OpenGL/GL/flextGL.cpp
@@ -30,7 +30,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglMultiDrawArraysIndirectCountARB)(GLenum, GL
 FLEXTGL_EXPORT void(APIENTRY *flextglMultiDrawElementsIndirectCountARB)(GLenum, GLenum, GLintptr, GLintptr, GLsizei, GLsizei) = nullptr;
 
 /* GL_ARB_robustness */
-FLEXTGL_EXPORT GLenum(APIENTRY *flextglGetGraphicsResetStatusARB)(void) = nullptr;
+FLEXTGL_EXPORT GLenum(APIENTRY *flextglGetGraphicsResetStatusARB)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetnCompressedTexImageARB)(GLenum, GLint, GLsizei, void *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetnTexImageARB)(GLenum, GLint, GLenum, GLenum, GLsizei, void *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetnUniformdvARB)(GLuint, GLint, GLsizei, GLdouble *) = nullptr;
@@ -53,7 +53,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglLabelObjectEXT)(GLenum, GLuint, GLsizei, co
 
 /* GL_EXT_debug_marker */
 FLEXTGL_EXPORT void(APIENTRY *flextglInsertEventMarkerEXT)(GLsizei, const GLchar *) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglPopGroupMarkerEXT)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglPopGroupMarkerEXT)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglPushGroupMarkerEXT)(GLsizei, const GLchar *) = nullptr;
 
 /* GL_EXT_direct_state_access */
@@ -317,7 +317,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglVertexArrayVertexOffsetEXT)(GLuint, GLuint,
 FLEXTGL_EXPORT void(APIENTRY *flextglStringMarkerGREMEDY)(GLsizei, const void *) = nullptr;
 
 /* GL_KHR_blend_equation_advanced */
-FLEXTGL_EXPORT void(APIENTRY *flextglBlendBarrierKHR)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglBlendBarrierKHR)() = nullptr;
 
 /* GL_VERSION_1_2 */
 FLEXTGL_EXPORT void(APIENTRY *flextglCopyTexSubImage3D)(GLenum, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei) = nullptr;
@@ -373,7 +373,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglAttachShader)(GLuint, GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglBindAttribLocation)(GLuint, GLuint, const GLchar *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglBlendEquationSeparate)(GLenum, GLenum) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglCompileShader)(GLuint) = nullptr;
-FLEXTGL_EXPORT GLuint(APIENTRY *flextglCreateProgram)(void) = nullptr;
+FLEXTGL_EXPORT GLuint(APIENTRY *flextglCreateProgram)() = nullptr;
 FLEXTGL_EXPORT GLuint(APIENTRY *flextglCreateShader)(GLenum) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglDeleteProgram)(GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglDeleteShader)(GLuint) = nullptr;
@@ -493,8 +493,8 @@ FLEXTGL_EXPORT void(APIENTRY *flextglDeleteRenderbuffers)(GLsizei, const GLuint 
 FLEXTGL_EXPORT void(APIENTRY *flextglDeleteVertexArrays)(GLsizei, const GLuint *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglDisablei)(GLenum, GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglEnablei)(GLenum, GLuint) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglEndConditionalRender)(void) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglEndTransformFeedback)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglEndConditionalRender)() = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglEndTransformFeedback)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglFlushMappedBufferRange)(GLenum, GLintptr, GLsizeiptr) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglFramebufferRenderbuffer)(GLenum, GLenum, GLenum, GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglFramebufferTexture1D)(GLenum, GLenum, GLenum, GLuint, GLint) = nullptr;
@@ -649,8 +649,8 @@ FLEXTGL_EXPORT GLboolean(APIENTRY *flextglIsTransformFeedback)(GLuint) = nullptr
 FLEXTGL_EXPORT void(APIENTRY *flextglMinSampleShading)(GLfloat) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglPatchParameterfv)(GLenum, const GLfloat *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglPatchParameteri)(GLenum, GLint) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglPauseTransformFeedback)(void) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglResumeTransformFeedback)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglPauseTransformFeedback)() = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglResumeTransformFeedback)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglUniform1d)(GLint, GLdouble) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglUniform1dv)(GLint, GLsizei, const GLdouble *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglUniform2d)(GLint, GLdouble, GLdouble) = nullptr;
@@ -740,7 +740,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglProgramUniformMatrix4x2dv)(GLuint, GLint, G
 FLEXTGL_EXPORT void(APIENTRY *flextglProgramUniformMatrix4x2fv)(GLuint, GLint, GLsizei, GLboolean, const GLfloat *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglProgramUniformMatrix4x3dv)(GLuint, GLint, GLsizei, GLboolean, const GLdouble *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglProgramUniformMatrix4x3fv)(GLuint, GLint, GLsizei, GLboolean, const GLfloat *) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglReleaseShaderCompiler)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglReleaseShaderCompiler)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglScissorArrayv)(GLuint, GLsizei, const GLint *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglScissorIndexed)(GLuint, GLint, GLint, GLsizei, GLsizei) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglScissorIndexedv)(GLuint, const GLint *) = nullptr;
@@ -807,7 +807,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglMultiDrawArraysIndirect)(GLenum, const void
 FLEXTGL_EXPORT void(APIENTRY *flextglMultiDrawElementsIndirect)(GLenum, GLenum, const void *, GLsizei, GLsizei) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglObjectLabel)(GLenum, GLuint, GLsizei, const GLchar *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglObjectPtrLabel)(const void *, GLsizei, const GLchar *) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglPopDebugGroup)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglPopDebugGroup)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglPushDebugGroup)(GLenum, GLuint, GLsizei, const GLchar *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglShaderStorageBlockBinding)(GLuint, GLuint, GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglTexBufferRange)(GLenum, GLenum, GLuint, GLintptr, GLsizeiptr) = nullptr;
@@ -864,7 +864,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglFlushMappedNamedBufferRange)(GLuint, GLintp
 FLEXTGL_EXPORT void(APIENTRY *flextglGenerateTextureMipmap)(GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetCompressedTextureImage)(GLuint, GLint, GLsizei, void *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetCompressedTextureSubImage)(GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLsizei, void *) = nullptr;
-FLEXTGL_EXPORT GLenum(APIENTRY *flextglGetGraphicsResetStatus)(void) = nullptr;
+FLEXTGL_EXPORT GLenum(APIENTRY *flextglGetGraphicsResetStatus)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetNamedBufferParameteri64v)(GLuint, GLenum, GLint64 *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetNamedBufferParameteriv)(GLuint, GLenum, GLint *) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglGetNamedBufferPointerv)(GLuint, GLenum, void **) = nullptr;
@@ -914,7 +914,7 @@ FLEXTGL_EXPORT void(APIENTRY *flextglNamedFramebufferTextureLayer)(GLuint, GLenu
 FLEXTGL_EXPORT void(APIENTRY *flextglNamedRenderbufferStorage)(GLuint, GLenum, GLsizei, GLsizei) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglNamedRenderbufferStorageMultisample)(GLuint, GLsizei, GLenum, GLsizei, GLsizei) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglReadnPixels)(GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, GLsizei, void *) = nullptr;
-FLEXTGL_EXPORT void(APIENTRY *flextglTextureBarrier)(void) = nullptr;
+FLEXTGL_EXPORT void(APIENTRY *flextglTextureBarrier)() = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglTextureBuffer)(GLuint, GLenum, GLuint) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglTextureBufferRange)(GLuint, GLenum, GLuint, GLintptr, GLsizeiptr) = nullptr;
 FLEXTGL_EXPORT void(APIENTRY *flextglTextureParameterIiv)(GLuint, GLenum, const GLint *) = nullptr;

--- a/src/MagnumExternal/OpenGL/GL/flextGLPlatform.cpp
+++ b/src/MagnumExternal/OpenGL/GL/flextGLPlatform.cpp
@@ -34,7 +34,7 @@ void flextGLInit() {
     flextglMultiDrawElementsIndirectCountARB = reinterpret_cast<void(APIENTRY*)(GLenum, GLenum, GLintptr, GLintptr, GLsizei, GLsizei)>(loader.load("glMultiDrawElementsIndirectCountARB"));
 
     /* GL_ARB_robustness */
-    flextglGetGraphicsResetStatusARB = reinterpret_cast<GLenum(APIENTRY*)(void)>(loader.load("glGetGraphicsResetStatusARB"));
+    flextglGetGraphicsResetStatusARB = reinterpret_cast<GLenum(APIENTRY*)()>(loader.load("glGetGraphicsResetStatusARB"));
     flextglGetnCompressedTexImageARB = reinterpret_cast<void(APIENTRY*)(GLenum, GLint, GLsizei, void *)>(loader.load("glGetnCompressedTexImageARB"));
     flextglGetnTexImageARB = reinterpret_cast<void(APIENTRY*)(GLenum, GLint, GLenum, GLenum, GLsizei, void *)>(loader.load("glGetnTexImageARB"));
     flextglGetnUniformdvARB = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLsizei, GLdouble *)>(loader.load("glGetnUniformdvARB"));
@@ -57,7 +57,7 @@ void flextGLInit() {
 
     /* GL_EXT_debug_marker */
     flextglInsertEventMarkerEXT = reinterpret_cast<void(APIENTRY*)(GLsizei, const GLchar *)>(loader.load("glInsertEventMarkerEXT"));
-    flextglPopGroupMarkerEXT = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glPopGroupMarkerEXT"));
+    flextglPopGroupMarkerEXT = reinterpret_cast<void(APIENTRY*)()>(loader.load("glPopGroupMarkerEXT"));
     flextglPushGroupMarkerEXT = reinterpret_cast<void(APIENTRY*)(GLsizei, const GLchar *)>(loader.load("glPushGroupMarkerEXT"));
 
     /* GL_EXT_direct_state_access */
@@ -321,7 +321,7 @@ void flextGLInit() {
     flextglStringMarkerGREMEDY = reinterpret_cast<void(APIENTRY*)(GLsizei, const void *)>(loader.load("glStringMarkerGREMEDY"));
 
     /* GL_KHR_blend_equation_advanced */
-    flextglBlendBarrierKHR = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glBlendBarrierKHR"));
+    flextglBlendBarrierKHR = reinterpret_cast<void(APIENTRY*)()>(loader.load("glBlendBarrierKHR"));
 
     /* GL_VERSION_1_2 */
     flextglCopyTexSubImage3D = reinterpret_cast<void(APIENTRY*)(GLenum, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei)>(loader.load("glCopyTexSubImage3D"));
@@ -377,7 +377,7 @@ void flextGLInit() {
     flextglBindAttribLocation = reinterpret_cast<void(APIENTRY*)(GLuint, GLuint, const GLchar *)>(loader.load("glBindAttribLocation"));
     flextglBlendEquationSeparate = reinterpret_cast<void(APIENTRY*)(GLenum, GLenum)>(loader.load("glBlendEquationSeparate"));
     flextglCompileShader = reinterpret_cast<void(APIENTRY*)(GLuint)>(loader.load("glCompileShader"));
-    flextglCreateProgram = reinterpret_cast<GLuint(APIENTRY*)(void)>(loader.load("glCreateProgram"));
+    flextglCreateProgram = reinterpret_cast<GLuint(APIENTRY*)()>(loader.load("glCreateProgram"));
     flextglCreateShader = reinterpret_cast<GLuint(APIENTRY*)(GLenum)>(loader.load("glCreateShader"));
     flextglDeleteProgram = reinterpret_cast<void(APIENTRY*)(GLuint)>(loader.load("glDeleteProgram"));
     flextglDeleteShader = reinterpret_cast<void(APIENTRY*)(GLuint)>(loader.load("glDeleteShader"));
@@ -497,8 +497,8 @@ void flextGLInit() {
     flextglDeleteVertexArrays = reinterpret_cast<void(APIENTRY*)(GLsizei, const GLuint *)>(loader.load("glDeleteVertexArrays"));
     flextglDisablei = reinterpret_cast<void(APIENTRY*)(GLenum, GLuint)>(loader.load("glDisablei"));
     flextglEnablei = reinterpret_cast<void(APIENTRY*)(GLenum, GLuint)>(loader.load("glEnablei"));
-    flextglEndConditionalRender = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glEndConditionalRender"));
-    flextglEndTransformFeedback = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glEndTransformFeedback"));
+    flextglEndConditionalRender = reinterpret_cast<void(APIENTRY*)()>(loader.load("glEndConditionalRender"));
+    flextglEndTransformFeedback = reinterpret_cast<void(APIENTRY*)()>(loader.load("glEndTransformFeedback"));
     flextglFlushMappedBufferRange = reinterpret_cast<void(APIENTRY*)(GLenum, GLintptr, GLsizeiptr)>(loader.load("glFlushMappedBufferRange"));
     flextglFramebufferRenderbuffer = reinterpret_cast<void(APIENTRY*)(GLenum, GLenum, GLenum, GLuint)>(loader.load("glFramebufferRenderbuffer"));
     flextglFramebufferTexture1D = reinterpret_cast<void(APIENTRY*)(GLenum, GLenum, GLenum, GLuint, GLint)>(loader.load("glFramebufferTexture1D"));
@@ -653,8 +653,8 @@ void flextGLInit() {
     flextglMinSampleShading = reinterpret_cast<void(APIENTRY*)(GLfloat)>(loader.load("glMinSampleShading"));
     flextglPatchParameterfv = reinterpret_cast<void(APIENTRY*)(GLenum, const GLfloat *)>(loader.load("glPatchParameterfv"));
     flextglPatchParameteri = reinterpret_cast<void(APIENTRY*)(GLenum, GLint)>(loader.load("glPatchParameteri"));
-    flextglPauseTransformFeedback = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glPauseTransformFeedback"));
-    flextglResumeTransformFeedback = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glResumeTransformFeedback"));
+    flextglPauseTransformFeedback = reinterpret_cast<void(APIENTRY*)()>(loader.load("glPauseTransformFeedback"));
+    flextglResumeTransformFeedback = reinterpret_cast<void(APIENTRY*)()>(loader.load("glResumeTransformFeedback"));
     flextglUniform1d = reinterpret_cast<void(APIENTRY*)(GLint, GLdouble)>(loader.load("glUniform1d"));
     flextglUniform1dv = reinterpret_cast<void(APIENTRY*)(GLint, GLsizei, const GLdouble *)>(loader.load("glUniform1dv"));
     flextglUniform2d = reinterpret_cast<void(APIENTRY*)(GLint, GLdouble, GLdouble)>(loader.load("glUniform2d"));
@@ -744,7 +744,7 @@ void flextGLInit() {
     flextglProgramUniformMatrix4x2fv = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLsizei, GLboolean, const GLfloat *)>(loader.load("glProgramUniformMatrix4x2fv"));
     flextglProgramUniformMatrix4x3dv = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLsizei, GLboolean, const GLdouble *)>(loader.load("glProgramUniformMatrix4x3dv"));
     flextglProgramUniformMatrix4x3fv = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLsizei, GLboolean, const GLfloat *)>(loader.load("glProgramUniformMatrix4x3fv"));
-    flextglReleaseShaderCompiler = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glReleaseShaderCompiler"));
+    flextglReleaseShaderCompiler = reinterpret_cast<void(APIENTRY*)()>(loader.load("glReleaseShaderCompiler"));
     flextglScissorArrayv = reinterpret_cast<void(APIENTRY*)(GLuint, GLsizei, const GLint *)>(loader.load("glScissorArrayv"));
     flextglScissorIndexed = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLint, GLsizei, GLsizei)>(loader.load("glScissorIndexed"));
     flextglScissorIndexedv = reinterpret_cast<void(APIENTRY*)(GLuint, const GLint *)>(loader.load("glScissorIndexedv"));
@@ -811,7 +811,7 @@ void flextGLInit() {
     flextglMultiDrawElementsIndirect = reinterpret_cast<void(APIENTRY*)(GLenum, GLenum, const void *, GLsizei, GLsizei)>(loader.load("glMultiDrawElementsIndirect"));
     flextglObjectLabel = reinterpret_cast<void(APIENTRY*)(GLenum, GLuint, GLsizei, const GLchar *)>(loader.load("glObjectLabel"));
     flextglObjectPtrLabel = reinterpret_cast<void(APIENTRY*)(const void *, GLsizei, const GLchar *)>(loader.load("glObjectPtrLabel"));
-    flextglPopDebugGroup = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glPopDebugGroup"));
+    flextglPopDebugGroup = reinterpret_cast<void(APIENTRY*)()>(loader.load("glPopDebugGroup"));
     flextglPushDebugGroup = reinterpret_cast<void(APIENTRY*)(GLenum, GLuint, GLsizei, const GLchar *)>(loader.load("glPushDebugGroup"));
     flextglShaderStorageBlockBinding = reinterpret_cast<void(APIENTRY*)(GLuint, GLuint, GLuint)>(loader.load("glShaderStorageBlockBinding"));
     flextglTexBufferRange = reinterpret_cast<void(APIENTRY*)(GLenum, GLenum, GLuint, GLintptr, GLsizeiptr)>(loader.load("glTexBufferRange"));
@@ -868,7 +868,7 @@ void flextGLInit() {
     flextglGenerateTextureMipmap = reinterpret_cast<void(APIENTRY*)(GLuint)>(loader.load("glGenerateTextureMipmap"));
     flextglGetCompressedTextureImage = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLsizei, void *)>(loader.load("glGetCompressedTextureImage"));
     flextglGetCompressedTextureSubImage = reinterpret_cast<void(APIENTRY*)(GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLsizei, void *)>(loader.load("glGetCompressedTextureSubImage"));
-    flextglGetGraphicsResetStatus = reinterpret_cast<GLenum(APIENTRY*)(void)>(loader.load("glGetGraphicsResetStatus"));
+    flextglGetGraphicsResetStatus = reinterpret_cast<GLenum(APIENTRY*)()>(loader.load("glGetGraphicsResetStatus"));
     flextglGetNamedBufferParameteri64v = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, GLint64 *)>(loader.load("glGetNamedBufferParameteri64v"));
     flextglGetNamedBufferParameteriv = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, GLint *)>(loader.load("glGetNamedBufferParameteriv"));
     flextglGetNamedBufferPointerv = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, void **)>(loader.load("glGetNamedBufferPointerv"));
@@ -918,7 +918,7 @@ void flextGLInit() {
     flextglNamedRenderbufferStorage = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, GLsizei, GLsizei)>(loader.load("glNamedRenderbufferStorage"));
     flextglNamedRenderbufferStorageMultisample = reinterpret_cast<void(APIENTRY*)(GLuint, GLsizei, GLenum, GLsizei, GLsizei)>(loader.load("glNamedRenderbufferStorageMultisample"));
     flextglReadnPixels = reinterpret_cast<void(APIENTRY*)(GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, GLsizei, void *)>(loader.load("glReadnPixels"));
-    flextglTextureBarrier = reinterpret_cast<void(APIENTRY*)(void)>(loader.load("glTextureBarrier"));
+    flextglTextureBarrier = reinterpret_cast<void(APIENTRY*)()>(loader.load("glTextureBarrier"));
     flextglTextureBuffer = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, GLuint)>(loader.load("glTextureBuffer"));
     flextglTextureBufferRange = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, GLuint, GLintptr, GLsizeiptr)>(loader.load("glTextureBufferRange"));
     flextglTextureParameterIiv = reinterpret_cast<void(APIENTRY*)(GLuint, GLenum, const GLint *)>(loader.load("glTextureParameterIiv"));

--- a/src/MagnumPlugins/ObjImporter/ObjImporter.cpp
+++ b/src/MagnumPlugins/ObjImporter/ObjImporter.cpp
@@ -298,13 +298,13 @@ std::optional<MeshData3D> ObjImporter::doMesh3D(UnsignedInt id) {
                 return std::nullopt;
             }
 
-            if(textureCoordinates.empty()) textureCoordinates.push_back({});
-            textureCoordinates.front().push_back(data);
+            if(textureCoordinates.empty()) textureCoordinates.emplace_back();
+            textureCoordinates.front().emplace_back(data);
 
         /* Normal */
         } else if(keyword == "vn") {
-            if(normals.empty()) normals.push_back({});
-            normals.front().push_back(extractFloatData<3>(contents));
+            if(normals.empty()) normals.emplace_back();
+            normals.front().emplace_back(extractFloatData<3>(contents));
 
         /* Indices */
         } else if(keyword == "p" || keyword == "l" || keyword == "f") {
@@ -470,9 +470,9 @@ std::optional<MeshData3D> ObjImporter::doMesh3D(UnsignedInt id) {
     if(!normalIndices.empty() || !textureCoordinateIndices.empty()) {
         std::vector<std::reference_wrapper<std::vector<UnsignedInt>>> arrays;
         arrays.reserve(3);
-        arrays.push_back(positionIndices);
-        if(!normalIndices.empty()) arrays.push_back(normalIndices);
-        if(!textureCoordinateIndices.empty()) arrays.push_back(textureCoordinateIndices);
+        arrays.emplace_back(positionIndices);
+        if(!normalIndices.empty()) arrays.emplace_back(normalIndices);
+        if(!textureCoordinateIndices.empty()) arrays.emplace_back(textureCoordinateIndices);
         indices = MeshTools::combineIndexArrays(arrays);
 
         /* Reindex data arrays */

--- a/src/MagnumPlugins/ObjImporter/ObjImporter.cpp
+++ b/src/MagnumPlugins/ObjImporter/ObjImporter.cpp
@@ -53,7 +53,7 @@ void ignoreLine(std::istream& in) {
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 }
 
-template<std::size_t size> Math::Vector<size, Float> extractFloatData(std::string str, Float* extra = nullptr) {
+template<std::size_t size> Math::Vector<size, Float> extractFloatData(const std::string& str, Float* extra = nullptr) {
     std::vector<std::string> data = Utility::String::splitWithoutEmptyParts(str, ' ');
     if(data.size() < size || data.size() > size + (extra ? 1 : 0)) {
         Error() << "Trade::ObjImporter::mesh3D(): invalid float array size";


### PR DESCRIPTION
This is a minor commit that meticulously modernizes Magnum with the following changes:

1. No moving elements that are better simply copied
2. push_back -> emplace_back when appropriate
3. Use defaulted constructor/destructors, not trivial ones
4. Use more modern initialization
5.  Remove unnecessary quantifiers / add ones where appropriate

Feel free to take what you like and leave what you don't!