### PR TITLE
Zero-copy importer plugin APIs

### DIFF
--- a/doc/snippets/MagnumTrade.cpp
+++ b/doc/snippets/MagnumTrade.cpp
@@ -180,6 +180,24 @@ importer->openFile("scene.gltf"); // memory-maps all files
 }
 #endif
 
+#if defined(CORRADE_TARGET_UNIX) || (defined(CORRADE_TARGET_WINDOWS) && !defined(CORRADE_TARGET_WINDOWS_RT))
+{
+Containers::Pointer<Trade::AbstractImporter> importer;
+/* [AbstractImporter-usage-zerocopy] */
+importer->addFlags(Trade::ImporterFlag::ZeroCopy);
+
+Containers::Array<const char, Utility::Directory::MapDeleter> memory;
+if(!(memory = Utility::Directory::mapRead("huge-file.gltf")) ||
+   !importer->openMemory(memory))
+    Fatal{} << "Can't memory-map and open the file";
+
+/* Depending on the importer, the actual vertex/index data will get paged from
+   the above file into the physical memory only once you actually access them */
+Containers::Optional<Trade::MeshData> mesh = importer->mesh("huge-cathedral");
+/* [AbstractImporter-usage-zerocopy] */
+}
+#endif
+
 {
 Containers::Pointer<Trade::AbstractImporter> importer;
 Int materialIndex;

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -98,6 +98,30 @@ AbstractImporter::AbstractImporter(PluginManager::AbstractManager& manager, cons
 void AbstractImporter::setFlags(ImporterFlags flags) {
     CORRADE_ASSERT(!isOpened(),
         "Trade::AbstractImporter::setFlags(): can't be set while a file is opened", );
+    #ifndef CORRADE_NO_ASSERT
+    /* Separating the common string prefix in a hope that the compiler
+       deduplicates the literals to reduce binary size. There's probably also a
+       fancy loop-ish way to do this if we'd have the same binary value for the
+       features and flags but it's Sunday evening and my brain capacity is
+       limited. */
+    const ImporterFeatures features = this->features();
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopyAnimations) || (features & ImporterFeature::ZeroCopyAnimations),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "animations", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopyImages) || (features & ImporterFeature::ZeroCopyImages),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "images", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopyMaterialAttributes) || (features & ImporterFeature::ZeroCopyMaterialAttributes),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "material attributes", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopyMaterialLayers) || (features & ImporterFeature::ZeroCopyMaterialLayers),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "material layers", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopyMeshIndices) || (features & ImporterFeature::ZeroCopyMeshIndices),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "mesh indices", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopyMeshVertices) || (features & ImporterFeature::ZeroCopyMeshVertices),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "mesh vertices", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopySkinJoints) || (features & ImporterFeature::ZeroCopySkinJoints),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "skin joints", );
+    CORRADE_ASSERT(!(flags >= ImporterFlag::ForceZeroCopySkinInverseBindMatrices) || (features & ImporterFeature::ZeroCopySkinInverseBindMatrices),
+        "Trade::AbstractImporter::setFlags(): importer doesn't support zero-copy" << "skin inverse bind matrices", );
+    #endif
     _flags = flags;
     doSetFlags(flags);
 }
@@ -1155,11 +1179,19 @@ Debug& operator<<(Debug& debug, const ImporterFeature value) {
         _c(OpenData)
         _c(OpenState)
         _c(FileCallback)
+        _c(ZeroCopyAnimations)
+        _c(ZeroCopyImages)
+        _c(ZeroCopyMaterialAttributes)
+        _c(ZeroCopyMaterialLayers)
+        _c(ZeroCopyMeshIndices)
+        _c(ZeroCopyMeshVertices)
+        _c(ZeroCopySkinJoints)
+        _c(ZeroCopySkinInverseBindMatrices)
         #undef _c
         /* LCOV_EXCL_STOP */
     }
 
-    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedByte(value)) << Debug::nospace << ")";
+    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedShort(value)) << Debug::nospace << ")";
 }
 
 Debug& operator<<(Debug& debug, const ImporterFeatures value) {
@@ -1177,17 +1209,33 @@ Debug& operator<<(Debug& debug, const ImporterFlag value) {
         #define _c(v) case ImporterFlag::v: return debug << "::" #v;
         _c(Verbose)
         _c(ZeroCopy)
+        _c(ForceZeroCopyAnimations)
+        _c(ForceZeroCopyImages)
+        _c(ForceZeroCopyMaterialAttributes)
+        _c(ForceZeroCopyMaterialLayers)
+        _c(ForceZeroCopyMeshIndices)
+        _c(ForceZeroCopyMeshVertices)
+        _c(ForceZeroCopySkinJoints)
+        _c(ForceZeroCopySkinInverseBindMatrices)
         #undef _c
         /* LCOV_EXCL_STOP */
     }
 
-    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedByte(value)) << Debug::nospace << ")";
+    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedShort(value)) << Debug::nospace << ")";
 }
 
 Debug& operator<<(Debug& debug, const ImporterFlags value) {
     return Containers::enumSetDebugOutput(debug, value, "Trade::ImporterFlags{}", {
         ImporterFlag::Verbose,
-        ImporterFlag::ZeroCopy});
+        ImporterFlag::ZeroCopy,
+        ImporterFlag::ForceZeroCopyAnimations,
+        ImporterFlag::ForceZeroCopyImages,
+        ImporterFlag::ForceZeroCopyMaterialAttributes,
+        ImporterFlag::ForceZeroCopyMaterialLayers,
+        ImporterFlag::ForceZeroCopyMeshIndices,
+        ImporterFlag::ForceZeroCopyMeshVertices,
+        ImporterFlag::ForceZeroCopySkinJoints,
+        ImporterFlag::ForceZeroCopySkinInverseBindMatrices});
 }
 
 }}

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -1176,6 +1176,7 @@ Debug& operator<<(Debug& debug, const ImporterFlag value) {
         /* LCOV_EXCL_START */
         #define _c(v) case ImporterFlag::v: return debug << "::" #v;
         _c(Verbose)
+        _c(ZeroCopy)
         #undef _c
         /* LCOV_EXCL_STOP */
     }
@@ -1185,7 +1186,8 @@ Debug& operator<<(Debug& debug, const ImporterFlag value) {
 
 Debug& operator<<(Debug& debug, const ImporterFlags value) {
     return Containers::enumSetDebugOutput(debug, value, "Trade::ImporterFlags{}", {
-        ImporterFlag::Verbose});
+        ImporterFlag::Verbose,
+        ImporterFlag::ZeroCopy});
 }
 
 }}

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -147,7 +147,7 @@ void AbstractImporter::setFileCallback(Containers::Optional<Containers::ArrayVie
 
 void AbstractImporter::doSetFileCallback(Containers::Optional<Containers::ArrayView<const char>>(*)(const std::string&, InputFileCallbackPolicy, void*), void*) {}
 
-bool AbstractImporter::openData(Containers::ArrayView<const void> data) {
+bool AbstractImporter::openData(Containers::Array<char>&& data, const DataFlags dataFlags) {
     CORRADE_ASSERT(features() & ImporterFeature::OpenData,
         "Trade::AbstractImporter::openData(): feature not supported", {});
 
@@ -155,8 +155,12 @@ bool AbstractImporter::openData(Containers::ArrayView<const void> data) {
        the check doesn't be done on the plugin side) because for some file
        formats it could be valid (e.g. OBJ or JSON-based formats). */
     close();
-    doOpenData(Containers::Array<char>{const_cast<char*>(static_cast<const char*>(data.data())), data.size(), Implementation::nonOwnedArrayDeleter}, {});
+    doOpenData(std::move(data), dataFlags);
     return isOpened();
+}
+
+bool AbstractImporter::openData(Containers::ArrayView<const void> data) {
+    return openData(Containers::Array<char>{const_cast<char*>(static_cast<const char*>(data.data())), data.size(), Implementation::nonOwnedArrayDeleter}, {});
 }
 
 #ifdef MAGNUM_BUILD_DEPRECATED

--- a/src/Magnum/Trade/AbstractImporter.h
+++ b/src/Magnum/Trade/AbstractImporter.h
@@ -48,7 +48,7 @@ namespace Magnum { namespace Trade {
 
 @see @ref ImporterFeatures, @ref AbstractImporter::features()
 */
-enum class ImporterFeature: UnsignedByte {
+enum class ImporterFeature: UnsignedShort {
     /**
      * Opening files from raw data or non-temporary memory using
      * @ref AbstractImporter::openData() or
@@ -68,7 +68,121 @@ enum class ImporterFeature: UnsignedByte {
      * See @ref Trade-AbstractImporter-usage-callbacks and particular importer
      * documentation for more information.
      */
-    FileCallback = 1 << 2
+    FileCallback = 1 << 2,
+
+    /**
+     * Importing animations without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the animation data doesn't need
+     * to be processed in any way during the import,
+     * @ref AbstractImporter::animation() will then return an
+     * @ref AnimationData that's a view on the memory passed to
+     * @relativeref{AbstractImporter,openMemory()}, indicated with
+     * @ref DataFlag::ExternallyOwned in @ref AnimationData::dataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopyAnimations
+     * @m_since_latest
+     */
+    ZeroCopyAnimations = 1 << 3,
+
+    /**
+     * Importing images without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the image data doesn't need to be
+     * processed in any way during the import,
+     * @ref AbstractImporter::image1D() / @relativeref{AbstractImporter,image2D()}
+     * / @relativeref{AbstractImporter,image3D()} will then return an
+     * @ref ImageData that's a view on the memory passed to
+     * @relativeref{AbstractImporter,openMemory()}, indicated with
+     * @ref DataFlag::ExternallyOwned in @ref ImageData::dataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopyImages
+     * @m_since_latest
+     */
+    ZeroCopyImages = 1 << 4,
+
+    /**
+     * Importing material attributes without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the material attribute data
+     * doesn't need to be processed in any way during the import,
+     * @ref AbstractImporter::material() will then return a
+     * @ref MaterialData with attributes being a view on the memory passed to
+     * @relativeref{AbstractImporter,openMemory()}, indicated with
+     * @ref DataFlag::ExternallyOwned in @ref MaterialData::attributeDataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopyMaterialAttributes
+     * @m_since_latest
+     */
+    ZeroCopyMaterialAttributes = 1 << 5,
+
+    /**
+     * Importing material layers without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the material layer data doesn't
+     * need to be processed in any way during the import,
+     * @ref AbstractImporter::material() will then return a
+     * @ref MaterialData with layers being a view on the memory passed to
+     * @relativeref{AbstractImporter,openMemory()}, indicated with
+     * @ref DataFlag::ExternallyOwned in @ref MaterialData::layerDataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopyMaterialLayers
+     * @m_since_latest
+     */
+    ZeroCopyMaterialLayers = 1 << 6,
+
+    /**
+     * Importing mesh indices without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the mesh index data doesn't need
+     * to be processed in any way during the import,
+     * @ref AbstractImporter::mesh() will then return a @ref MeshData with
+     * indices being a view on the memory passed to
+     * @relativeref{AbstractImporter,openMemory()}, indicated with
+     * @ref DataFlag::ExternallyOwned in @ref MeshData::indexDataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopyMeshIndices
+     * @m_since_latest
+     */
+    ZeroCopyMeshIndices = 1 << 7,
+
+    /**
+     * Importing mesh vertices without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the mesh vertex data doesn't need
+     * to be processed in any way during the import,
+     * @ref AbstractImporter::mesh() will then return a @ref MeshData with
+     * vertices being a view on the memory passed to
+     * @relativeref{AbstractImporter,openMemory()}, indicated with
+     * @ref DataFlag::ExternallyOwned in @ref MeshData::vertexDataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopyMeshVertices
+     * @m_since_latest
+     */
+    ZeroCopyMeshVertices = 1 << 8,
+
+    /**
+     * Importing skin joints without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the skin joint data doesn't need
+     * to be processed in any way during the import,
+     * @ref AbstractImporter::skin2D() / @relativeref{AbstractImporter,skin3D()}
+     * will then return a @ref SkinData with vertices being a view on the
+     * memory passed to @relativeref{AbstractImporter,openMemory()}, indicated
+     * with @ref DataFlag::ExternallyOwned in @ref SkinData::jointDataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopySkinJoints
+     * @m_since_latest
+     */
+    ZeroCopySkinJoints = 1 << 9,
+
+    /**
+     * Importing skin inverse bind matrices without data copies. If the
+     * @ref AbstractImporter::openMemory() function is used,
+     * @ref ImporterFlag::ZeroCopy is set and the skin joint data doesn't need
+     * to be processed in any way during the import,
+     * @ref AbstractImporter::skin2D() / @relativeref{AbstractImporter,skin3D()}
+     * will then return a @ref SkinData with vertices being a view on the
+     * memory passed to @relativeref{AbstractImporter,openMemory()}, indicated
+     * with @ref DataFlag::ExternallyOwned in
+     * @ref SkinData::inverseBindMatrixDataFlags().
+     * @see @ref ImporterFlag::ForceZeroCopySkinInverseBindMatrices
+     * @m_since_latest
+     */
+    ZeroCopySkinInverseBindMatrices = 1 << 10
 };
 
 /**
@@ -100,7 +214,7 @@ typedef CORRADE_DEPRECATED("use InputFileCallbackPolicy instead") InputFileCallb
 
 @see @ref ImporterFlags, @ref AbstractImporter::setFlags()
 */
-enum class ImporterFlag: UnsignedByte {
+enum class ImporterFlag: UnsignedShort {
     /**
      * Print verbose diagnostic during import. By default the importer only
      * prints messages on error or when some operation might cause unexpected
@@ -134,6 +248,122 @@ enum class ImporterFlag: UnsignedByte {
      * @m_since_latest
      */
     ZeroCopy = 1 << 1,
+
+    /**
+     * Force zero-copy import of animation data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopyAnimations.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::animation() to fail
+     * if it can't perform a zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopyAnimations = ZeroCopy|(1 << 2),
+
+    /**
+     * Force zero-copy import of image data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopyImages.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::image1D() /
+     * @relativeref{AbstractImporter,image2D()} /
+     * @relativeref{AbstractImporter,image3D()} to fail if it can't perform a
+     * zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopyImages = ZeroCopy|(1 << 3),
+
+    /**
+     * Force zero-copy import of material attribute data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopyMaterialAttributes.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::material() to fail
+     * if it can't perform a zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopyMaterialAttributes = ZeroCopy|(1 << 4),
+
+    /**
+     * Force zero-copy import of material layer data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopyMaterialLayers.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::material() to fail
+     * if it can't perform a zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopyMaterialLayers = ZeroCopy|(1 << 5),
+
+    /**
+     * Force zero-copy import of mesh index data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopyMeshIndices.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::mesh() to fail if it
+     * can't perform a zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopyMeshIndices = ZeroCopy|(1 << 6),
+
+    /**
+     * Force zero-copy import of mesh vertex data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopyMeshVertices.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::mesh() to fail if it
+     * can't perform a zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopyMeshVertices = ZeroCopy|(1 << 7),
+
+    /**
+     * Force zero-copy import of skin joint data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopySkinJoints.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::skin2D() /
+     * @relativeref{AbstractImporter,skin3D()} to fail if it can't perform a
+     * zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopySkinJoints = ZeroCopy|(1 << 8),
+
+    /**
+     * Force zero-copy import of skin inverse bind matrix data opened through
+     * @ref AbstractImporter::openMemory(). Implies
+     * @ref ImporterFlag::ZeroCopy, can be set only if the importer supports
+     * @ref ImporterFeature::ZeroCopySkinInverseBindMatrices.
+     *
+     * By default, if the data has to be processed in some way, preventing
+     * zero-copy import, the importer will return a modified copy of the data.
+     * Setting this flag will cause @ref AbstractImporter::skin2D() /
+     * @relativeref{AbstractImporter,skin3D()} to fail if it can't perform a
+     * zero-copy import.
+     * @m_since_latest
+     */
+    ForceZeroCopySkinInverseBindMatrices = ZeroCopy|(1 << 9)
 
     /** @todo ~~Y flip~~ Y up for images, "I want to import just once, don't copy" ... */
 };

--- a/src/Magnum/Trade/AbstractImporter.h
+++ b/src/Magnum/Trade/AbstractImporter.h
@@ -1901,6 +1901,34 @@ class MAGNUM_TRADE_EXPORT AbstractImporter: public PluginManager::AbstractManagi
 
     protected:
         /**
+         * @brief Open data that originated elsewhere
+         * @m_since_latest
+         *
+         * Closes previous file, if it was opened, and tries to open given raw
+         * data. Available only if @ref ImporterFeature::OpenData is supported.
+         * Returns @cpp true @ce on success, @cpp false @ce otherwise.
+         *
+         * Designed to be called instead of the public
+         * @ref openData(Containers::ArrayView<const void>) by importers that
+         * proxy loading to other plugins, with the intent of enabling
+         * zero-copy import in the proxied-to implementations as well. Possible
+         * scenarios:
+         *
+         * -    Called from inside a @ref doOpenData() implementation that
+         *      proxies loading to other plugins (for example based on file
+         *      type). In this case it's meant to pass through the @p data and
+         *      @p dataFlags unchanged.
+         * -    Called from inside (for example) a @ref doImage2D() in a scene
+         *      importer that delegates image loading to specialized plugins.
+         *      Assuming the delegated-to importer receives a subrange of the
+         *      data held by the originating importer and its lifetime doesn't
+         *      exceed the originating importer lifetime, the @p data should
+         *      have a no-op deleter and @p dataFlags should be
+         *      @ref DataFlag::Owned.
+         */
+        bool openData(Containers::Array<char>&& data, DataFlags dataFlags);
+
+        /**
          * @brief Implementation for @ref openFile()
          *
          * If @ref ImporterFeature::OpenData is supported, default

--- a/src/Magnum/Trade/AbstractImporter.h
+++ b/src/Magnum/Trade/AbstractImporter.h
@@ -113,6 +113,28 @@ enum class ImporterFlag: UnsignedByte {
      */
     Verbose = 1 << 0,
 
+    /**
+     * Opt-in to zero-copy import, if possible. When this flag is set and
+     * @ref AbstractImporter::openMemory() is used, returned @ref AnimationData,
+     * @ref ImageData, @ref MaterialData, @ref MeshData and @ref SkinData
+     * instances may be views on memory passed to
+     * @relativeref{AbstractImporter,openMemory()} instead of allocated copies,
+     * indicated with @ref DataFlag::ExternallyOwned.
+     *
+     * Since it's not always possible to directly reference the input memory
+     * (for example because the input data may need to be parsed from text,
+     * gathered from an incompatible data layout or patched in some way), this
+     * flag doesn't put any requirement on the importer --- plugins that don't
+     * support zero-copy import will behave the same as if this flag was not
+     * set.
+     *
+     * Setting this flag however means you're responsible to keep the memory
+     * passed to @relativeref{AbstractImporter,openMemory()} in scope for as
+     * long as any `*Data` instances referencing it are alive.
+     * @m_since_latest
+     */
+    ZeroCopy = 1 << 1,
+
     /** @todo ~~Y flip~~ Y up for images, "I want to import just once, don't copy" ... */
 };
 
@@ -654,7 +676,8 @@ class MAGNUM_TRADE_EXPORT AbstractImporter: public PluginManager::AbstractManagi
          * scope until the importer is destructed, @ref close() is called or
          * another file is opened. This allows the implementation to directly
          * operate on the provided memory, without having to allocate a local
-         * copy to extend its lifetime.
+         * copy to extend its lifetime. See also @ref ImporterFlag::ZeroCopy
+         * for a possibility of further optimizations.
          * @see @ref features(), @ref openFile(), @ref openState()
          */
         bool openMemory(Containers::ArrayView<const void> memory);

--- a/src/Magnum/Trade/Test/AbstractImporterTest.cpp
+++ b/src/Magnum/Trade/Test/AbstractImporterTest.cpp
@@ -586,14 +586,13 @@ void AbstractImporterTest::setFlags() {
     CORRADE_COMPARE(importer.flags(), ImporterFlag::Verbose);
     CORRADE_COMPARE(importer._flags, ImporterFlag::Verbose);
 
-    /** @todo use a real flag when we have more than one */
-    importer.addFlags(ImporterFlag(4));
-    CORRADE_COMPARE(importer.flags(), ImporterFlag::Verbose|ImporterFlag(4));
-    CORRADE_COMPARE(importer._flags, ImporterFlag::Verbose|ImporterFlag(4));
+    importer.addFlags(ImporterFlag::ZeroCopy);
+    CORRADE_COMPARE(importer.flags(), ImporterFlag::Verbose|ImporterFlag::ZeroCopy);
+    CORRADE_COMPARE(importer._flags, ImporterFlag::Verbose|ImporterFlag::ZeroCopy);
 
     importer.clearFlags(ImporterFlag::Verbose);
-    CORRADE_COMPARE(importer.flags(), ImporterFlag(4));
-    CORRADE_COMPARE(importer._flags, ImporterFlag(4));
+    CORRADE_COMPARE(importer.flags(), ImporterFlag::ZeroCopy);
+    CORRADE_COMPARE(importer._flags, ImporterFlag::ZeroCopy);
 }
 
 void AbstractImporterTest::setFlagsFileOpened() {

--- a/src/MagnumPlugins/AnyImageImporter/AnyImageImporter.cpp
+++ b/src/MagnumPlugins/AnyImageImporter/AnyImageImporter.cpp
@@ -153,7 +153,7 @@ void AnyImageImporter::doOpenFile(const std::string& filename) {
     _in = std::move(importer);
 }
 
-void AnyImageImporter::doOpenData(Containers::Array<char>&& data, DataFlags) {
+void AnyImageImporter::doOpenData(Containers::Array<char>&& data, const DataFlags dataFlags) {
     using namespace Containers::Literals;
 
     CORRADE_INTERNAL_ASSERT(manager());
@@ -253,7 +253,7 @@ void AnyImageImporter::doOpenData(Containers::Array<char>&& data, DataFlags) {
 
     /* Try to open the file (error output should be printed by the plugin
        itself) */
-    if(!importer->openData(data)) return;
+    if(!importer->openData(std::move(data), dataFlags)) return;
 
     /* Success, save the instance */
     _in = std::move(importer);


### PR DESCRIPTION
The end goal for this:

- use `Utility::Directory::mapRead()` to memory-map a huge image / audio / scene file
- open the memory-mapped file via an importer and parse it without copying the data
- provide a view on the data to the user (again, no copy)
- take small slices of the imported data and upload them to the GPU / play them on the soundcard / ..., again no copy
- have `AnimationData`, `MeshData`, `ImageData` ... work directly on the memory-mapped data

The progress, as of 2021-10-24:

![image](https://user-images.githubusercontent.com/344828/138599532-d5cab7a0-ff7d-4d61-bdb1-ac8599723130.png)

TODO:

- [x] rework `doOpenData()` to accept an r-value Array and `DataFlags` describing whether it's temporary, owned by the importer, make `openFile()` then pass over the allocated array ownership there -- 116d327a6426a5b2bf811535cd9a366117ead01c
  - [ ] make a protected `openData()` with the same signature and the usual assertions from the public `openData()` so proxy plugins such as `AnyImageImporter` or opening images from within other plugins can make use of the memory ownership annotations as well
- [x] implement `openMemory()` as a zero-copy counterpart to `openData()` in `Trade::AbstractImporter` + `DataFlag::ExternallyOwned`, delegate to the above new `doOpenData() -- 27044a4fefa9ac4d61b7bfc29040658658253fd6
  - [ ] a mutable overload of it, passing `DataFlag::Mutable` to `doOpenData()`
  - [x] expose in `magnum-sceneconverter` -- 03aeb4971f6fd97b152f742d55612072b07e720c
  - [ ] make `magnum-sceneconverter` memory-map also referenced files via a callback
- [x] ~~implement `openMemory()` as a zero-copy counterpart to `openData()` in `Audio::AbstractImporter`~~ these interfaces will eventually get deprecated and merged into `Trade::AbstractImporter`
- [ ] implement `doOpenData()` and `openMemory()` equivalently in `Text::AbstractFont` as well
- [x] ~~redesign `Trade::MeshData2D` / `Trade::MeshData3D` to eat an array (view) instead of vectors~~ -- done in #371 instead
- [x] ~~add an ability to put an array view to `Trade::ImageData2D` / ... (convert it to an array with a custom no-op deleter internally)~~ -- done in #371 instead
- [x] ~~implement `Trade::AbstractImporter::mesh2DMemory()` / ... that's able to pass through the mapped data in case the file was opened via `openMemory()`~~ done differently in #371
- [x] ~~implement `Trade::AbstractImporter::image2DMemory()` / ... that's able to pass through the mapped data in case the file was opened via `openMemory()`~~ done differently in #371
- [x] ~~implement `Audio::Importer::data()` that's able to pass through the mapped data in case the file was opened via `openMemory()`~~ these interfaces will eventually get deprecated and merged into `Trade::AbstractImporter`
- [x] Add an `ImporterFlag::ZeroCopy` flag, which will enable importers to pass the input data from `openMemory()` through to `AnimationData` / `MeshData` / `ImageData` / ... without copies
  - and silently falling back to copies if the data is not directly representable there (because it needs to be modified, flipped, swizzled, deinterleaved, whatever)
  - if the importer doesn't support it, it behaves same as without the flag (no error)
- [x] Add an `ImporterFlag::ForceZeroCopyThing` for animations, images, mesh index/vertex buffers, ... that turns the above opt-in behavior to enforced
  - and a `ImporterFeature::ZeroCopyThing` with which the importer advertises ability to zero-copy certain data, which then gets assert for presence if the corresponding flag gets set
  - useful for example when editing image/mesh/scene files in-place, to ensure we're not editing an in-memory copy
  - or to ensure the app doesn't have any suboptimal behavior by accident
  - should the output data be checked? probably not, the base class doesn't remember the memory range anywhere
  - [ ] Also `ImporterFeature::ZeroCopyScenes` and `ImporterFlag::ForceZeroCopyScenes` once #525 is in
  - [ ] And apparently `SkinData` needs to expose `jointDataFlags()` & `inverseBindMatrixDataFlags()`
  - [ ] All those inflate the flag/feature enums which now need to be 16-bit (or maybe more with the `YUp` etc flags?), bump importer plugin interfaces for that
  - [ ] `AnyImageImporter` etc. flag propagation now needs to handle the cases of the flag not being supported in the target and provide a runtime error instead of an assert
- [ ] `ImporterFlag::YUp` & `ImageConverterFlag::YUp` to control whether images get Y-flipped on import and on conversion (otherwise it's not really possible to implement zero-copy import), similarly for `ZBackward` (and `XLeft`?)
  - [ ] `ImageFlag::YUp` to annotate what orientation the image is in so this information doesn't get lost after
  - [ ] Probably also need `ImporterFlag::YDown` / `ImageConverterFlag::YDown` and a presence of neither meaning "keep it in whatever orientation it was" to make the zero-copy import not annoying to set up
  - [ ] Decide how should `pixels()` behave -- they should probably return the view with X right, Y down, Z forward always to be consistent? That'll break existing code tho.
- [ ] Implement this in `WavAudioImporter` once `Trade::AbstractImporter` can do audio as well
- [ ] Implement this in `FreeTypeFont`
- [ ] Implement this in `TgaImporter`  once the `YUp` flag is in (it also converts from ARGB or something, what to do ?) 
- [ ] Implement this in `DdsImporter` once the `YUp` flag is in
- [ ] Implement this in `KtxImporter` once the `YUp` flag is in
- [ ] Implement this in `StanfordImporter` <kbd>in progress, `zerocopy` branch</kbd>
- [ ] Implement this in ~~`TinyGltfImageImporter`~~ (impossible) `CgltfImporter`
- [ ] Optional, for fun: implement `ImageView::slice()` and then upload a slice to GPU memory

Open questions / followup tasks:

- [ ] might be worth to investigate hugepages support for faster memory reservation (https://chrisgreendevelopmentblog.wordpress.com/2021/10/14/fun-with-large-memory-allocations-well-not-really-fun-at-all/) and expose such feature somehow