### PR TITLE
Solid circle primitive is missing a triangle

### DIFF
--- a/src/Magnum/Primitives/Circle.cpp
+++ b/src/Magnum/Primitives/Circle.cpp
@@ -44,7 +44,7 @@ Trade::MeshData2D Circle::solid(UnsignedInt segments) {
 
     /* Points on circle */
     const Rad angleIncrement(Constants::tau()/segments);
-    for(UnsignedInt i = 0; i != segments; ++i) {
+    for(UnsignedInt i = 0; i != segments+1; ++i) {
         const Rad angle(Float(i)*angleIncrement);
         positions.emplace_back(Math::cos(angle), Math::sin(angle));
     }


### PR DESCRIPTION
Adding one extra vertex in solid circle primitive in order to fill missing triangle.

This is what I see with the following code:
```
		auto const circle = Primitives::Circle::solid(6);
		
		_vertexBuffer.setData(circle.positions(0), BufferUsage::StaticDraw);
		_mesh.setPrimitive(circle.primitive())
			.setCount(circle.positions(0).size())
			.addVertexBuffer(_vertexBuffer, 0, Shaders::Flat2D::Position{})

```

![image](https://user-images.githubusercontent.com/9445488/32351862-2cd90da6-c01f-11e7-9a28-b0dba6c24450.png)
