### PR TITLE
Culling math

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -32,8 +32,8 @@ Contributors to Magnum library
 -   [@wivlaro](https://github.com/wivlaro) -- numerous bug reports, macOS
     fixes, feature improvements
 -   Jonathan Hale ([@Squareys](https://github.com/Squareys)) -- Audio library
-    enhancements, GlfwApplication implementation, frustum culling, bug reports,
-    documentation improvements
+    enhancements, GlfwApplication implementation, frustum and cone culling, bug
+    reports, documentation improvements
 -   Gerhard de Clercq -- Windows RT (Store/Phone) port
 -   Ashwin Ravichandran ([@](ashrko619)[https://github.com/ashrko619]) --
     Bézier curve implementation

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -42,6 +42,15 @@ See also:
 
 @subsubsection changelog-lates-new-math Math library
 
+-   Added @ref Math::Geometry::Intersection::rangeFrustum(),
+    @ref Math::Geometry::Intersection::aabbFrustum(),
+    @ref Math::Geometry::Intersection::sphereFrustum(),
+    @ref Math::Geometry::Intersection::pointCone(),
+    @ref Math::Geometry::Intersection::pointDoubleCone(),
+    @ref Math::Geometry::Intersection::sphereConeView(),
+    @ref Math::Geometry::Intersection::sphereCone(),
+    @ref Math::Geometry::Intersection::aabbCone(),
+    @ref Math::Geometry::Intersection::rangeCone()
 -   Added @ref Math::Constants::piQuarter()
 -   Ability to convert @ref Math::BoolVector from and to external
     representation
@@ -68,6 +77,11 @@ See also:
     due to a pointer not being properly initialized after the
     @ref Platform::GlfwApplication::GLConfiguration "GLConfiguration" rework in
     2018.04 (see [mosra/magnum#246](https://github.com/mosra/magnum/pull/246))
+
+@subsection changelog-latest-deprecated Deprecated APIs
+
+-   `Math::Geometry::Intersection::boxFrustum()` is deprecated, use
+    @ref Math::Geometry::Intersection::rangeFrustum() instead
 
 @section changelog-2018-04 2018.04
 
@@ -711,7 +725,7 @@ a high-level overview.
 -   New @ref Math::Bezier class for handling N-dimensional M-order Bézier
     curves (see [mosra/magnum#165](https://github.com/mosra/magnum/pull/165))
 -   New @ref Math::Frustum class and @ref Math::Geometry::Intersection::pointFrustum(),
-    @ref Math::Geometry::Intersection::boxFrustum() functions (see
+    `Math::Geometry::Intersection::boxFrustum()` functions (see
     [mosra/magnum#185](https://github.com/mosra/magnum/pull/185)
 -   New @ref Math::Half class, @link Math::Literals::operator""_h @endlink
     literal and @ref Math::packHalf() and @ref Math::unpackHalf() functions

--- a/src/Magnum/Math/Geometry/Intersection.h
+++ b/src/Magnum/Math/Geometry/Intersection.h
@@ -5,7 +5,7 @@
 
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
               Vladimír Vondruš <mosra@centrum.cz>
-    Copyright © 2016 Jonathan Hale <squareys@googlemail.com>
+    Copyright © 2016, 2018 Jonathan Hale <squareys@googlemail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,9 @@
 #include "Magnum/Math/Frustum.h"
 #include "Magnum/Math/Geometry/Distance.h"
 #include "Magnum/Math/Range.h"
+#include "Magnum/Math/Vector2.h"
 #include "Magnum/Math/Vector3.h"
+#include "Magnum/Math/Matrix4.h"
 
 namespace Magnum { namespace Math { namespace Geometry { namespace Intersection {
 
@@ -143,7 +145,7 @@ template<class T> inline T planeLine(const Vector3<T>& planePosition, const Vect
 }
 
 /**
-@brief Intersection of a point and a camera frustum
+@brief Intersection of a point and a frustum
 @param point    Point
 @param frustum  Frustum planes with normals pointing outwards
 
@@ -155,19 +157,259 @@ points distance from the plane is negative) using @ref Distance::pointPlaneScale
 template<class T> bool pointFrustum(const Vector3<T>& point, const Frustum<T>& frustum);
 
 /**
-@brief Intersection of an axis-aligned box and a camera frustum
+@brief Intersection of a range and a frustum
+@param range    Range
+@param frustum  Frustum planes with normals pointing outwards
+
+Returns @cpp true @ce if the box intersects with the frustum.
+
+Uses the "p/n-vertex" approach: First converts the @ref Range3D into a representation
+using center and extent which allows using the following condition for whether the
+plane is intersecting the box: @f[
+     \begin{array}{rcl}
+         d & = & \boldsymbol c \cdot \boldsymbol n \\
+         r & = & \boldsymbol c \cdot \text{abs}(\boldsymbol n) \\
+         d + r & < & -w
+     \end{array}
+@f]
+
+for plane normal @f$ \boldsymbol n @f$ and determinant @f$ w @f$.
+
+@see @ref aabbFrustum()
+*/
+template<class T> bool rangeFrustum(const Range3D<T>& range, const Frustum<T>& frustum);
+
+#ifdef MAGNUM_BUILD_DEPRECATED
+/**
+@brief @copybrief rangeFrustum()
+@deprecated Use @ref rangeFrustum() instead.
+*/
+template<class T> CORRADE_DEPRECATED("use rangeFrustum() instead") bool boxFrustum(const Range3D<T>& box, const Frustum<T>& frustum) {
+    return rangeFrustum(box, frustum);
+}
+#endif
+
+/**
+@brief Intersection of an axis-aligned box and a frustum
 @param box      Axis-aligned box
 @param frustum  Frustum planes with normals pointing outwards
 
-Returns @cpp true @ce if the box intersects with the camera frustum.
+Returns @cpp true @ce if the box intersects with the frustum.
 
-Counts for each plane of the frustum how many points of the box lie in front of
-the plane (outside of the frustum). If none, the box must lie entirely outside
-of the frustum and there is no intersection. Else, the box is considered as
-intersecting, even if it is merely corners of the box overlapping with corners
-of the frustum, since checking the corners is less efficient.
+Uses the same method as @ref rangeFrustum() "rangeFrustum()", but does not need to
+convert to center/extents representation.
 */
-template<class T> bool boxFrustum(const Range3D<T>& box, const Frustum<T>& frustum);
+template<class T> bool aabbFrustum(const Vector3<T>& center, const Vector3<T>& extents, const Frustum<T>& frustum);
+
+/**
+@brief Intersection of a sphere and a frustum
+@param center   Sphere center
+@param radius   Sphere radius
+@param frustum  Frustum planes with normals pointing outwards
+
+Returns @cpp true @ce if the sphere intersects the frustum.
+
+Checks for each plane of the frustum whether the sphere is behind the plane (the
+points distance larger than the sphere's radius) using @ref Distance::pointPlaneScaled().
+*/
+template<class T> bool sphereFrustum(const Vector3<T>& center, T radius, const Frustum<T>& frustum);
+
+/**
+@brief Intersection of a point and a cone
+@param p        The point
+@param origin   Cone origin
+@param normal   Cone normal
+@param angle    Apex angle of the cone
+
+Returns @cpp true @ce if the point is inside the cone.
+
+Precomputes a portion of the intersection equation from @p angle and calls
+@ref pointCone(const Vector3&, const Vector3&, const Vector3&, T)
+*/
+template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, Rad<T> angle);
+
+/**
+@brief Intersection of a point and a cone using precomputed values
+@param p            The point
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
+                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
+
+Returns @cpp true @ce if the point is inside the cone.
+*/
+template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
+
+/**
+@brief Intersection of a point and a double cone
+@param p            The point
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param coneAngle    Apex angle of the cone
+
+Returns @cpp true @ce if the point is inside the double cone.
+
+Precomputes a portion of the intersection equation from @p angle and calls
+@ref pointDoubleCone(const Vector3&, const Vector3&, const Vector3&, T)
+*/
+template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
+
+/**
+@brief Intersection of a point and a double cone using precomputed values
+@param p            The point
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
+                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
+
+Returns @cpp true @ce if the point is inside the double cone.
+
+Uses the result of precomputing @f$ x = \tan^2{\theta} + 1 @f$.
+*/
+template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
+
+/**
+@brief Intersection of a sphere and a cone view
+@param sphereCenter   Center of the sphere
+@param radius         Radius of the sphere
+@param coneView       View matrix with translation and rotation of the cone
+@param coneAngle      Cone opening angle
+
+Returns @cpp true @ce if the sphere intersects the cone.
+
+Transforms the sphere center into cone space (using the cone view matrix) and
+performs sphere-cone intersection with the zero-origin -Z axis-aligned cone.
+
+Precomputes a portion of the intersection equation from @p angle and calls
+@ref sphereConeView(const Vector3<T>&, T, const Matrix4<T>&, T, T, T)
+*/
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T radius, const Matrix4<T>& coneView, Rad<T> coneAngle);
+
+/**
+@brief Intersection of a sphere and a cone view
+@param sphereCenter Sphere center
+@param radius   Sphere radius
+@param coneView View matrix with translation and rotation of the cone
+@param sinAngle Precomputed sine of half the cone's opening angle: @cpp Math::sin(angle/T(2)) @ce
+@param cosAngle Precomputed cosine of half the cone's opening angle: @cpp Math::cos(angle/T(2)) @ce
+@param tanAngle Precomputed tangens of half the cone's opening angle: @cpp Math::tan(angle/T(2)) @ce
+
+Returns @cpp true @ce if the sphere intersects the cone.
+*/
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T radius, const Matrix4<T>& coneView, T sinAngle, T cosAngle, T tanAngle);
+
+/**
+@brief Intersection of a sphere and a cone
+@param sphereCenter   Sphere center
+@param radius Sphere  Sphere radius
+@param coneOrigin     Cone origin
+@param coneNormal     Cone normal
+@param coneAngle      Cone opening angle (@f$ 0 < \text{angle} < \pi @f$).
+
+Returns @cpp true @ce if the sphere intersects with the cone.
+
+Offsets the cone plane by @f$ -r\sin{\theta} \cdot \boldsymbol n @f$ (with  @f$ \theta @f$
+the cone's half-angle) which separates two half-spaces:
+In front of the plane, in which the sphere cone intersection test is equivalent
+to testing the sphere's center against a similarly offset cone (which is equivalent
+the cone with surface expanded by @f$ r @f$ in surface normal direction), and
+behind the plane, where the test is equivalent to testing whether the origin of
+the original cone intersects the sphere.
+
+Precomputes a portion of the intersection equation from @p angle and calls
+@ref sphereCone(const Vector3<T>& sphereCenter, T, const Vector3<T>&, const Vector3<T>&, T, T)
+*/
+template<class T> bool sphereCone(const Vector3<T>& sphereCenter, T radius, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
+
+/**
+@brief Intersection of a sphere and a cone using precomputed values
+@param sphereCenter Sphere center
+@param radius       Sphere radius
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param sinAngle     Precomputed sine of half the cone's opening angle:
+                    @cpp Math::sin(angle/T(2)) @ce
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
+                         @cpp Math::pow(Math::tan(angle/T(2)), 2) + 1 @ce
+
+Returns @cpp true @ce if the sphere intersects with the cone.
+*/
+template<class T> bool sphereCone(const Vector3<T>& sphereCenter, T radius, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T sinAngle, T tanAngleSqPlusOne);
+
+/**
+@brief Intersection of an axis aligned bounding box and a cone
+@param center      Center of the AABB
+@param extents     (Half-)extents of the AABB
+@param coneOrigin  Cone origin
+@param coneNormal  Cone normal
+@param coneAngle   Cone opening angle
+
+Returns @cpp true @ce if the axis aligned bounding box intersects the cone.
+
+On each axis finds the intersection points of the cone's axis with infinite planes
+obtained by extending the two faces of the box that are perpendicular to that axis.
+
+The intersection points on the planes perpendicular to axis @f$ a \in {0, 1, 2} @f$
+are given by @f[
+    \boldsymbol i = \boldsymbol n \cdot \frac{(\boldsymbol c_a - \boldsymbol o_a) \pm \boldsymbol e_a}{\boldsymbol n_a}
+@f]
+
+with normal @f$ n @f$, cone origin @f$ o @f$, box center @f$ x @f$ and box extents @f$ e @f$.
+
+The points on the faces that are closest to this intersection point are the closest
+to the cone's axis and are tested for intersection with the cone using
+@ref pointCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const T) "pointCone()".
+
+As soon as an intersecting point is found, the function returns @cpp true @ce.
+If all points lie outside of the cone, it will return @cpp false @ce.
+
+Precomputes a portion of the intersection equation from @p angle and calls
+@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T)
+*/
+template<class T> bool aabbCone(const Vector3<T>& center, const Vector3<T>& extents, const Vector3<T>& origin, const Vector3<T>& normal, Rad<T> angle);
+
+/**
+@brief Intersection of an axis aligned bounding box and a cone using precomputed values
+@param center Center of the AABB
+@param extents (Half-)extents of the AABB
+@param origin Cone origin
+@param normal Cone normal
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
+                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
+
+Returns @cpp true @ce if the axis aligned bounding box intersects the cone.
+*/
+template<class T> bool aabbCone(const Vector3<T>& center, const Vector3<T>& extents, const Vector3<T>& origin, const Vector3<T>& normal, T tanAngleSqPlusOne);
+
+/**
+@brief Intersection of a range and a cone
+
+@param range        Range
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param coneAngle    Cone opening angle
+
+Returns @cpp true @ce if the range intersects the cone.
+
+Converts the range into center/extents representation and passes it on to
+@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T) "aabbCone()".
+*/
+template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> angle);
+
+/**
+@brief Intersection of a range and a cone using precomputed values
+@param range        Range
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
+                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
+
+Returns @cpp true @ce if the range intersects the cone.
+
+Converts the range into center/extents representation and passes it on to
+@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T) "aabbCone()".
+*/
+template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne);
 
 template<class T> bool pointFrustum(const Vector3<T>& point, const Frustum<T>& frustum) {
     for(const Vector4<T>& plane: frustum.planes()) {
@@ -180,26 +422,205 @@ template<class T> bool pointFrustum(const Vector3<T>& point, const Frustum<T>& f
     return true;
 }
 
-template<class T> bool boxFrustum(const Range3D<T>& box, const Frustum<T>& frustum) {
+template<class T> bool rangeFrustum(const Range3D<T>& box, const Frustum<T>& frustum) {
+    /* Convert to center/extent, avoiding division by 2 and instead comparing
+       to 2*-plane.w() later */
+    const Vector3<T> center = box.min() + box.max();
+    const Vector3<T> extent = box.max() - box.min();
+
     for(const Vector4<T>& plane: frustum.planes()) {
-        bool cornerHit = 0;
+        const Vector3<T> absPlaneNormal = Math::abs(plane.xyz());
 
-        for(UnsignedByte c = 0; c != 8; ++c) {
-            const Vector3<T> corner = Math::lerp(box.min(), box.max(), Math::BoolVector<3>{c});
-
-            if(Distance::pointPlaneScaled<T>(corner, plane) >= T(0)) {
-                cornerHit = true;
-                break;
-            }
+        const Float d = Math::dot(center, plane.xyz());
+        const Float r = Math::dot(extent, absPlaneNormal);
+        if(d + r < -T(2)*plane.w()) {
+            return false;
         }
-
-        /* All corners are outside this plane */
-        if(!cornerHit) return false;
     }
 
-    /** @todo potentially check corners here to avoid false positives */
+    return true;
+}
+
+template<class T> bool aabbFrustum(
+    const Vector3<T>& center, const Vector3<T>& extents, const Frustum<T>& frustum)
+{
+    for(const Vector4<T>& plane: frustum.planes()) {
+        const Vector3<T> absPlaneNormal = Math::abs(plane.xyz());
+
+        const Float d = Math::dot(center, plane.xyz());
+        const Float r = Math::dot(extents, absPlaneNormal);
+        if(d + r < -plane.w()) {
+            return false;
+        }
+    }
 
     return true;
+}
+
+template<class T> bool sphereFrustum(const Vector3<T>& center, const T radius, const Frustum<T>& frustum) {
+    const T radiusSq = radius*radius;
+
+    for(const Vector4<T>& plane: frustum.planes()) {
+        /* The sphere is in front of one of the frustum planes (normals point
+           outwards) */
+        if(Distance::pointPlaneScaled<T>(center, plane) < -radiusSq)
+            return false;
+    }
+
+    return true;
+}
+
+
+template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const Rad<T> angle) {
+    const T x = T(1) + Math::pow(Math::tan(angle/T(2)), T(2));
+
+    return pointCone(p, origin, normal, x);
+}
+
+template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const T tanAngleSqPlusOne) {
+    const Vector3<T> c = p - origin;
+    const T lenA = dot(c, normal);
+
+    return lenA >= 0 && c.dot() <= lenA*lenA*tanAngleSqPlusOne;
+}
+
+template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const Rad<T> angle) {
+    const T x = T(1) + Math::pow(Math::tan(angle/T(2)), T(2));
+
+    return pointDoubleCone(p, origin, normal, x);
+}
+
+template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const T tanAngleSqPlusOne) {
+    const Vector3<T> c = p - origin;
+    const T lenA = dot(c, normal);
+
+    return c.dot() <= lenA*lenA*tanAngleSqPlusOne;
+}
+
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, const T radius, const Matrix4<T>& coneView, const Rad<T> angle) {
+    const T sinAngle = Math::sin(angle/T(2));
+    const T cosAngle = Math::cos(angle/T(2));
+    const T tanAngle = Math::tan(angle/T(2));
+
+    return sphereConeView(sphereCenter, radius, coneView, sinAngle, cosAngle, tanAngle);
+}
+
+template<class T> bool sphereConeView(
+    const Vector3<T>& sphereCenter, const T radius, const Matrix4<T>& coneView,
+    const T sinAngle, const T cosAngle, const T tanAngle)
+{
+    CORRADE_ASSERT(coneView.isRigidTransformation(), "Math::Geometry::Intersection::sphereConeView(): coneView must be rigid", false);
+
+    /* Transform the sphere so that we can test against Z axis aligned origin cone instead */
+    const Vector3<T> center = coneView.transformPoint(sphereCenter);
+
+    /* Test against plane which determines whether to test against shifted cone or center-sphere */
+    if (-center.z() > -radius*sinAngle) {
+        /* Point - axis aligned cone test, shifted so that the cone's surface is extended by the radius of the sphere */
+        const T coneRadius = tanAngle*(center.z() - radius/sinAngle);
+        return center.xy().dot() <= coneRadius*coneRadius;
+    } else {
+        /* Simple sphere point check */
+        return center.dot() <= radius*radius;
+    }
+
+    return false;
+}
+
+template<class T> bool sphereCone(
+    const Vector3<T>& sCenter, const T radius,
+    const Vector3<T>& origin, const Vector3<T>& normal, const Rad<T> angle)
+{
+    const T sinAngle = Math::sin(angle/T(2));
+    const T tanAngleSqPlusOne = T(1) + Math::pow<T>(Math::tan<T>(angle/T(2)), T(2));
+
+    return sphereCone(sCenter, radius, origin, normal, sinAngle, tanAngleSqPlusOne);
+}
+
+template<class T> bool sphereCone(
+    const Vector3<T>& sCenter, const T radius,
+    const Vector3<T>& origin, const Vector3<T>& normal,
+    const T sinAngle, const T tanAngleSqPlusOne)
+{
+    const Vector3<T> diff = sCenter - origin;
+
+    if (dot(diff - radius*sinAngle*normal, normal) > T(0)) {
+        /* point - cone test */
+        const Vector3<T> c = sinAngle*diff + normal*radius;
+        const T lenA = dot(c, normal);
+
+        return c.dot() <= lenA*lenA*(tanAngleSqPlusOne);
+    } else {
+        /* Simple sphere point check */
+        return diff.dot() <= radius*radius;
+    }
+}
+
+template<class T> bool aabbCone(
+    const Vector3<T>& center, const Vector3<T>& extents, const Vector3<T>& origin,
+    const Vector3<T>& normal, const Rad<T> angle)
+{
+    const T x = T(1) + Math::pow<T>(Math::tan<T>(angle/T(2)), T(2));
+    return aabbCone(center, extents, origin, normal, x);
+}
+
+template<class T> bool aabbCone(
+    const Vector3<T>& center, const Vector3<T>& extents,
+    const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne)
+{
+    const Vector3<T> c = center - coneOrigin;
+
+    for (const Int axis: {0, 1, 2}) {
+        const Int z = axis;
+        const Int x = (axis + 1) % 3;
+        const Int y = (axis + 2) % 3;
+        if(coneNormal[z] != T(0)) {
+            Float t0 = ((c[z] - extents[z])/coneNormal[z]);
+            Float t1 = ((c[z] + extents[z])/coneNormal[z]);
+
+            const Vector3<T> i0 = coneNormal*t0;
+            const Vector3<T> i1 = coneNormal*t1;
+
+            for(const auto& i : {i0, i1}) {
+                Vector3<T> closestPoint = i;
+
+                if(i[x] - c[x] > extents[x]) {
+                    closestPoint[x] = c[x] + extents[x];
+                } else if(i[x] - c[x] < -extents[x]) {
+                    closestPoint[x] = c[x] - extents[x];
+                }
+                /* Else: normal intersects within x bounds */
+
+                if(i[y] - c[y] > extents[y]) {
+                    closestPoint[y] = c[y] + extents[y];
+                } else if(i[y] - c[y] < -extents[y]) {
+                    closestPoint[y] = c[y] - extents[y];
+                }
+                /* Else: normal intersects within Y bounds */
+
+                if (pointCone<T>(closestPoint, {}, coneNormal, tanAngleSqPlusOne)) {
+                    /* Found a point in cone and aabb */
+                    return true;
+                }
+            }
+        }
+        /* else: normal will intersect one of the other planes */
+    }
+
+    return false;
+}
+
+template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> angle) {
+    const Vector3<T> center = (range.min() + range.max())/T(2);
+    const Vector3<T> extents = (range.max() - range.min())/T(2);
+    const T x = T(1) + Math::pow<T>(Math::tan<T>(angle/T(2)), T(2));
+    return aabbCone(center, extents, coneOrigin, coneNormal, x);
+}
+
+template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne) {
+    const Vector3<T> center = (range.min() + range.max())/T(2);
+    const Vector3<T> extents = (range.max() - range.min())/T(2);
+    return aabbCone(center, extents, coneOrigin, coneNormal, tanAngleSqPlusOne);
 }
 
 }}}}

--- a/src/Magnum/Math/Geometry/Intersection.h
+++ b/src/Magnum/Math/Geometry/Intersection.h
@@ -148,8 +148,8 @@ template<class T> inline T planeLine(const Vector3<T>& planePosition, const Vect
 @brief Intersection of a point and a frustum
 @param point    Point
 @param frustum  Frustum planes with normals pointing outwards
-
-Returns @cpp true @ce if the point is on or inside the frustum.
+@return @cpp true @ce if the point is on or inside the frustum, @cpp false @ce
+    otherwise
 
 Checks for each plane of the frustum whether the point is behind the plane (the
 points distance from the plane is negative) using @ref Distance::pointPlaneScaled().
@@ -160,12 +160,12 @@ template<class T> bool pointFrustum(const Vector3<T>& point, const Frustum<T>& f
 @brief Intersection of a range and a frustum
 @param range    Range
 @param frustum  Frustum planes with normals pointing outwards
+@return @cpp true @ce if the box intersects with the frustum, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the box intersects with the frustum.
-
-Uses the "p/n-vertex" approach: First converts the @ref Range3D into a representation
-using center and extent which allows using the following condition for whether the
-plane is intersecting the box: @f[
+Uses the "p/n-vertex" approach: First converts the @ref Range3D into a
+representation using center and extent which allows using the following
+condition for whether the plane is intersecting the box: @f[
      \begin{array}{rcl}
          d & = & \boldsymbol c \cdot \boldsymbol n \\
          r & = & \boldsymbol c \cdot \text{abs}(\boldsymbol n) \\
@@ -181,9 +181,9 @@ template<class T> bool rangeFrustum(const Range3D<T>& range, const Frustum<T>& f
 
 #ifdef MAGNUM_BUILD_DEPRECATED
 /**
-@brief @copybrief rangeFrustum()
-@deprecated Use @ref rangeFrustum() instead.
-*/
+ * @brief @copybrief rangeFrustum()
+ * @deprecated Use @ref rangeFrustum() instead.
+ */
 template<class T> CORRADE_DEPRECATED("use rangeFrustum() instead") bool boxFrustum(const Range3D<T>& box, const Frustum<T>& frustum) {
     return rangeFrustum(box, frustum);
 }
@@ -191,223 +191,246 @@ template<class T> CORRADE_DEPRECATED("use rangeFrustum() instead") bool boxFrust
 
 /**
 @brief Intersection of an axis-aligned box and a frustum
-@param box      Axis-aligned box
-@param frustum  Frustum planes with normals pointing outwards
+@param aabbCenter   Center of the AABB
+@param aabbExtents  (Half-)extents of the AABB
+@param frustum      Frustum planes with normals pointing outwards
+@return @cpp true @ce if the box intersects with the frustum, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the box intersects with the frustum.
-
-Uses the same method as @ref rangeFrustum() "rangeFrustum()", but does not need to
-convert to center/extents representation.
+Uses the same method as @ref rangeFrustum(), but does not need to convert to
+center/extents representation.
 */
-template<class T> bool aabbFrustum(const Vector3<T>& center, const Vector3<T>& extents, const Frustum<T>& frustum);
+template<class T> bool aabbFrustum(const Vector3<T>& aabbCenter, const Vector3<T>& aabbExtents, const Frustum<T>& frustum);
 
 /**
 @brief Intersection of a sphere and a frustum
-@param center   Sphere center
-@param radius   Sphere radius
-@param frustum  Frustum planes with normals pointing outwards
+@param sphereCenter Sphere center
+@param sphereRadius Sphere radius
+@param frustum      Frustum planes with normals pointing outwards
+@return @cpp true @ce if the sphere intersects the frustum, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the sphere intersects the frustum.
-
-Checks for each plane of the frustum whether the sphere is behind the plane (the
-points distance larger than the sphere's radius) using @ref Distance::pointPlaneScaled().
+Checks for each plane of the frustum whether the sphere is behind the plane
+(the points distance larger than the sphere's radius) using
+@ref Distance::pointPlaneScaled().
 */
-template<class T> bool sphereFrustum(const Vector3<T>& center, T radius, const Frustum<T>& frustum);
+template<class T> bool sphereFrustum(const Vector3<T>& sphereCenter, T sphereRadius, const Frustum<T>& frustum);
 
 /**
 @brief Intersection of a point and a cone
-@param p        The point
-@param origin   Cone origin
-@param normal   Cone normal
-@param angle    Apex angle of the cone
-
-Returns @cpp true @ce if the point is inside the cone.
-
-Precomputes a portion of the intersection equation from @p angle and calls
-@ref pointCone(const Vector3&, const Vector3&, const Vector3&, T)
-*/
-template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, Rad<T> angle);
-
-/**
-@brief Intersection of a point and a cone using precomputed values
-@param p            The point
-@param coneOrigin   Cone origin
-@param coneNormal   Cone normal
-@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
-                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
-
-Returns @cpp true @ce if the point is inside the cone.
-*/
-template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
-
-/**
-@brief Intersection of a point and a double cone
-@param p            The point
+@param point        The point
 @param coneOrigin   Cone origin
 @param coneNormal   Cone normal
 @param coneAngle    Apex angle of the cone
+@return @cpp true @ce if the point is inside the cone, @cpp false @ce otherwise
 
-Returns @cpp true @ce if the point is inside the double cone.
-
-Precomputes a portion of the intersection equation from @p angle and calls
-@ref pointDoubleCone(const Vector3&, const Vector3&, const Vector3&, T)
+Precomputes a portion of the intersection equation from @p coneAngle and calls
+@ref pointCone(const Vector3&, const Vector3&, const Vector3&, T).
 */
-template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
+template<class T> bool pointCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
+
+/**
+@brief Intersection of a point and a cone using precomputed values
+@param point        The point
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation
+@return @cpp true @ce if the point is inside the cone, @cpp false @ce
+    otherwise
+
+The @p tanAngleSqPlusOne parameter can be calculated as:
+
+@code{.cpp}
+Math::pow<2>(Math::tan(angle*T(0.5))) + T(1)
+@endcode
+*/
+template<class T> bool pointCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
+
+/**
+@brief Intersection of a point and a double cone
+@param point        The point
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param coneAngle    Apex angle of the cone
+@return @cpp true @ce if the point is inside the double cone, @cpp false @ce
+    otherwise
+
+Precomputes a portion of the intersection equation from @p coneAngle and calls
+@ref pointDoubleCone(const Vector3&, const Vector3&, const Vector3&, T).
+*/
+template<class T> bool pointDoubleCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
 
 /**
 @brief Intersection of a point and a double cone using precomputed values
-@param p            The point
+@param point        The point
 @param coneOrigin   Cone origin
 @param coneNormal   Cone normal
-@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
-                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation
+@return @cpp true @ce if the point is inside the double cone, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the point is inside the double cone.
+The @p tanAngleSqPlusOne parameter can be precomputed like this:
 
-Uses the result of precomputing @f$ x = \tan^2{\theta} + 1 @f$.
+@code{.cpp}
+T tanAngleSqPlusOne = Math::pow<2>(Math::tan(angle*T(0.5))) + T(1);
+@endcode
 */
-template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
+template<class T> bool pointDoubleCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
 
 /**
 @brief Intersection of a sphere and a cone view
-@param sphereCenter   Center of the sphere
-@param radius         Radius of the sphere
-@param coneView       View matrix with translation and rotation of the cone
-@param coneAngle      Cone opening angle
+@param sphereCenter Center of the sphere
+@param sphereRadius Radius of the sphere
+@param coneView     View matrix with translation and rotation of the cone
+@param coneAngle    Apex angle of the cone (@f$ 0 < \Theta < \pi @f$)
+@return @cpp true @ce if the sphere intersects the cone, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the sphere intersects the cone.
-
-Transforms the sphere center into cone space (using the cone view matrix) and
-performs sphere-cone intersection with the zero-origin -Z axis-aligned cone.
-
-Precomputes a portion of the intersection equation from @p angle and calls
-@ref sphereConeView(const Vector3<T>&, T, const Matrix4<T>&, T, T, T)
+Precomputes a portion of the intersection equation from @p coneAngle and calls
+@ref sphereConeView(const Vector3<T>&, T, const Matrix4<T>&, T, T, T).
 */
-template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T radius, const Matrix4<T>& coneView, Rad<T> coneAngle);
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T sphereRadius, const Matrix4<T>& coneView, Rad<T> coneAngle);
 
 /**
 @brief Intersection of a sphere and a cone view
 @param sphereCenter Sphere center
-@param radius   Sphere radius
-@param coneView View matrix with translation and rotation of the cone
-@param sinAngle Precomputed sine of half the cone's opening angle: @cpp Math::sin(angle/T(2)) @ce
-@param cosAngle Precomputed cosine of half the cone's opening angle: @cpp Math::cos(angle/T(2)) @ce
-@param tanAngle Precomputed tangens of half the cone's opening angle: @cpp Math::tan(angle/T(2)) @ce
+@param sphereRadius Sphere radius
+@param coneView     View matrix with translation and rotation of the cone
+@param sinAngle     Precomputed sine of half the cone's opening angle
+@param cosAngle     Precomputed cosine of half the cone's opening angle
+@param tanAngle     Precomputed tangens of half the cone's opening angle
+@return @cpp true @ce if the sphere intersects the cone, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the sphere intersects the cone.
+Transforms the sphere center into cone space (using the cone view matrix) and
+performs sphere-cone intersection with the zero-origin -Z axis-aligned cone.
+The @p sinAngle, @p cosAngle, @p tanAngle can be precomputed like this:
+
+@code{.cpp}
+T sinAngle = Math::sin(angle*T(0.5));
+T cosAngle = Math::cos(angle*T(0.5));
+T tanAngle = Math::tan(angle*T(0.5));
+@endcode
 */
-template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T radius, const Matrix4<T>& coneView, T sinAngle, T cosAngle, T tanAngle);
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T sphereRadius, const Matrix4<T>& coneView, T sinAngle, T cosAngle, T tanAngle);
 
 /**
 @brief Intersection of a sphere and a cone
-@param sphereCenter   Sphere center
-@param radius Sphere  Sphere radius
-@param coneOrigin     Cone origin
-@param coneNormal     Cone normal
-@param coneAngle      Cone opening angle (@f$ 0 < \text{angle} < \pi @f$).
+@param sphereCenter Sphere center
+@param sphereRadius Sphere radius
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param coneAngle    Apex angle of the cone (@f$ 0 < \Theta < \pi @f$)
+@return @cpp true @ce if the sphere intersects with the cone, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the sphere intersects with the cone.
-
-Offsets the cone plane by @f$ -r\sin{\theta} \cdot \boldsymbol n @f$ (with  @f$ \theta @f$
-the cone's half-angle) which separates two half-spaces:
-In front of the plane, in which the sphere cone intersection test is equivalent
-to testing the sphere's center against a similarly offset cone (which is equivalent
-the cone with surface expanded by @f$ r @f$ in surface normal direction), and
-behind the plane, where the test is equivalent to testing whether the origin of
-the original cone intersects the sphere.
-
-Precomputes a portion of the intersection equation from @p angle and calls
-@ref sphereCone(const Vector3<T>& sphereCenter, T, const Vector3<T>&, const Vector3<T>&, T, T)
+Precomputes a portion of the intersection equation from @p coneAngle and calls
+@ref sphereCone(const Vector3<T>& sphereCenter, T, const Vector3<T>&, const Vector3<T>&, T, T).
 */
-template<class T> bool sphereCone(const Vector3<T>& sphereCenter, T radius, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
+template<class T> bool sphereCone(const Vector3<T>& sphereCenter, T sphereRadius, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
 
 /**
 @brief Intersection of a sphere and a cone using precomputed values
 @param sphereCenter Sphere center
-@param radius       Sphere radius
+@param sphereRadius Sphere radius
 @param coneOrigin   Cone origin
 @param coneNormal   Cone normal
-@param sinAngle     Precomputed sine of half the cone's opening angle:
-                    @cpp Math::sin(angle/T(2)) @ce
-@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
-                         @cpp Math::pow(Math::tan(angle/T(2)), 2) + 1 @ce
+@param sinAngle     Precomputed sine of half the cone's opening angle
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation
+@return @cpp true @ce if the sphere intersects with the cone, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the sphere intersects with the cone.
+Offsets the cone plane by @f$ -r\sin{\frac{\Theta}{2}} \cdot \boldsymbol n @f$
+(with @f$ \Theta @f$ being the cone apex angle) which separates two
+half-spaces: In front of the plane, in which the sphere cone intersection test
+is equivalent to testing the sphere's center against a similarly offset cone
+(which is equivalent the cone with surface expanded by @f$ r @f$ in surface
+normal direction), and behind the plane, where the test is equivalent to
+testing whether the origin of the original cone intersects the sphere. The
+@p sinAngle and @p tanAngleSqPlusOne parameters can be precomputed like this:
+
+@code{.cpp}
+T sinAngle = Math::sin(angle*T(0.5));
+T tanAngleSqPlusOne = Math::pow<2>(Math::tan(angle*T(0.5))) + T(1);
+@endcode
 */
-template<class T> bool sphereCone(const Vector3<T>& sphereCenter, T radius, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T sinAngle, T tanAngleSqPlusOne);
+template<class T> bool sphereCone(const Vector3<T>& sphereCenter, T sphereRadius, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T sinAngle, T tanAngleSqPlusOne);
 
 /**
 @brief Intersection of an axis aligned bounding box and a cone
-@param center      Center of the AABB
-@param extents     (Half-)extents of the AABB
-@param coneOrigin  Cone origin
-@param coneNormal  Cone normal
-@param coneAngle   Cone opening angle
+@param aabbCenter   Center of the AABB
+@param aabbExtents  (Half-)extents of the AABB
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param coneAngle    Apex angle of the cone (@f$ 0 < \Theta < \pi @f$)
+@return @cpp true @ce if the box intersects the cone, @cpp false @ce otherwise
 
-Returns @cpp true @ce if the axis aligned bounding box intersects the cone.
-
-On each axis finds the intersection points of the cone's axis with infinite planes
-obtained by extending the two faces of the box that are perpendicular to that axis.
-
-The intersection points on the planes perpendicular to axis @f$ a \in {0, 1, 2} @f$
-are given by @f[
-    \boldsymbol i = \boldsymbol n \cdot \frac{(\boldsymbol c_a - \boldsymbol o_a) \pm \boldsymbol e_a}{\boldsymbol n_a}
-@f]
-
-with normal @f$ n @f$, cone origin @f$ o @f$, box center @f$ x @f$ and box extents @f$ e @f$.
-
-The points on the faces that are closest to this intersection point are the closest
-to the cone's axis and are tested for intersection with the cone using
-@ref pointCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const T) "pointCone()".
-
-As soon as an intersecting point is found, the function returns @cpp true @ce.
-If all points lie outside of the cone, it will return @cpp false @ce.
-
-Precomputes a portion of the intersection equation from @p angle and calls
-@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T)
+Precomputes a portion of the intersection equation from @p coneAngle and calls
+@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T).
 */
-template<class T> bool aabbCone(const Vector3<T>& center, const Vector3<T>& extents, const Vector3<T>& origin, const Vector3<T>& normal, Rad<T> angle);
+template<class T> bool aabbCone(const Vector3<T>& aabbCenter, const Vector3<T>& aabbExtents, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, Rad<T> coneAngle);
 
 /**
 @brief Intersection of an axis aligned bounding box and a cone using precomputed values
-@param center Center of the AABB
-@param extents (Half-)extents of the AABB
-@param origin Cone origin
-@param normal Cone normal
-@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
-                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
+@param aabbCenter   Center of the AABB
+@param aabbExtents  (Half-)extents of the AABB
+@param coneOrigin   Cone origin
+@param coneNormal   Cone normal
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation
+@return @cpp true @ce if the box intersects the cone, @cpp false @ce otherwise
 
-Returns @cpp true @ce if the axis aligned bounding box intersects the cone.
+On each axis finds the intersection points of the cone's axis with infinite
+planes obtained by extending the two faces of the box that are perpendicular to
+that axis. The intersection points on the planes perpendicular to axis
+@f$ a \in \{ 0, 1, 2 \} @f$ are given by @f[
+    \boldsymbol i = \boldsymbol n \cdot \frac{(\boldsymbol c_a - \boldsymbol o_a) \pm \boldsymbol e_a}{\boldsymbol n_a}
+@f]
+
+with normal @f$ \boldsymbol n @f$, cone origin @f$ \boldsymbol o @f$, box
+center @f$ \boldsymbol c @f$ and box extents @f$ \boldsymbol e @f$. The points
+on the faces that are closest to this intersection point are the closest to the
+cone's axis and are tested for intersection with the cone using
+@ref pointCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const T) "pointCone()". As soon as an intersecting point is found, the function returns
+@cpp true @ce. If all points lie outside of the cone, it will return
+@cpp false @ce.
+
+The @p tanAngleSqPlusOne parameter can be precomputed like this:
+
+@code{.cpp}
+T tanAngleSqPlusOne = Math::pow<2>(Math::tan(angle*T(0.5))) + T(1);
+@endcode
 */
-template<class T> bool aabbCone(const Vector3<T>& center, const Vector3<T>& extents, const Vector3<T>& origin, const Vector3<T>& normal, T tanAngleSqPlusOne);
+template<class T> bool aabbCone(const Vector3<T>& aabbCenter, const Vector3<T>& aabbExtents, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, T tanAngleSqPlusOne);
 
 /**
 @brief Intersection of a range and a cone
-
 @param range        Range
 @param coneOrigin   Cone origin
 @param coneNormal   Cone normal
-@param coneAngle    Cone opening angle
+@param coneAngle    Apex angle of the cone (@f$ 0 < \Theta < \pi @f$)
+@return @cpp true @ce if the range intersects the cone, @cpp false @ce
+    otherwise
 
-Returns @cpp true @ce if the range intersects the cone.
-
-Converts the range into center/extents representation and passes it on to
-@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T) "aabbCone()".
+Precomputes a portion of the intersection equation from @p coneAngle and calls
+@ref rangeCone(const Range3D<T>&, const Vector3<T>&, const Vector3<T>&, T).
 */
-template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> angle);
+template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> coneAngle);
 
 /**
 @brief Intersection of a range and a cone using precomputed values
 @param range        Range
 @param coneOrigin   Cone origin
 @param coneNormal   Cone normal
-@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation:
-                         @cpp T(1) + Math::pow(Math::tan(angle/T(2)), T(2)) @ce
-
-Returns @cpp true @ce if the range intersects the cone.
+@param tanAngleSqPlusOne Precomputed portion of the cone intersection equation
+@return @cpp true @ce if the range intersects the cone, @cpp false @ce
+    otherwise
 
 Converts the range into center/extents representation and passes it on to
-@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T) "aabbCone()".
+@ref aabbCone(const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, const Vector3<T>&, T) "aabbCone()". The @p tanAngleSqPlusOne parameter can be precomputed like this:
+
+@code{.cpp}
+T tanAngleSqPlusOne = Math::pow<2>(Math::tan(angle*T(0.5))) + T(1);
+@endcode
 */
 template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne);
 
@@ -422,48 +445,42 @@ template<class T> bool pointFrustum(const Vector3<T>& point, const Frustum<T>& f
     return true;
 }
 
-template<class T> bool rangeFrustum(const Range3D<T>& box, const Frustum<T>& frustum) {
+template<class T> bool rangeFrustum(const Range3D<T>& range, const Frustum<T>& frustum) {
     /* Convert to center/extent, avoiding division by 2 and instead comparing
        to 2*-plane.w() later */
-    const Vector3<T> center = box.min() + box.max();
-    const Vector3<T> extent = box.max() - box.min();
+    const Vector3<T> center = range.min() + range.max();
+    const Vector3<T> extent = range.max() - range.min();
 
     for(const Vector4<T>& plane: frustum.planes()) {
         const Vector3<T> absPlaneNormal = Math::abs(plane.xyz());
 
         const Float d = Math::dot(center, plane.xyz());
         const Float r = Math::dot(extent, absPlaneNormal);
-        if(d + r < -T(2)*plane.w()) {
-            return false;
-        }
+        if(d + r < -T(2)*plane.w()) return false;
     }
 
     return true;
 }
 
-template<class T> bool aabbFrustum(
-    const Vector3<T>& center, const Vector3<T>& extents, const Frustum<T>& frustum)
-{
+template<class T> bool aabbFrustum(const Vector3<T>& aabbCenter, const Vector3<T>& aabbExtents, const Frustum<T>& frustum) {
     for(const Vector4<T>& plane: frustum.planes()) {
         const Vector3<T> absPlaneNormal = Math::abs(plane.xyz());
 
-        const Float d = Math::dot(center, plane.xyz());
-        const Float r = Math::dot(extents, absPlaneNormal);
-        if(d + r < -plane.w()) {
-            return false;
-        }
+        const Float d = Math::dot(aabbCenter, plane.xyz());
+        const Float r = Math::dot(aabbExtents, absPlaneNormal);
+        if(d + r < -plane.w()) return false;
     }
 
     return true;
 }
 
-template<class T> bool sphereFrustum(const Vector3<T>& center, const T radius, const Frustum<T>& frustum) {
-    const T radiusSq = radius*radius;
+template<class T> bool sphereFrustum(const Vector3<T>& sphereCenter, const T sphereRadius, const Frustum<T>& frustum) {
+    const T radiusSq = sphereRadius*sphereRadius;
 
     for(const Vector4<T>& plane: frustum.planes()) {
         /* The sphere is in front of one of the frustum planes (normals point
            outwards) */
-        if(Distance::pointPlaneScaled<T>(center, plane) < -radiusSq)
+        if(Distance::pointPlaneScaled<T>(sphereCenter, plane) < -radiusSq)
             return false;
     }
 
@@ -471,112 +488,114 @@ template<class T> bool sphereFrustum(const Vector3<T>& center, const T radius, c
 }
 
 
-template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const Rad<T> angle) {
-    const T x = T(1) + Math::pow(Math::tan(angle/T(2)), T(2));
-
-    return pointCone(p, origin, normal, x);
+template<class T> bool pointCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> coneAngle) {
+    const T tanAngleSqPlusOne = Math::pow<2>(Math::tan(coneAngle*T(0.5))) + T(1);
+    return pointCone(point, coneOrigin, coneNormal, tanAngleSqPlusOne);
 }
 
-template<class T> bool pointCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const T tanAngleSqPlusOne) {
-    const Vector3<T> c = p - origin;
-    const T lenA = dot(c, normal);
+template<class T> bool pointCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne) {
+    const Vector3<T> c = point - coneOrigin;
+    const T lenA = dot(c, coneNormal);
 
     return lenA >= 0 && c.dot() <= lenA*lenA*tanAngleSqPlusOne;
 }
 
-template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const Rad<T> angle) {
-    const T x = T(1) + Math::pow(Math::tan(angle/T(2)), T(2));
-
-    return pointDoubleCone(p, origin, normal, x);
+template<class T> bool pointDoubleCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> coneAngle) {
+    const T tanAngleSqPlusOne = Math::pow<2>(Math::tan(coneAngle*T(0.5))) + T(1);
+    return pointDoubleCone(point, coneOrigin, coneNormal, tanAngleSqPlusOne);
 }
 
-template<class T> bool pointDoubleCone(const Vector3<T>& p, const Vector3<T>& origin, const Vector3<T>& normal, const T tanAngleSqPlusOne) {
-    const Vector3<T> c = p - origin;
-    const T lenA = dot(c, normal);
+template<class T> bool pointDoubleCone(const Vector3<T>& point, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne) {
+    const Vector3<T> c = point - coneOrigin;
+    const T lenA = dot(c, coneNormal);
 
     return c.dot() <= lenA*lenA*tanAngleSqPlusOne;
 }
 
-template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, const T radius, const Matrix4<T>& coneView, const Rad<T> angle) {
-    const T sinAngle = Math::sin(angle/T(2));
-    const T cosAngle = Math::cos(angle/T(2));
-    const T tanAngle = Math::tan(angle/T(2));
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, const T sphereRadius, const Matrix4<T>& coneView, const Rad<T> coneAngle) {
+    const Rad<T> halfAngle = coneAngle*T(0.5);
+    const T sinAngle = Math::sin(halfAngle);
+    const T cosAngle = Math::cos(halfAngle);
+    const T tanAngle = Math::tan(halfAngle);
 
-    return sphereConeView(sphereCenter, radius, coneView, sinAngle, cosAngle, tanAngle);
+    return sphereConeView(sphereCenter, sphereRadius, coneView, sinAngle, cosAngle, tanAngle);
 }
 
 template<class T> bool sphereConeView(
-    const Vector3<T>& sphereCenter, const T radius, const Matrix4<T>& coneView,
+    const Vector3<T>& sphereCenter, const T sphereRadius, const Matrix4<T>& coneView,
     const T sinAngle, const T cosAngle, const T tanAngle)
 {
     CORRADE_ASSERT(coneView.isRigidTransformation(), "Math::Geometry::Intersection::sphereConeView(): coneView must be rigid", false);
 
-    /* Transform the sphere so that we can test against Z axis aligned origin cone instead */
+    /* Transform the sphere so that we can test against Z axis aligned origin
+       cone instead */
     const Vector3<T> center = coneView.transformPoint(sphereCenter);
 
-    /* Test against plane which determines whether to test against shifted cone or center-sphere */
-    if (-center.z() > -radius*sinAngle) {
-        /* Point - axis aligned cone test, shifted so that the cone's surface is extended by the radius of the sphere */
-        const T coneRadius = tanAngle*(center.z() - radius/sinAngle);
+    /* Test against plane which determines whether to test against shifted cone
+       or center-sphere */
+    if (-center.z() > -sphereRadius*sinAngle) {
+        /* Point - axis aligned cone test, shifted so that the cone's surface
+           is extended by the radius of the sphere */
+        const T coneRadius = tanAngle*(center.z() - sphereRadius/sinAngle);
         return center.xy().dot() <= coneRadius*coneRadius;
     } else {
         /* Simple sphere point check */
-        return center.dot() <= radius*radius;
+        return center.dot() <= sphereRadius*sphereRadius;
     }
 
     return false;
 }
 
 template<class T> bool sphereCone(
-    const Vector3<T>& sCenter, const T radius,
-    const Vector3<T>& origin, const Vector3<T>& normal, const Rad<T> angle)
+    const Vector3<T>& sphereCenter, const T sphereRadius,
+    const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> coneAngle)
 {
-    const T sinAngle = Math::sin(angle/T(2));
-    const T tanAngleSqPlusOne = T(1) + Math::pow<T>(Math::tan<T>(angle/T(2)), T(2));
+    const Rad<T> halfAngle = coneAngle*T(0.5);
+    const T sinAngle = Math::sin(halfAngle);
+    const T tanAngleSqPlusOne = T(1) + Math::pow<T>(Math::tan<T>(halfAngle), T(2));
 
-    return sphereCone(sCenter, radius, origin, normal, sinAngle, tanAngleSqPlusOne);
+    return sphereCone(sphereCenter, sphereRadius, coneOrigin, coneNormal, sinAngle, tanAngleSqPlusOne);
 }
 
 template<class T> bool sphereCone(
-    const Vector3<T>& sCenter, const T radius,
-    const Vector3<T>& origin, const Vector3<T>& normal,
+    const Vector3<T>& sphereCenter, const T sphereRadius,
+    const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal,
     const T sinAngle, const T tanAngleSqPlusOne)
 {
-    const Vector3<T> diff = sCenter - origin;
+    const Vector3<T> diff = sphereCenter - coneOrigin;
 
-    if (dot(diff - radius*sinAngle*normal, normal) > T(0)) {
-        /* point - cone test */
-        const Vector3<T> c = sinAngle*diff + normal*radius;
-        const T lenA = dot(c, normal);
+    /* Point - cone test */
+    if(Math::dot(diff - sphereRadius*sinAngle*coneNormal, coneNormal) > T(0)) {
+        const Vector3<T> c = sinAngle*diff + coneNormal*sphereRadius;
+        const T lenA = Math::dot(c, coneNormal);
 
-        return c.dot() <= lenA*lenA*(tanAngleSqPlusOne);
-    } else {
-        /* Simple sphere point check */
-        return diff.dot() <= radius*radius;
-    }
+        return c.dot() <= lenA*lenA*tanAngleSqPlusOne;
+
+    /* Simple sphere point check */
+    } else return diff.dot() <= sphereRadius*sphereRadius;
 }
 
 template<class T> bool aabbCone(
-    const Vector3<T>& center, const Vector3<T>& extents, const Vector3<T>& origin,
-    const Vector3<T>& normal, const Rad<T> angle)
+    const Vector3<T>& aabbCenter, const Vector3<T>& aabbExtents,
+    const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> coneAngle)
 {
-    const T x = T(1) + Math::pow<T>(Math::tan<T>(angle/T(2)), T(2));
-    return aabbCone(center, extents, origin, normal, x);
+    const T tanAngleSqPlusOne = Math::pow<T>(Math::tan<T>(coneAngle*T(0.5)), T(2)) + T(1);
+    return aabbCone(aabbCenter, aabbExtents, coneOrigin, coneNormal, tanAngleSqPlusOne);
 }
 
 template<class T> bool aabbCone(
-    const Vector3<T>& center, const Vector3<T>& extents,
+    const Vector3<T>& aabbCenter, const Vector3<T>& aabbExtents,
     const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne)
 {
-    const Vector3<T> c = center - coneOrigin;
+    const Vector3<T> c = aabbCenter - coneOrigin;
 
-    for (const Int axis: {0, 1, 2}) {
+    for(const Int axis: {0, 1, 2}) {
         const Int z = axis;
         const Int x = (axis + 1) % 3;
         const Int y = (axis + 2) % 3;
         if(coneNormal[z] != T(0)) {
-            Float t0 = ((c[z] - extents[z])/coneNormal[z]);
-            Float t1 = ((c[z] + extents[z])/coneNormal[z]);
+            const Float t0 = ((c[z] - aabbExtents[z])/coneNormal[z]);
+            const Float t1 = ((c[z] + aabbExtents[z])/coneNormal[z]);
 
             const Vector3<T> i0 = coneNormal*t0;
             const Vector3<T> i1 = coneNormal*t1;
@@ -584,42 +603,36 @@ template<class T> bool aabbCone(
             for(const auto& i : {i0, i1}) {
                 Vector3<T> closestPoint = i;
 
-                if(i[x] - c[x] > extents[x]) {
-                    closestPoint[x] = c[x] + extents[x];
-                } else if(i[x] - c[x] < -extents[x]) {
-                    closestPoint[x] = c[x] - extents[x];
-                }
-                /* Else: normal intersects within x bounds */
+                if(i[x] - c[x] > aabbExtents[x]) {
+                    closestPoint[x] = c[x] + aabbExtents[x];
+                } else if(i[x] - c[x] < -aabbExtents[x]) {
+                    closestPoint[x] = c[x] - aabbExtents[x];
+                } /* Else: normal intersects within x bounds */
 
-                if(i[y] - c[y] > extents[y]) {
-                    closestPoint[y] = c[y] + extents[y];
-                } else if(i[y] - c[y] < -extents[y]) {
-                    closestPoint[y] = c[y] - extents[y];
-                }
-                /* Else: normal intersects within Y bounds */
+                if(i[y] - c[y] > aabbExtents[y]) {
+                    closestPoint[y] = c[y] + aabbExtents[y];
+                } else if(i[y] - c[y] < -aabbExtents[y]) {
+                    closestPoint[y] = c[y] - aabbExtents[y];
+                } /* Else: normal intersects within Y bounds */
 
-                if (pointCone<T>(closestPoint, {}, coneNormal, tanAngleSqPlusOne)) {
-                    /* Found a point in cone and aabb */
+                /* Found a point in cone and aabb */
+                if(pointCone<T>(closestPoint, {}, coneNormal, tanAngleSqPlusOne))
                     return true;
-                }
             }
-        }
-        /* else: normal will intersect one of the other planes */
+        } /* Else: normal will intersect one of the other planes */
     }
 
     return false;
 }
 
-template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> angle) {
-    const Vector3<T> center = (range.min() + range.max())/T(2);
-    const Vector3<T> extents = (range.max() - range.min())/T(2);
-    const T x = T(1) + Math::pow<T>(Math::tan<T>(angle/T(2)), T(2));
-    return aabbCone(center, extents, coneOrigin, coneNormal, x);
+template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const Rad<T> coneAngle) {
+    const T tanAngleSqPlusOne = Math::pow<2>(Math::tan(coneAngle*T(0.5))) + T(1);
+    return rangeCone(range, coneOrigin, coneNormal, tanAngleSqPlusOne);
 }
 
 template<class T> bool rangeCone(const Range3D<T>& range, const Vector3<T>& coneOrigin, const Vector3<T>& coneNormal, const T tanAngleSqPlusOne) {
-    const Vector3<T> center = (range.min() + range.max())/T(2);
-    const Vector3<T> extents = (range.max() - range.min())/T(2);
+    const Vector3<T> center = (range.min() + range.max())*T(0.5);
+    const Vector3<T> extents = (range.max() - range.min())*T(0.5);
     return aabbCone(center, extents, coneOrigin, coneNormal, tanAngleSqPlusOne);
 }
 

--- a/src/Magnum/Math/Geometry/Intersection.h
+++ b/src/Magnum/Math/Geometry/Intersection.h
@@ -287,7 +287,7 @@ template<class T> bool pointDoubleCone(const Vector3<T>& point, const Vector3<T>
     otherwise
 
 Precomputes a portion of the intersection equation from @p coneAngle and calls
-@ref sphereConeView(const Vector3<T>&, T, const Matrix4<T>&, T, T, T).
+@ref sphereConeView(const Vector3<T>&, T, const Matrix4<T>&, T, T).
 */
 template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T sphereRadius, const Matrix4<T>& coneView, Rad<T> coneAngle);
 
@@ -297,8 +297,7 @@ template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T sphereRa
 @param sphereRadius Sphere radius
 @param coneView     View matrix with translation and rotation of the cone
 @param sinAngle     Precomputed sine of half the cone's opening angle
-@param cosAngle     Precomputed cosine of half the cone's opening angle
-@param tanAngle     Precomputed tangens of half the cone's opening angle
+@param tanAngle     Precomputed tangent of half the cone's opening angle
 @return @cpp true @ce if the sphere intersects the cone, @cpp false @ce
     otherwise
 
@@ -308,11 +307,10 @@ The @p sinAngle, @p cosAngle, @p tanAngle can be precomputed like this:
 
 @code{.cpp}
 T sinAngle = Math::sin(angle*T(0.5));
-T cosAngle = Math::cos(angle*T(0.5));
 T tanAngle = Math::tan(angle*T(0.5));
 @endcode
 */
-template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T sphereRadius, const Matrix4<T>& coneView, T sinAngle, T cosAngle, T tanAngle);
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, T sphereRadius, const Matrix4<T>& coneView, T sinAngle, T tanAngle);
 
 /**
 @brief Intersection of a sphere and a cone
@@ -515,16 +513,12 @@ template<class T> bool pointDoubleCone(const Vector3<T>& point, const Vector3<T>
 template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, const T sphereRadius, const Matrix4<T>& coneView, const Rad<T> coneAngle) {
     const Rad<T> halfAngle = coneAngle*T(0.5);
     const T sinAngle = Math::sin(halfAngle);
-    const T cosAngle = Math::cos(halfAngle);
     const T tanAngle = Math::tan(halfAngle);
 
-    return sphereConeView(sphereCenter, sphereRadius, coneView, sinAngle, cosAngle, tanAngle);
+    return sphereConeView(sphereCenter, sphereRadius, coneView, sinAngle, tanAngle);
 }
 
-template<class T> bool sphereConeView(
-    const Vector3<T>& sphereCenter, const T sphereRadius, const Matrix4<T>& coneView,
-    const T sinAngle, const T cosAngle, const T tanAngle)
-{
+template<class T> bool sphereConeView(const Vector3<T>& sphereCenter, const T sphereRadius, const Matrix4<T>& coneView, const T sinAngle, const T tanAngle) {
     CORRADE_ASSERT(coneView.isRigidTransformation(), "Math::Geometry::Intersection::sphereConeView(): coneView does not represent a rigid transformation", false);
 
     /* Transform the sphere so that we can test against Z axis aligned origin

--- a/src/Magnum/Math/Geometry/Intersection.h
+++ b/src/Magnum/Math/Geometry/Intersection.h
@@ -525,7 +525,7 @@ template<class T> bool sphereConeView(
     const Vector3<T>& sphereCenter, const T sphereRadius, const Matrix4<T>& coneView,
     const T sinAngle, const T cosAngle, const T tanAngle)
 {
-    CORRADE_ASSERT(coneView.isRigidTransformation(), "Math::Geometry::Intersection::sphereConeView(): coneView must be rigid", false);
+    CORRADE_ASSERT(coneView.isRigidTransformation(), "Math::Geometry::Intersection::sphereConeView(): coneView does not represent a rigid transformation", false);
 
     /* Transform the sphere so that we can test against Z axis aligned origin
        cone instead */

--- a/src/Magnum/Math/Geometry/Test/CMakeLists.txt
+++ b/src/Magnum/Math/Geometry/Test/CMakeLists.txt
@@ -27,8 +27,14 @@ corrade_add_test(MathGeometryDistanceTest DistanceTest.cpp LIBRARIES MagnumMathT
 target_compile_definitions(MathGeometryDistanceTest PRIVATE "CORRADE_GRACEFUL_ASSERT")
 
 corrade_add_test(MathGeometryIntersectionTest IntersectionTest.cpp LIBRARIES MagnumMathTestLib)
+corrade_add_test(MathGeometryIntersectionBenchmark IntersectionBenchmark.cpp LIBRARIES MagnumMathTestLib)
 
 set_target_properties(
     MathGeometryDistanceTest
     MathGeometryIntersectionTest
+    MathGeometryIntersectionBenchmark
     PROPERTIES FOLDER "Magnum/Math/Geometry/Test")
+
+set_property(TARGET
+    MathGeometryIntersectionTest
+    APPEND PROPERTY COMPILE_DEFINITIONS "CORRADE_GRACEFUL_ASSERT")

--- a/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
@@ -1,0 +1,222 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2018 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <Corrade/TestSuite/Tester.h>
+
+#include <random>
+#include <tuple>
+#include <utility>
+
+#include "Magnum/Math/Geometry/Intersection.h"
+#include "Magnum/Math/Angle.h"
+#include "Magnum/Math/Matrix4.h"
+
+namespace Magnum { namespace Math { namespace Geometry { namespace Test {
+
+template<class T> bool rangeFrustumNaive(const Math::Range3D<T>& box, const Math::Frustum<T>& frustum) {
+    for(const Math::Vector4<T>& plane: frustum.planes()) {
+        bool cornerHit = 0;
+
+        for(UnsignedByte c = 0; c != 8; ++c) {
+            const Math::Vector3<T> corner = Math::lerp(box.min(), box.max(), Math::BoolVector<3>{c});
+
+            if(Distance::pointPlaneScaled<T>(corner, plane) >= T(0)) {
+                cornerHit = true;
+                break;
+            }
+        }
+
+        /* All corners are outside this plane */
+        if(!cornerHit) return false;
+    }
+
+    return true;
+}
+
+/* @brief Ground truth, slow sphere cone intersection - calculating exact distances,
+ *        no optimizations, no precomputations
+ * @param sphereCenter Sphere center
+ * @param radius Sphere radius
+ * @param origin Origin of the cone
+ * @param normal Cone normal
+ * @param angle Cone opening angle (0 < angle < pi).
+ *
+ * Returns `true` if the sphere intersects with the cone. */
+template<class T> bool sphereConeGT(
+        const Math::Vector3<T>& sphereCenter, const T radius,
+        const Math::Vector3<T>& origin, const Math::Vector3<T>& normal, const Math::Rad<T> angle) {
+    const Math::Vector3<T> diff = sphereCenter - origin;
+    const Math::Vector3<T> dir = diff.normalized();
+    const Math::Rad<T> halfAngle = angle/T(2);
+
+    /* Compute angle between normal and point */
+    const Math::Rad<T> actual = Math::acos(dot(normal, dir));
+
+    /* Distance from cone surface */
+    const T distanceFromCone = Math::sin(actual - halfAngle)*diff.length();
+
+    /* Either the sphere center lies in cone, or cone is max radius away from the cone */
+    return actual <= halfAngle || distanceFromCone <= radius;
+}
+
+template<class T>
+Math::Matrix4<T> coneViewFromCone(const Math::Vector3<T>& origin, const Math::Vector3<T>& normal) {
+    return Math::Matrix4<T>::lookAt(origin, origin + normal, Math::Vector3<T>::yAxis()).inverted();
+}
+
+typedef Math::Vector2<Float> Vector2;
+typedef Math::Vector3<Float> Vector3;
+typedef Math::Vector4<Float> Vector4;
+typedef Math::Matrix4<Float> Matrix4;
+typedef Math::Frustum<Float> Frustum;
+typedef Math::Range3D<Float> Range3D;
+typedef Math::Deg<Float> Deg;
+typedef Math::Rad<Float> Rad;
+
+struct IntersectionBenchmark: Corrade::TestSuite::Tester {
+    explicit IntersectionBenchmark();
+
+    void rangeFrustumNaive();
+    void rangeFrustum();
+
+    void rangeCone();
+
+    void sphereFrustum();
+
+    void sphereConeNaive();
+    void sphereCone();
+    void sphereConeView();
+
+    Frustum _frustum;
+    std::tuple<Vector3, Vector3, Rad> _cone;
+    Matrix4 _coneView;
+
+    std::vector<Range3D> _boxes;
+    std::vector<Vector4> _spheres;
+};
+
+IntersectionBenchmark::IntersectionBenchmark() {
+    addBenchmarks({&IntersectionBenchmark::rangeFrustumNaive,
+                   &IntersectionBenchmark::rangeFrustum,
+
+                   &IntersectionBenchmark::rangeCone,
+
+                   &IntersectionBenchmark::sphereFrustum,
+
+                   &IntersectionBenchmark::sphereConeNaive,
+                   &IntersectionBenchmark::sphereCone,
+                   &IntersectionBenchmark::sphereConeView}, 25);
+
+    /* Generate random data for the benchmarks */
+    std::random_device rnd;
+    std::mt19937 g(rnd());
+    /* Position distribution */
+    std::uniform_real_distribution<float> pd(-10.0f, 10.0f);
+    /* Cone angle distribution */
+    std::uniform_real_distribution<float> ad(1.0f, 179.0f);
+
+    _cone = std::make_tuple(Vector3{pd(g), pd(g), pd(g)},
+                Vector3{pd(g), pd(g), pd(g)}.normalized(),
+                Rad(Deg(ad(g))));
+    _coneView = coneViewFromCone(std::get<0>(_cone), std::get<1>(_cone));
+    _frustum = Frustum::fromMatrix(_coneView*Matrix4::perspectiveProjection(std::get<2>(_cone), 1.0f, 0.001f, 100.0f));
+
+    _boxes.reserve(512);
+    _spheres.reserve(512);
+    for(int i = 0; i < 512; ++i) {
+        Vector3 center{pd(g), pd(g), pd(g)};
+        Vector3 extents{pd(g), pd(g), pd(g)};
+        _boxes.emplace_back(center - extents, center + extents);
+        _spheres.emplace_back(center, extents.length());
+    }
+}
+
+void IntersectionBenchmark::rangeFrustumNaive() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) for(auto& box: _boxes) {
+        b = b ^ Test::rangeFrustumNaive<Float>(box, _frustum);
+    }
+}
+
+void IntersectionBenchmark::rangeFrustum() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) for(auto& box: _boxes) {
+        b = b ^ Intersection::rangeFrustum(box, _frustum);
+    }
+}
+
+void IntersectionBenchmark::rangeCone() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) {
+        const Float tanAngle = Math::tan(std::get<2>(_cone));
+        const Float tanAngleSqPlusOne = tanAngle*tanAngle + 1.0f;
+        for(auto& box: _boxes) {
+            b = b ^ Intersection::rangeCone(box, std::get<0>(_cone), std::get<1>(_cone), tanAngleSqPlusOne);
+        }
+    }
+}
+
+void IntersectionBenchmark::sphereFrustum() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) for(auto& sphere: _spheres) {
+        b = b ^ Intersection::sphereFrustum(sphere.xyz(), sphere.w(), _frustum);
+    }
+}
+
+void IntersectionBenchmark::sphereConeNaive() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) for(auto& sphere: _spheres) {
+        b = b ^ sphereConeGT<Float>(sphere.xyz(), sphere.w(), std::get<0>(_cone), std::get<1>(_cone), std::get<2>(_cone));
+    }
+}
+
+void IntersectionBenchmark::sphereCone() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) {
+        const Float sinAngle = Math::sin(std::get<2>(_cone));
+        const Float tanAngle = Math::tan(std::get<2>(_cone));
+        const Float tanAngleSqPlusOne = tanAngle*tanAngle + 1.0f;
+        for(auto& sphere: _spheres) {
+            b = b ^ Intersection::sphereCone(sphere.xyz(), sphere.w(), std::get<0>(_cone), std::get<1>(_cone), sinAngle, tanAngleSqPlusOne);
+        }
+    }
+}
+
+void IntersectionBenchmark::sphereConeView() {
+    volatile bool b = false;
+    CORRADE_BENCHMARK(50) {
+        const Float sinAngle = Math::sin(std::get<2>(_cone));
+        const Float cosAngle = Math::cos(std::get<2>(_cone));
+        const Float tanAngle = Math::tan(std::get<2>(_cone));
+        for(auto& sphere: _spheres) {
+            b = b ^ Intersection::sphereConeView(sphere.xyz(), sphere.w(), _coneView, sinAngle, cosAngle, tanAngle);
+        }
+    }
+}
+
+}}}}
+
+CORRADE_TEST_MAIN(Magnum::Math::Geometry::Test::IntersectionBenchmark)

--- a/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
@@ -212,10 +212,9 @@ void IntersectionBenchmark::sphereConeView() {
     volatile bool b = false;
     CORRADE_BENCHMARK(50) {
         const Float sinAngle = Math::sin(std::get<2>(_cone));
-        const Float cosAngle = Math::cos(std::get<2>(_cone));
         const Float tanAngle = Math::tan(std::get<2>(_cone));
         for(auto& sphere: _spheres) {
-            b = b ^ Intersection::sphereConeView(sphere.xyz(), sphere.w(), _coneView, sinAngle, cosAngle, tanAngle);
+            b = b ^ Intersection::sphereConeView(sphere.xyz(), sphere.w(), _coneView, sinAngle, tanAngle);
         }
     }
 }

--- a/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
@@ -24,11 +24,10 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <Corrade/TestSuite/Tester.h>
-
 #include <random>
 #include <tuple>
 #include <utility>
+#include <Corrade/TestSuite/Tester.h>
 
 #include "Magnum/Math/Geometry/Intersection.h"
 #include "Magnum/Math/Angle.h"
@@ -56,15 +55,18 @@ template<class T> bool rangeFrustumNaive(const Math::Range3D<T>& box, const Math
     return true;
 }
 
-/* @brief Ground truth, slow sphere cone intersection - calculating exact distances,
- *        no optimizations, no precomputations
- * @param sphereCenter Sphere center
- * @param radius Sphere radius
- * @param origin Origin of the cone
- * @param normal Cone normal
- * @param angle Cone opening angle (0 < angle < pi).
- *
- * Returns `true` if the sphere intersects with the cone. */
+/*
+    Ground truth, slow sphere cone intersection - calculating exact distances,
+    no optimizations, no precomputations
+
+    sphereCenter     Sphere center
+    radius           Sphere radius
+    origin           Origin of the cone
+    normal           Cone normal
+    angle            Cone opening angle (0 < angle < pi)
+
+    Returns true if the sphere intersects with the cone.
+*/
 template<class T> bool sphereConeGT(
         const Math::Vector3<T>& sphereCenter, const T radius,
         const Math::Vector3<T>& origin, const Math::Vector3<T>& normal, const Math::Rad<T> angle) {
@@ -78,7 +80,8 @@ template<class T> bool sphereConeGT(
     /* Distance from cone surface */
     const T distanceFromCone = Math::sin(actual - halfAngle)*diff.length();
 
-    /* Either the sphere center lies in cone, or cone is max radius away from the cone */
+    /* Either the sphere center lies in cone, or cone is max radius away from
+       the cone */
     return actual <= halfAngle || distanceFromCone <= radius;
 }
 

--- a/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionBenchmark.cpp
@@ -131,7 +131,7 @@ IntersectionBenchmark::IntersectionBenchmark() {
 
                    &IntersectionBenchmark::sphereConeNaive,
                    &IntersectionBenchmark::sphereCone,
-                   &IntersectionBenchmark::sphereConeView}, 25);
+                   &IntersectionBenchmark::sphereConeView}, 10);
 
     /* Generate random data for the benchmarks */
     std::random_device rnd;

--- a/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
@@ -230,6 +230,9 @@ void IntersectionTest::pointCone() {
     auto surface = Matrix4::rotation(0.5f*angle, axis).transformVector(normal);
     /* Normal on the curved surface */
     auto sNormal = Matrix4::rotation(90.0_degf, axis).transformVector(surface);
+    /* Same for Double precision */
+    auto axisDouble = Math::cross(Vector3d::yAxis(), normalDouble).normalized();
+    auto surfaceDouble = Matrix4d::rotation(0.5*angleDouble, axisDouble).transformVector(normalDouble);
 
     /* Point on edge */
     CORRADE_VERIFY(Intersection::pointCone(center, center, normal, angle));
@@ -240,6 +243,12 @@ void IntersectionTest::pointCone() {
     CORRADE_VERIFY(!Intersection::pointCone(center + 5.0f*surface + 0.01f*sNormal, center, normal, angle));
     /* Point behind the cone plane */
     CORRADE_VERIFY(!Intersection::pointCone(-normal, center, normal, angle));
+
+    /* Point touching cone */
+    {
+        CORRADE_EXPECT_FAIL("Point touching cone fails, possibly because of precision.");
+        CORRADE_VERIFY(Intersection::pointCone(centerDouble, centerDouble + surfaceDouble, normalDouble, angleDouble));
+    }
 }
 
 void IntersectionTest::pointDoubleCone() {

--- a/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
@@ -378,28 +378,33 @@ void IntersectionTest::rangeCone() {
     const Rad angle{72.0_degf};
 
     /* Box fully inside cone */
-    CORRADE_VERIFY(Intersection::rangeCone(Range3D::fromSize(15.0f*normal - Vector3{1.0f}, Vector3{2.0f}),
-                                           center, normal, angle));
+    CORRADE_VERIFY(Intersection::rangeCone(Range3D::fromSize(
+        15.0f*normal - Vector3{1.0f}, Vector3{2.0f}), center, normal, angle));
     /* Box intersecting cone */
-    CORRADE_VERIFY(Intersection::rangeCone(Range3D::fromSize(5.0f*normal - Vector3{10.0f, 10.0f, 0.5f}, Vector3{20.0f, 20.0f, 1.0f}),
-                                           center, normal, angle));
-    CORRADE_VERIFY(Intersection::rangeCone(Range3D{{-1.0f, -2.0f, -3.0f}, {1.0f, 2.0f, 3.0f}},
-                                           center, normal, angle));
+    CORRADE_VERIFY(Intersection::rangeCone(Range3D::fromSize(
+        5.0f*normal - Vector3{10.0f, 10.0f, 0.5f}, Vector3{20.0f, 20.0f, 1.0f}),
+        center, normal, angle));
+    CORRADE_VERIFY(Intersection::rangeCone(
+        Range3D{{-1.0f, -2.0f, -3.0f}, {1.0f, 2.0f, 3.0f}}, center, normal, angle));
     /* Cone inside large box */
-    CORRADE_VERIFY(Intersection::rangeCone(Range3D::fromSize(12.0f*normal - Vector3{20.0f}, Vector3{40.0f}),
-                                           center, normal, angle));
+    CORRADE_VERIFY(Intersection::rangeCone(Range3D::fromSize(
+        12.0f*normal - Vector3{20.0f}, Vector3{40.0f}), center, normal, angle));
     /* Same corner chosen on all intersecting faces */
-    CORRADE_VERIFY(Intersection::rangeCone(Range3D{{2.0f, -0.1f, -1.5f}, {3.0f, 0.1f, 1.5f}},
-                                           center, {0.353553f, 0.707107f, 0.612372f}, angle));
+    CORRADE_VERIFY(Intersection::rangeCone(
+        Range3D{{2.0f, -0.1f, -1.5f}, {3.0f, 0.1f, 1.5f}},
+        center, {0.353553f, 0.707107f, 0.612372f}, angle));
 
     /* Boxes outside cone */
-    CORRADE_VERIFY(!Intersection::rangeCone(Range3D{Vector3{2.0f, 2.0f, -2.0f}, Vector3{8.0f, 7.0f, 2.0f}},
-                                            center, normal, angle));
-    CORRADE_VERIFY(!Intersection::rangeCone(Range3D{Vector3{6.0f, 5.0f, -7.0f}, Vector3{5.0f, 9.0f, -3.0f}},
-                                            center, normal, angle));
+    CORRADE_VERIFY(!Intersection::rangeCone(
+        Range3D{Vector3{2.0f, 2.0f, -2.0f}, Vector3{8.0f, 7.0f, 2.0f}},
+        center, normal, angle));
+    CORRADE_VERIFY(!Intersection::rangeCone(
+        Range3D{Vector3{6.0f, 5.0f, -7.0f}, Vector3{5.0f, 9.0f, -3.0f}},
+        center, normal, angle));
     /* Box fully contained in double cone */
-    CORRADE_VERIFY(!Intersection::rangeCone(Range3D::fromSize(-15.0f*normal - Vector3{1.0f}, Vector3{2.0f}),
-                                            center, normal, angle));
+    CORRADE_VERIFY(!Intersection::rangeCone(
+        Range3D::fromSize(-15.0f*normal - Vector3{1.0f}, Vector3{2.0f}),
+        center, normal, angle));
 }
 
 void IntersectionTest::aabbCone() {

--- a/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
@@ -308,6 +308,8 @@ void IntersectionTest::sphereCone() {
     {
         #ifndef CORRADE_TARGET_EMSCRIPTEN
         CORRADE_EXPECT_FAIL("Cone touching from the outside fails, possibly because of precision.");
+        #else
+        CORRADE_EXPECT_FAIL_IF(!Intersection::sphereCone(centerDouble + 4.0*surfaceDouble + sNormalDouble*0.5, 0.5, centerDouble, normalDouble, angleDouble), "Cone touching from the outside fails on optimized Emscripten builds, possibly because of precision.");
         #endif
         CORRADE_VERIFY(Intersection::sphereCone(centerDouble + 4.0*surfaceDouble + sNormalDouble*0.5, 0.5, centerDouble, normalDouble, angleDouble));
     }

--- a/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
+++ b/src/Magnum/Math/Geometry/Test/IntersectionTest.cpp
@@ -369,7 +369,7 @@ void IntersectionTest::sphereConeView() {
     Error redirectError{&out};
 
     CORRADE_VERIFY(!Intersection::sphereConeView(center, 1.0f, Matrix4{ZeroInit}, angle));
-    CORRADE_COMPARE(out.str(), "Math::Geometry::Intersection::sphereConeView(): coneView must be rigid\n");
+    CORRADE_COMPARE(out.str(), "Math::Geometry::Intersection::sphereConeView(): coneView does not represent a rigid transformation\n");
 }
 
 void IntersectionTest::rangeCone() {


### PR DESCRIPTION
Hi @mosra !

As discussed per gitter, I started working on some culling math for a project at university. This pullrequest will add cleanly tested implementations for:

 - [x] `Math::Geometry::Intersection::sphereFrustum`
 - [x] Improve `Math::Geometry::Intersection::boxFrustum`
     - [x] Deprecate and rename to `Math::Geometry::Intersection::rangeFrustum`
     - [x] Split and add to`Math::Geometry::Intersection::aabbFrustum`
 - [x] `Math::Geometry::Intersection::pointCone`
 - [x] `Math::Geometry::Intersection::pointDoubleCone`
 - [x] `Math::Geometry::Intersection::sphereCone`
 - [x] `Math::Geometry::Intersection::rangeCone`
 - ~~(Maybe `Math::Geometry::Intersection::triangleCone`, even though it's not really useful for culling)~~

Cheers, Jonathan

___

~~Plus batch intersection methods for:~~ (not part of this PR, progress backed up in [separate branch](https://github.com/Squareys/magnum/tree/culling-math-batch) )
 - [x] ~~Range - Frustum~~
 - ~~Range - Cone~~
 - [x] ~~Sphere - Frustum~~ Batching does not seem to yield improvements with array of structures
 - ~~Sphere - Cone~~

~~Should I put them into a separate file? And/or separate `Batch::` namespace?~~ Discussed: `IntersectionBatch.h/.cpp` and same namespace.