### PR TITLE
Fixed bit setting bug in BoolVector::set

### DIFF
--- a/src/Magnum/Math/BoolVector.h
+++ b/src/Magnum/Math/BoolVector.h
@@ -122,7 +122,7 @@ template<std::size_t size> class BoolVector {
 
         /** @brief Set bit at given position */
         BoolVector<size>& set(std::size_t i, bool value) {
-            _data[i/8] ^= (-Byte(value) ^ _data[i/8]) & (0x01 << i);
+            _data[i/8] ^= (-Byte(value) ^ _data[i/8]) & (0x01 << i%8);
             return *this;
         }
 

--- a/src/Magnum/Math/BoolVector.h
+++ b/src/Magnum/Math/BoolVector.h
@@ -122,7 +122,7 @@ template<std::size_t size> class BoolVector {
 
         /** @brief Set bit at given position */
         BoolVector<size>& set(std::size_t i, bool value) {
-            _data[i/8] |= ((value & 0x01) << i%8);
+            _data[i/8] &= ~(1 << i%8) | (value << i%8);
             return *this;
         }
 

--- a/src/Magnum/Math/BoolVector.h
+++ b/src/Magnum/Math/BoolVector.h
@@ -122,7 +122,7 @@ template<std::size_t size> class BoolVector {
 
         /** @brief Set bit at given position */
         BoolVector<size>& set(std::size_t i, bool value) {
-            _data[i/8] &= ~(1 << i%8) | (value << i%8);
+            _data[i/8] ^= (-Byte(value) ^ _data[i/8]) & (0x01 << i);
             return *this;
         }
 

--- a/src/Magnum/Math/Test/BoolVectorTest.cpp
+++ b/src/Magnum/Math/Test/BoolVectorTest.cpp
@@ -169,6 +169,9 @@ void BoolVectorTest::data() {
     d.set(15, true);
     CORRADE_VERIFY(d[15]);
     CORRADE_COMPARE(d, BoolVector19(0x08, 0x83, 0x04));
+    d.set(15, false);
+    CORRADE_VERIFY(!d[15]);
+    CORRADE_COMPARE(d, BoolVector19(0x08, 0x03, 0x04));
 }
 
 void BoolVectorTest::compare() {


### PR DESCRIPTION
There's also an issue which I created before I realised it'd be probably better to create a PR: https://github.com/mosra/magnum/issues/208
Anyway - if `value` arg is `false` and desired bit is set to 1, then the bit will still remain 1 (won't change value to 0). The solution I found [here](https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit), ~~but I didn't use *best answer* - [the one](https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit#comment-46654671) from the comments seemed more reliable to me~~.