### PR TITLE
Fix builds without GL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,13 +213,15 @@ if(BUILD_STATIC)
 endif()
 
 # Check dependencies
-if(NOT TARGET_GLES OR TARGET_DESKTOP_GLES)
-    set(OpenGL_GL_PREFERENCE GLVND) # since CMake 3.11
-    find_package(OpenGL REQUIRED)
-elseif(TARGET_GLES2)
-    find_package(OpenGLES2 REQUIRED)
-else()
-    find_package(OpenGLES3 REQUIRED)
+if(WITH_GL OR TARGET_GL)
+    if(NOT TARGET_GLES OR TARGET_DESKTOP_GLES)
+        set(OpenGL_GL_PREFERENCE GLVND) # since CMake 3.11
+        find_package(OpenGL REQUIRED)
+    elseif(TARGET_GLES2)
+        find_package(OpenGLES2 REQUIRED)
+    else()
+        find_package(OpenGLES3 REQUIRED)
+    endif()
 endif()
 
 # Configuration variables (saved later to configure.h)

--- a/src/Magnum/CMakeLists.txt
+++ b/src/Magnum/CMakeLists.txt
@@ -185,7 +185,9 @@ endif()
 target_include_directories(Magnum PUBLIC
     ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_BINARY_DIR}/src)
-if(BUILD_DEPRECATED AND TARGET_GL) # TODO: remove once compat gets dropped
+if(BUILD_DEPRECATED) # TODO: remove once compat gets dropped
+    # Some deprecated APIs use headers (but not externally defined symbols)
+    # from the GL library, link those includes as well
     target_include_directories(Magnum PUBLIC
         ${PROJECT_SOURCE_DIR}/src/MagnumExternal/OpenGL)
 endif()
@@ -272,7 +274,7 @@ if(BUILD_TESTS)
     target_include_directories(MagnumTestLib PUBLIC
         ${PROJECT_SOURCE_DIR}/src
         ${PROJECT_BINARY_DIR}/src)
-    if(BUILD_DEPRECATED AND TARGET_GL) # TODO: remove once compat gets dropped
+    if(BUILD_DEPRECATED) # TODO: remove once compat gets dropped
         target_include_directories(MagnumTestLib PUBLIC
             ${PROJECT_SOURCE_DIR}/src/MagnumExternal/OpenGL)
     endif()

--- a/src/MagnumExternal/CMakeLists.txt
+++ b/src/MagnumExternal/CMakeLists.txt
@@ -26,7 +26,10 @@
 if(WITH_AUDIO)
     add_subdirectory(OpenAL)
 endif()
-if(WITH_GL)
+# Some deprecated APIs use headers (but not externally defined symbols)
+# from the GL library, link those includes as well
+# TODO: remove once compat gets dropped
+if(WITH_GL OR MAGNUM_BUILD_DEPRECATED)
     add_subdirectory(OpenGL)
 endif()
 if(WITH_VK)

--- a/src/MagnumExternal/OpenGL/GL/CMakeLists.txt
+++ b/src/MagnumExternal/OpenGL/GL/CMakeLists.txt
@@ -23,15 +23,20 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-# flextGLPlatform.cpp is compiled as part of Magnum*Context libraries in Platform
-add_library(MagnumFlextGLObjects OBJECT flextGL.cpp)
-target_include_directories(MagnumFlextGLObjects PUBLIC $<TARGET_PROPERTY:MagnumGL,INTERFACE_INCLUDE_DIRECTORIES>)
-if(NOT BUILD_STATIC)
-    target_compile_definitions(MagnumFlextGLObjects PRIVATE "FlextGL_EXPORTS")
+# Some deprecated APIs use headers (but not externally defined symbols)
+# from the GL library, link those includes as well
+# TODO: remove once compat gets dropped (condition only)
+if(WITH_GL)
+    # flextGLPlatform.cpp is compiled as part of Magnum*Context libraries in Platform
+    add_library(MagnumFlextGLObjects OBJECT flextGL.cpp)
+    target_include_directories(MagnumFlextGLObjects PUBLIC $<TARGET_PROPERTY:MagnumGL,INTERFACE_INCLUDE_DIRECTORIES>)
+    if(NOT BUILD_STATIC)
+        target_compile_definitions(MagnumFlextGLObjects PRIVATE "FlextGL_EXPORTS")
+    endif()
+    if(NOT BUILD_STATIC OR BUILD_STATIC_PIC)
+        set_target_properties(MagnumFlextGLObjects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif()
+    set_target_properties(MagnumFlextGLObjects PROPERTIES FOLDER "MagnumExternal/OpenGL")
 endif()
-if(NOT BUILD_STATIC OR BUILD_STATIC_PIC)
-    set_target_properties(MagnumFlextGLObjects PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif()
-set_target_properties(MagnumFlextGLObjects PROPERTIES FOLDER "MagnumExternal/OpenGL")
 
 install(FILES flextGL.h DESTINATION ${MAGNUM_EXTERNAL_INCLUDE_INSTALL_DIR}/OpenGL/GL)


### PR DESCRIPTION
Hi @mosra !

I applied your patch for the fix for building `WITH_GL=OFF`. If building with `BUILD_DEPRECATED=ON`, it would not find External/OpenGL, which I made sure that it gets installed anyway now (untested!).

Cheers, Jonathan

The issue you get when trying to build a project using magnum that was build accordingly:
~~~
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
-- Check for working C compiler using: Ninja
-- Check for working C compiler using: Ninja -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler using: Ninja
-- Check for working CXX compiler using: Ninja -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Corrade: /usr/local/include  found components:  Utility Containers 
-- Found Corrade: /usr/local/include  found components:  Utility Containers rc 
-- Found Magnum: /usr/local/include   
-- LIB_SUFFIX variable is not defined. It will be autodetected now.
-- You can set it manually with -DLIB_SUFFIX=<value> (64 for example)
-- LIB_SUFFIX autodetected as '64', libraries will be installed into /builds/vhiterabbit/webvr-pong/deploy/lib64
-- Found Magnum: /usr/local/include  found components:  Magnum 
-- Configuring done
CMake Error in src/server/CMakeLists.txt:
  Imported target "Magnum::Magnum" includes non-existent path

    "/usr/local/include/MagnumExternal/OpenGL"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
~~~