### PR TITLE
Audio::Error/Audio::Context::Error enums and some emscripten specifics 

### DIFF
--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -228,7 +228,16 @@ bool Context::tryCreateContext(const Configuration& config) {
         attributes[last++] = config.refreshRate();
     }
 
+#ifndef CORRADE_TARGET_EMSCRIPTEN
     _context = alcCreateContext(_device, attributes);
+#else
+    /* Attribute list currently not supported by emscripten */
+    if(last != 0) {
+        Magnum::Error() << "Audio::Context::tryCreateContext(): spcifying attributes is not supported with emscripten.";
+        return false;
+    }
+    _context = alcCreateContext(_device, nullptr);
+#endif
     return !!_context;
 }
 

--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -74,6 +74,40 @@ Debug& operator<<(Debug& debug, const Context::HrtfStatus value) {
     return debug << "Audio::Context::HrtfStatus(" << Debug::nospace << reinterpret_cast<void*>(ALenum(value)) << Debug::nospace << ")";
 }
 
+Debug& operator<<(Debug& debug, const Error value) {
+    switch(value) {
+        /* LCOV_EXCL_START */
+        #define _c(value) case Error::value: return debug << "Audio::Error::" #value;
+        _c(None)
+        _c(InvalidName)
+        _c(InvalidEnum)
+        _c(InvalidValue)
+        _c(InvalidOperation)
+        _c(OutOfMemory)
+        #undef _c
+        /* LCOV_EXCL_STOP */
+    }
+
+    return debug << "Audio::Error(" << Debug::nospace << reinterpret_cast<void*>(ALenum(value)) << Debug::nospace << ")";
+}
+
+Debug& operator<<(Debug& debug, const Context::Error value) {
+    switch(value) {
+        /* LCOV_EXCL_START */
+        #define _c(value) case Context::Error::value: return debug << "Audio::Context::Error::" #value;
+        _c(None)
+        _c(InvalidDevice)
+        _c(InvalidContext)
+        _c(InvalidEnum)
+        _c(InvalidValue)
+        _c(OutOfMemory)
+        #undef _c
+        /* LCOV_EXCL_STOP */
+    }
+
+    return debug << "Audio::Context::Error(" << Debug::nospace << reinterpret_cast<void*>(ALenum(value)) << Debug::nospace << ")";
+}
+
 Context* Context::_current = nullptr;
 
 std::vector<std::string> Context::deviceSpecifierStrings() {
@@ -100,12 +134,12 @@ Context::Context(const Configuration& config) {
     /* Open the device */
     const ALCchar* const deviceSpecifier = config.deviceSpecifier().empty() ? alcGetString(nullptr, ALC_DEFAULT_DEVICE_SPECIFIER) : config.deviceSpecifier().data();
     if(!(_device = alcOpenDevice(deviceSpecifier))) {
-        Error() << "Audio::Context: cannot open sound device" << deviceSpecifier;
+        Magnum::Error() << "Audio::Context: cannot open sound device" << deviceSpecifier;
         std::exit(1);
     }
 
     if(!tryCreateContext(config)) {
-        Error() << "Audio::Context: cannot create context:" << alcGetError(_device);
+        Magnum::Error() << "Audio::Context: cannot create context:" << Audio::Context::Error(alcGetError(_device));
         std::exit(1);
     }
 

--- a/src/Magnum/Audio/Context.h
+++ b/src/Magnum/Audio/Context.h
@@ -51,6 +51,29 @@ typedef struct ALCcontext_struct ALCcontext;
 namespace Magnum { namespace Audio {
 
 /**
+ * @brief OpenAL error
+ */
+enum class Error: ALenum {
+    /** No error */
+    None = AL_NO_ERROR,
+
+    /** Invalid name parameter passed to AL call. */
+    InvalidName = AL_INVALID_NAME,
+
+    /** Invalid enum parameter passed to AL call. */
+    InvalidEnum = AL_INVALID_ENUM,
+
+    /** Invalid value parameter passed to AL call. */
+    InvalidValue = AL_INVALID_VALUE,
+
+    /** Illegal AL call. */
+    InvalidOperation = AL_INVALID_OPERATION,
+
+    /** Out of memory. */
+    OutOfMemory = AL_OUT_OF_MEMORY
+};
+
+/**
 @brief Run-time information about OpenAL extension
 
 Encapsulates runtime information about OpenAL extension, such as name string,
@@ -124,6 +147,29 @@ class MAGNUM_AUDIO_EXPORT Context {
              * @requires_al_extension Extension @alc_extension{SOFT,HRTF}
              */
             UnsupportedFormat = ALC_HRTF_UNSUPPORTED_FORMAT_SOFT
+        };
+
+        /**
+         * @brief OpenAL context error
+         */
+        enum class Error: ALenum {
+            /** No error. */
+            None = ALC_NO_ERROR,
+
+            /** Invalid device handle. */
+            InvalidDevice = ALC_INVALID_DEVICE,
+
+            /** Invalid context handle. */
+            InvalidContext = ALC_INVALID_CONTEXT,
+
+            /** Invalid enum parameter passed to an ALC call. */
+            InvalidEnum = ALC_INVALID_ENUM,
+
+            /** Invalid value parameter passed to an ALC call. */
+            InvalidValue = ALC_INVALID_VALUE,
+
+            /** Out of memory. */
+            OutOfMemory = ALC_OUT_OF_MEMORY
         };
 
         /**
@@ -466,6 +512,12 @@ MAGNUM_ASSERT_AUDIO_EXTENSION_SUPPORTED(Extensions::ALC::SOFTX::HRTF);
 
 /** @debugoperatorclassenum{Magnum::Audio::Context,Magnum::Audio::Context::HrtfStatus} */
 MAGNUM_AUDIO_EXPORT Debug& operator<<(Debug& debug, Context::HrtfStatus value);
+
+/** @debugoperatorclassenum{Magnum::Audio::Context,Magnum::Audio::Error} */
+MAGNUM_AUDIO_EXPORT Debug& operator<<(Debug& debug, Error value);
+
+/** @debugoperatorclassenum{Magnum::Audio::Context,Magnum::Audio::Context::Error} */
+MAGNUM_AUDIO_EXPORT Debug& operator<<(Debug& debug, Context::Error value);
 
 inline bool Context::isHrtfEnabled() const {
     Int enabled;

--- a/src/Magnum/Audio/Test/ContextTest.cpp
+++ b/src/Magnum/Audio/Test/ContextTest.cpp
@@ -35,16 +35,32 @@ struct ContextTest: TestSuite::Tester {
     explicit ContextTest();
 
     void debugHrtfStatus();
+    void debugError();
+    void debugContextError();
 };
 
 ContextTest::ContextTest() {
-    addTests({&ContextTest::debugHrtfStatus});
+    addTests({&ContextTest::debugHrtfStatus,
+              &ContextTest::debugError,
+              &ContextTest::debugContextError});
 }
 
 void ContextTest::debugHrtfStatus() {
     std::ostringstream out;
     Debug(&out) << Context::HrtfStatus::Denied << Context::HrtfStatus(0xdead);
     CORRADE_COMPARE(out.str(), "Audio::Context::HrtfStatus::Denied Audio::Context::HrtfStatus(0xdead)\n");
+}
+
+void ContextTest::debugError() {
+    std::ostringstream out;
+    Debug(&out) << Error::None << Error(0xdead);
+    CORRADE_COMPARE(out.str(), "Audio::Error::None Audio::Error(0xdead)\n");
+}
+
+void ContextTest::debugContextError() {
+    std::ostringstream out;
+    Debug(&out) << Context::Error::None << Context::Error(0xdead);
+    CORRADE_COMPARE(out.str(), "Audio::Context::Error::None Audio::Context::Error(0xdead)\n");
 }
 
 }}}


### PR DESCRIPTION
Hi @mosra !

As promised, I started porting the audio example. I made a minor enhancement which now prints a decent error when `alcCreateContext` fails because Emscripten does not support specifying attributes.

Cheers, Jonathan.