### PR TITLE
Fix uninitialized pointer check in GlfwApplication.

### DIFF
--- a/src/Magnum/Platform/GlfwApplication.h
+++ b/src/Magnum/Platform/GlfwApplication.h
@@ -480,7 +480,7 @@ class GlfwApplication {
 
         static GlfwApplication* _instance;
 
-        GLFWwindow* _window;
+        GLFWwindow* _window{ nullptr };
         Flags _flags;
         #ifdef MAGNUM_TARGET_GL
         std::unique_ptr<Platform::GLContext> _context;


### PR DESCRIPTION
Unfortunately, this pointer is checked when initializing the window, which makes the current release crash on application start. (Tested on VS2017 x64).

This small fix makes it work again. Not sure if you can easily get this into vcpkg, I am using a patched version locally right now.