### PR TITLE
ci: Explicitly set travis distro to trusty (Fix travis builds)

### DIFF
--- a/package/ci/travis-emscripten.sh
+++ b/package/ci/travis-emscripten.sh
@@ -42,8 +42,8 @@ cmake .. \
     -DCMAKE_TOOLCHAIN_FILE="../toolchains/generic/Emscripten.cmake" \
     -DEMSCRIPTEN_PREFIX=$(echo /usr/local/Cellar/emscripten/*/libexec) \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG -O1" \
-    -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-O1" \
+    -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG -O2" \
+    -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-O2" \
     -DCMAKE_INSTALL_PREFIX=$HOME/deps \
     -DCMAKE_FIND_ROOT_PATH=$HOME/deps \
     -DWITH_AUDIO=ON \

--- a/package/ci/travis.yml
+++ b/package/ci/travis.yml
@@ -1,5 +1,8 @@
 # kate: indent-width 2;
 
+# trusty has cmake >= 2.8.12 in the official package repository
+dist: trusty
+
 addons:
   apt:
     sources:
@@ -9,6 +12,9 @@ addons:
     - g++-4.7
     - cmake
     - libopenal-dev
+    - libxrandr-dev
+    - libxinerama-dev
+    - libxcursor-dev
 
 matrix:
   include:
@@ -39,6 +45,9 @@ matrix:
         - clang-3.8
         - cmake
         - libopenal-dev
+        - libxrandr-dev
+        - libxinerama-dev
+        - libxcursor-dev
   - language: cpp
     os: linux
     compiler: gcc

--- a/package/ci/travis.yml
+++ b/package/ci/travis.yml
@@ -54,14 +54,12 @@ matrix:
     env:
     - TARGET=desktop-gles
     - TARGET_GLES2=ON
-  # Disabled because the Ubuntu 12.04 drivers are missing some ES3 entrypoints
-  # Should be enabled after moving to 14.04
-  #- language: cpp
-    #os: linux
-    #compiler: gcc
-    #env:
-    #- TARGET=desktop-gles
-    #- TARGET_GLES2=OFF
+  - language: cpp
+    os: linux
+    compiler: gcc
+    env:
+    - TARGET=desktop-gles
+    - TARGET_GLES2=OFF
   - language: cpp
     os: osx
     compiler: clang


### PR DESCRIPTION
Hello everyone,

I just found the magnum builds to be failing on travis, because all of the sudden cmake is only version 2.8.7 there. I am guessing it may be using packages ffrom ubuntu percise instead of trusty, maybe because of default that changed on travis-ci.

I figured explicitly definiting `distro: trusty` may help. Let's see what the build says.

Cheers, Jonathan.