### PR TITLE
[WIP] C++14 constexpr additions

### DIFF
--- a/src/Magnum/Math/BoolVector.h
+++ b/src/Magnum/Math/BoolVector.h
@@ -94,7 +94,7 @@ template<std::size_t size> class BoolVector {
         constexpr BoolVector(const BoolVector<size>&) = default;
 
         /** @brief Copy assignment */
-        BoolVector<size>& operator=(const BoolVector<size>&) = default;
+        constexpr BoolVector<size>& operator=(const BoolVector<size>&) = default;
 
         /**
          * @brief Raw data
@@ -102,7 +102,7 @@ template<std::size_t size> class BoolVector {
          *
          * @see @ref operator[](), @ref set()
          */
-        UnsignedByte* data() { return _data; }
+        constexpr UnsignedByte* data() { return _data; }
         constexpr const UnsignedByte* data() const { return _data; } /**< @overload */
 
         /** @brief Bit at given position */
@@ -111,37 +111,37 @@ template<std::size_t size> class BoolVector {
         }
 
         /** @brief Set bit at given position */
-        BoolVector<size>& set(std::size_t i, bool value) {
+        constexpr BoolVector<size>& set(std::size_t i, bool value) {
             _data[i/8] |= ((value & 0x01) << i%8);
             return *this;
         }
 
         /** @brief Equality comparison */
-        bool operator==(const BoolVector<size>& other) const;
+        constexpr bool operator==(const BoolVector<size>& other) const;
 
         /** @brief Non-equality comparison */
-        bool operator!=(const BoolVector<size>& other) const {
+        constexpr bool operator!=(const BoolVector<size>& other) const {
             return !operator==(other);
         }
 
         /** @brief Whether all bits are set */
-        bool all() const;
+        constexpr bool all() const;
 
         /** @brief Whether no bits are set */
-        bool none() const;
+        constexpr bool none() const;
 
         /** @brief Whether any bit is set */
-        bool any() const { return !none(); }
+        constexpr bool any() const { return !none(); }
 
         /** @brief Bitwise inversion */
-        BoolVector<size> operator~() const;
+        constexpr BoolVector<size> operator~() const;
 
         /**
          * @brief Bitwise AND and assign
          *
          * The computation is done in-place.
          */
-        BoolVector<size>& operator&=(const BoolVector<size>& other) {
+        constexpr BoolVector<size>& operator&=(const BoolVector<size>& other) {
             for(std::size_t i = 0; i != DataSize; ++i)
                 _data[i] &= other._data[i];
 
@@ -153,7 +153,7 @@ template<std::size_t size> class BoolVector {
          *
          * @see @ref operator&=()
          */
-        BoolVector<size> operator&(const BoolVector<size>& other) const {
+        constexpr BoolVector<size> operator&(const BoolVector<size>& other) const {
             return BoolVector<size>(*this) &= other;
         }
 
@@ -162,7 +162,7 @@ template<std::size_t size> class BoolVector {
          *
          * The computation is done in-place.
          */
-        BoolVector<size>& operator|=(const BoolVector<size>& other) {
+        constexpr BoolVector<size>& operator|=(const BoolVector<size>& other) {
             for(std::size_t i = 0; i != DataSize; ++i)
                 _data[i] |= other._data[i];
 
@@ -174,7 +174,7 @@ template<std::size_t size> class BoolVector {
          *
          * @see @ref operator|=()
          */
-        BoolVector<size> operator|(const BoolVector<size>& other) const {
+        constexpr BoolVector<size> operator|(const BoolVector<size>& other) const {
             return BoolVector<size>(*this) |= other;
         }
 
@@ -183,7 +183,7 @@ template<std::size_t size> class BoolVector {
          *
          * The computation is done in-place.
          */
-        BoolVector<size>& operator^=(const BoolVector<size>& other) {
+        constexpr BoolVector<size>& operator^=(const BoolVector<size>& other) {
             for(std::size_t i = 0; i != DataSize; ++i)
                 _data[i] ^= other._data[i];
 
@@ -195,7 +195,7 @@ template<std::size_t size> class BoolVector {
          *
          * @see @ref operator^=()
          */
-        BoolVector<size> operator^(const BoolVector<size>& other) const {
+        constexpr BoolVector<size> operator^(const BoolVector<size>& other) const {
             return BoolVector<size>(*this) ^= other;
         }
 
@@ -224,7 +224,7 @@ template<std::size_t size> Corrade::Utility::Debug operator<<(Corrade::Utility::
     return debug;
 }
 
-template<std::size_t size> inline bool BoolVector<size>::operator==(const BoolVector< size >& other) const {
+template<std::size_t size> inline constexpr bool BoolVector<size>::operator==(const BoolVector< size >& other) const {
     for(std::size_t i = 0; i != size/8; ++i)
         if(_data[i] != other._data[i]) return false;
 
@@ -235,7 +235,7 @@ template<std::size_t size> inline bool BoolVector<size>::operator==(const BoolVe
     return true;
 }
 
-template<std::size_t size> inline bool BoolVector<size>::all() const {
+template<std::size_t size> inline constexpr bool BoolVector<size>::all() const {
     /* Check all full segments */
     for(std::size_t i = 0; i != size/8; ++i)
         if(_data[i] != FullSegmentMask) return false;
@@ -247,7 +247,7 @@ template<std::size_t size> inline bool BoolVector<size>::all() const {
     return true;
 }
 
-template<std::size_t size> inline bool BoolVector<size>::none() const {
+template<std::size_t size> inline constexpr bool BoolVector<size>::none() const {
     /* Check all full segments */
     for(std::size_t i = 0; i != size/8; ++i)
         if(_data[i]) return false;
@@ -259,8 +259,8 @@ template<std::size_t size> inline bool BoolVector<size>::none() const {
     return true;
 }
 
-template<std::size_t size> inline BoolVector<size> BoolVector<size>::operator~() const {
-    BoolVector<size> out;
+template<std::size_t size> inline constexpr BoolVector<size> BoolVector<size>::operator~() const {
+    BoolVector<size> out{};
 
     for(std::size_t i = 0; i != DataSize; ++i)
         out._data[i] = ~_data[i];

--- a/src/Magnum/Math/Matrix.h
+++ b/src/Magnum/Math/Matrix.h
@@ -119,10 +119,10 @@ template<std::size_t size, class T> class Matrix: public RectangularMatrix<size,
          * tr(A) = \sum_{i=1}^n a_{i,i}
          * @f]
          */
-        T trace() const { return RectangularMatrix<size, size, T>::diagonal().sum(); }
+        constexpr T trace() const { return RectangularMatrix<size, size, T>::diagonal().sum(); }
 
         /** @brief %Matrix without given column and row */
-        Matrix<size-1, T> ij(std::size_t skipCol, std::size_t skipRow) const;
+        constexpr Matrix<size-1, T> ij(std::size_t skipCol, std::size_t skipRow) const;
 
         /**
          * @brief Determinant
@@ -135,7 +135,7 @@ template<std::size_t size, class T> class Matrix: public RectangularMatrix<size,
          *      \det(A) = a_{0, 0} a_{1, 1} - a_{1, 0} a_{0, 1}
          * @f]
          */
-        T determinant() const { return Implementation::MatrixDeterminant<size, T>()(*this); }
+        constexpr T determinant() const { return Implementation::MatrixDeterminant<size, T>()(*this); }
 
         /**
          * @brief Inverted matrix
@@ -147,7 +147,7 @@ template<std::size_t size, class T> class Matrix: public RectangularMatrix<size,
          * @ref Matrix4::invertedRigid() which are faster alternatives for
          * particular matrix types.
          */
-        Matrix<size, T> inverted() const;
+        constexpr Matrix<size, T> inverted() const;
 
         /**
          * @brief Inverted orthogonal matrix
@@ -168,13 +168,13 @@ template<std::size_t size, class T> class Matrix: public RectangularMatrix<size,
 
         #ifndef DOXYGEN_GENERATING_OUTPUT
         /* Reimplementation of functions to return correct type */
-        Matrix<size, T> operator*(const Matrix<size, T>& other) const {
+        constexpr Matrix<size, T> operator*(const Matrix<size, T>& other) const {
             return RectangularMatrix<size, size, T>::operator*(other);
         }
-        template<std::size_t otherCols> RectangularMatrix<otherCols, size, T> operator*(const RectangularMatrix<otherCols, size, T>& other) const {
+        template<std::size_t otherCols> RectangularMatrix<otherCols, size, T> constexpr operator*(const RectangularMatrix<otherCols, size, T>& other) const {
             return RectangularMatrix<size, size, T>::operator*(other);
         }
-        Vector<size, T> operator*(const Vector<size, T>& other) const {
+        constexpr Vector<size, T> operator*(const Vector<size, T>& other) const {
             return RectangularMatrix<size, size, T>::operator*(other);
         }
         MAGNUM_RECTANGULARMATRIX_SUBCLASS_IMPLEMENTATION(size, size, Matrix<size, T>)
@@ -219,40 +219,40 @@ template<std::size_t size, class T> inline Corrade::Utility::Debug operator<<(Co
 
 #ifndef DOXYGEN_GENERATING_OUTPUT
 #define MAGNUM_MATRIX_SUBCLASS_IMPLEMENTATION(size, Type, VectorType)       \
-    VectorType<T>& operator[](std::size_t col) {                            \
+    constexpr VectorType<T>& operator[](std::size_t col) {                  \
         return static_cast<VectorType<T>&>(Matrix<size, T>::operator[](col)); \
     }                                                                       \
     constexpr const VectorType<T> operator[](std::size_t col) const {       \
         return VectorType<T>(Matrix<size, T>::operator[](col));             \
     }                                                                       \
-    VectorType<T> row(std::size_t row) const {                              \
+    constexpr VectorType<T> row(std::size_t row) const {                    \
         return VectorType<T>(Matrix<size, T>::row(row));                    \
     }                                                                       \
                                                                             \
-    Type<T> operator*(const Matrix<size, T>& other) const {                 \
+    constexpr Type<T> operator*(const Matrix<size, T>& other) const {       \
         return Matrix<size, T>::operator*(other);                           \
     }                                                                       \
-    template<std::size_t otherCols> RectangularMatrix<otherCols, size, T> operator*(const RectangularMatrix<otherCols, size, T>& other) const { \
+    template<std::size_t otherCols> constexpr RectangularMatrix<otherCols, size, T> operator*(const RectangularMatrix<otherCols, size, T>& other) const { \
         return Matrix<size, T>::operator*(other);                           \
     }                                                                       \
-    VectorType<T> operator*(const Vector<size, T>& other) const {           \
+    constexpr VectorType<T> operator*(const Vector<size, T>& other) const { \
         return Matrix<size, T>::operator*(other);                           \
     }                                                                       \
                                                                             \
-    Type<T> transposed() const { return Matrix<size, T>::transposed(); }    \
+    constexpr Type<T> transposed() const { return Matrix<size, T>::transposed(); } \
     constexpr VectorType<T> diagonal() const { return Matrix<size, T>::diagonal(); } \
-    Type<T> inverted() const { return Matrix<size, T>::inverted(); }        \
-    Type<T> invertedOrthogonal() const {                                    \
+    constexpr Type<T> inverted() const { return Matrix<size, T>::inverted(); } \
+    constexpr Type<T> invertedOrthogonal() const {                          \
         return Matrix<size, T>::invertedOrthogonal();                       \
     }
 
 namespace Implementation {
 
 template<std::size_t size, class T> struct MatrixDeterminant {
-    T operator()(const Matrix<size, T>& m);
+    constexpr T operator()(const Matrix<size, T>& m);
 };
 
-template<std::size_t size, class T> T MatrixDeterminant<size, T>::operator()(const Matrix<size, T>& m) {
+template<std::size_t size, class T> constexpr T MatrixDeterminant<size, T>::operator()(const Matrix<size, T>& m) {
     T out(0);
 
     for(std::size_t col = 0; col != size; ++col)
@@ -290,7 +290,7 @@ template<std::size_t size, class T> bool Matrix<size, T>::isOrthogonal() const {
     return true;
 }
 
-template<std::size_t size, class T> Matrix<size-1, T> Matrix<size, T>::ij(const std::size_t skipCol, const std::size_t skipRow) const {
+template<std::size_t size, class T> constexpr Matrix<size-1, T> Matrix<size, T>::ij(const std::size_t skipCol, const std::size_t skipRow) const {
     Matrix<size-1, T> out(Matrix<size-1, T>::Zero);
 
     for(std::size_t col = 0; col != size-1; ++col)
@@ -301,7 +301,7 @@ template<std::size_t size, class T> Matrix<size-1, T> Matrix<size, T>::ij(const 
     return out;
 }
 
-template<std::size_t size, class T> Matrix<size, T> Matrix<size, T>::inverted() const {
+template<std::size_t size, class T> constexpr Matrix<size, T> Matrix<size, T>::inverted() const {
     Matrix<size, T> out(Zero);
 
     const T _determinant = determinant();

--- a/src/Magnum/Math/Matrix3.h
+++ b/src/Magnum/Math/Matrix3.h
@@ -105,7 +105,7 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          * @see @ref Matrix4::orthographicProjection(),
          *      @ref Matrix4::perspectiveProjection()
          */
-        static Matrix3<T> projection(const Vector2<T>& size) {
+        constexpr static Matrix3<T> projection(const Vector2<T>& size) {
             return scaling(2.0f/size);
         }
 
@@ -247,7 +247,7 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          * First two elements of first column.
          * @see @ref up(), @ref Vector2::xAxis(), @ref Matrix4::right()
          */
-        Vector2<T>& right() { return (*this)[0].xy(); }
+        constexpr Vector2<T>& right() { return (*this)[0].xy(); }
         constexpr Vector2<T> right() const { return (*this)[0].xy(); } /**< @overload */
 
         /**
@@ -256,7 +256,7 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          * First two elements of second column.
          * @see @ref right(), @ref Vector2::yAxis(), @ref Matrix4::up()
          */
-        Vector2<T>& up() { return (*this)[1].xy(); }
+        constexpr Vector2<T>& up() { return (*this)[1].xy(); }
         constexpr Vector2<T> up() const { return (*this)[1].xy(); } /**< @overload */
 
         /**
@@ -267,7 +267,7 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          *      @ref translation(const Vector2<T>&),
          *      @ref Matrix4::translation()
          */
-        Vector2<T>& translation() { return (*this)[2].xy(); }
+        constexpr Vector2<T>& translation() { return (*this)[2].xy(); }
         constexpr Vector2<T> translation() const { return (*this)[2].xy(); } /**< @overload */
 
         /**
@@ -297,7 +297,7 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          *      @ref Matrix4::transformVector()
          * @todo extract 2x2 matrix and multiply directly? (benchmark that)
          */
-        Vector2<T> transformVector(const Vector2<T>& vector) const {
+        constexpr Vector2<T> transformVector(const Vector2<T>& vector) const {
             return ((*this)*Vector3<T>(vector, T(0))).xy();
         }
 
@@ -311,7 +311,7 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          * @see @ref DualComplex::transformPoint(),
          *      @ref Matrix4::transformPoint()
          */
-        Vector2<T> transformPoint(const Vector2<T>& vector) const {
+        constexpr Vector2<T> transformPoint(const Vector2<T>& vector) const {
             return ((*this)*Vector3<T>(vector, T(1))).xy();
         }
 

--- a/src/Magnum/Math/Matrix4.h
+++ b/src/Magnum/Math/Matrix4.h
@@ -151,7 +151,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          *
          * @see @ref perspectiveProjection(), @ref Matrix3::projection()
          */
-        static Matrix4<T> orthographicProjection(const Vector2<T>& size, T near, T far);
+        constexpr static Matrix4<T> orthographicProjection(const Vector2<T>& size, T near, T far);
 
         /**
          * @brief 3D perspective projection matrix
@@ -161,7 +161,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          *
          * @see @ref orthographicProjection(), @ref Matrix3::projection()
          */
-        static Matrix4<T> perspectiveProjection(const Vector2<T>& size, T near, T far);
+        constexpr static Matrix4<T> perspectiveProjection(const Vector2<T>& size, T near, T far);
 
         /**
          * @brief 3D perspective projection matrix
@@ -309,7 +309,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          * @see @ref up(), @ref backward(), @ref Vector3::xAxis(),
          *      @ref Matrix3::right()
          */
-        Vector3<T>& right() { return (*this)[0].xyz(); }
+        constexpr Vector3<T>& right() { return (*this)[0].xyz(); }
         constexpr Vector3<T> right() const { return (*this)[0].xyz(); } /**< @overload */
 
         /**
@@ -319,7 +319,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          * @see @ref right(), @ref backward(), @ref Vector3::yAxis(),
          *      @ref Matrix3::up()
          */
-        Vector3<T>& up() { return (*this)[1].xyz(); }
+        constexpr Vector3<T>& up() { return (*this)[1].xyz(); }
         constexpr Vector3<T> up() const { return (*this)[1].xyz(); } /**< @overload */
 
         /**
@@ -328,7 +328,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          * First three elements of third column.
          * @see @ref right(), @ref up(), @ref Vector3::yAxis()
          */
-        Vector3<T>& backward() { return (*this)[2].xyz(); }
+        constexpr Vector3<T>& backward() { return (*this)[2].xyz(); }
         constexpr Vector3<T> backward() const { return (*this)[2].xyz(); } /**< @overload */
 
         /**
@@ -339,7 +339,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          *      @ref translation(const Vector3<T>&),
          *      @ref Matrix3::translation()
          */
-        Vector3<T>& translation() { return (*this)[3].xyz(); }
+        constexpr Vector3<T>& translation() { return (*this)[3].xyz(); }
         constexpr Vector3<T> translation() const { return (*this)[3].xyz(); } /**< @overload */
 
         /**
@@ -369,7 +369,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          *      @ref Matrix3::transformVector()
          * @todo extract 3x3 matrix and multiply directly? (benchmark that)
          */
-        Vector3<T> transformVector(const Vector3<T>& vector) const {
+        constexpr Vector3<T> transformVector(const Vector3<T>& vector) const {
             return ((*this)*Vector4<T>(vector, T(0))).xyz();
         }
 
@@ -383,7 +383,7 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          * @see @ref DualQuaternion::transformPoint(),
          *      @ref Matrix3::transformPoint()
          */
-        Vector3<T> transformPoint(const Vector3<T>& vector) const {
+        constexpr Vector3<T> transformPoint(const Vector3<T>& vector) const {
             return ((*this)*Vector4<T>(vector, T(1))).xyz();
         }
 
@@ -466,7 +466,7 @@ template<class T> Matrix4<T> Matrix4<T>::reflection(const Vector3<T>& normal) {
     return from(Matrix3x3<T>() - T(2)*normal*RectangularMatrix<1, 3, T>(normal).transposed(), {});
 }
 
-template<class T> Matrix4<T> Matrix4<T>::orthographicProjection(const Vector2<T>& size, const T near, const T far) {
+template<class T> constexpr Matrix4<T> Matrix4<T>::orthographicProjection(const Vector2<T>& size, const T near, const T far) {
     const Vector2<T> xyScale = T(2.0)/size;
     const T zScale = T(2.0)/(near-far);
 
@@ -476,7 +476,7 @@ template<class T> Matrix4<T> Matrix4<T>::orthographicProjection(const Vector2<T>
             {       T(0),        T(0), near*zScale-T(1), T(1)}};
 }
 
-template<class T> Matrix4<T> Matrix4<T>::perspectiveProjection(const Vector2<T>& size, const T near, const T far) {
+template<class T> constexpr Matrix4<T> Matrix4<T>::perspectiveProjection(const Vector2<T>& size, const T near, const T far) {
     Vector2<T> xyScale = 2*near/size;
     T zScale = T(1.0)/(near-far);
 

--- a/src/Magnum/Math/RectangularMatrix.h
+++ b/src/Magnum/Math/RectangularMatrix.h
@@ -139,7 +139,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
         constexpr RectangularMatrix(const RectangularMatrix<cols, rows, T>&) = default;
 
         /** @brief Assignment operator */
-        RectangularMatrix<cols, rows, T>& operator=(const RectangularMatrix<cols, rows, T>&) = default;
+        constexpr RectangularMatrix<cols, rows, T>& operator=(const RectangularMatrix<cols, rows, T>&) = default;
 
         /** @brief Convert matrix to external representation */
         template<class U, class V = decltype(Implementation::RectangularMatrixConverter<cols, rows, T, U>::to(std::declval<RectangularMatrix<cols, rows, T>>()))> constexpr explicit operator U() const {
@@ -153,7 +153,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *
          * @see @ref operator[]()
          */
-        T* data() { return _data[0].data(); }
+        constexpr T* data() { return _data[0].data(); }
         constexpr const T* data() const { return _data[0].data(); } /**< @overload */
 
         /**
@@ -168,7 +168,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *
          * @see @ref row(), @ref data()
          */
-        Vector<rows, T>& operator[](std::size_t col) { return _data[col]; }
+        constexpr Vector<rows, T>& operator[](std::size_t col) { return _data[col]; }
         constexpr const Vector<rows, T>& operator[](std::size_t col) const { return _data[col]; } /**< @overload */
 
         /**
@@ -179,7 +179,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          * stored.
          * @see @ref operator[]()
          */
-        Vector<cols, T> row(std::size_t row) const;
+        constexpr Vector<cols, T> row(std::size_t row) const;
 
         /** @brief Equality comparison */
         bool operator==(const RectangularMatrix<cols, rows, T>& other) const {
@@ -206,7 +206,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      \boldsymbol B_j = -\boldsymbol A_j
          * @f]
          */
-        RectangularMatrix<cols, rows, T> operator-() const;
+        constexpr RectangularMatrix<cols, rows, T> operator-() const;
 
         /**
          * @brief Add and assign matrix
@@ -215,7 +215,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      \boldsymbol A_j = \boldsymbol A_j + \boldsymbol B_j
          * @f]
          */
-        RectangularMatrix<cols, rows, T>& operator+=(const RectangularMatrix<cols, rows, T>& other) {
+        constexpr RectangularMatrix<cols, rows, T>& operator+=(const RectangularMatrix<cols, rows, T>& other) {
             for(std::size_t i = 0; i != cols; ++i)
                 _data[i] += other._data[i];
 
@@ -227,7 +227,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *
          * @see @ref operator+=()
          */
-        RectangularMatrix<cols, rows, T> operator+(const RectangularMatrix<cols, rows, T>& other) const {
+        constexpr RectangularMatrix<cols, rows, T> operator+(const RectangularMatrix<cols, rows, T>& other) const {
             return RectangularMatrix<cols, rows, T>(*this)+=other;
         }
 
@@ -238,7 +238,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      \boldsymbol A_j = \boldsymbol A_j - \boldsymbol B_j
          * @f]
          */
-        RectangularMatrix<cols, rows, T>& operator-=(const RectangularMatrix<cols, rows, T>& other) {
+        constexpr RectangularMatrix<cols, rows, T>& operator-=(const RectangularMatrix<cols, rows, T>& other) {
             for(std::size_t i = 0; i != cols; ++i)
                 _data[i] -= other._data[i];
 
@@ -250,7 +250,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *
          * @see @ref operator-=()
          */
-        RectangularMatrix<cols, rows, T> operator-(const RectangularMatrix<cols, rows, T>& other) const {
+        constexpr RectangularMatrix<cols, rows, T> operator-(const RectangularMatrix<cols, rows, T>& other) const {
             return RectangularMatrix<cols, rows, T>(*this)-=other;
         }
 
@@ -261,7 +261,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      \boldsymbol A_j = a \boldsymbol A_j
          * @f]
          */
-        RectangularMatrix<cols, rows, T>& operator*=(T number) {
+        constexpr RectangularMatrix<cols, rows, T>& operator*=(T number) {
             for(std::size_t i = 0; i != cols; ++i)
                 _data[i] *= number;
 
@@ -273,7 +273,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *
          * @see @ref operator*=(T), @ref operator*(T, const RectangularMatrix<cols, rows, T>&)
          */
-        RectangularMatrix<cols, rows, T> operator*(T number) const {
+        constexpr RectangularMatrix<cols, rows, T> operator*(T number) const {
             return RectangularMatrix<cols, rows, T>(*this) *= number;
         }
 
@@ -284,7 +284,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      \boldsymbol A_j = \frac{\boldsymbol A_j} a
          * @f]
          */
-        RectangularMatrix<cols, rows, T>& operator/=(T number) {
+        constexpr RectangularMatrix<cols, rows, T>& operator/=(T number) {
             for(std::size_t i = 0; i != cols; ++i)
                 _data[i] /= number;
 
@@ -297,7 +297,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          * @see @ref operator/=(T),
          *      @ref operator/(T, const RectangularMatrix<cols, rows, T>&)
          */
-        RectangularMatrix<cols, rows, T> operator/(T number) const {
+        constexpr RectangularMatrix<cols, rows, T> operator/(T number) const {
             return RectangularMatrix<cols, rows, T>(*this) /= number;
         }
 
@@ -308,7 +308,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      (\boldsymbol {AB})_{ji} = \sum_{k=0}^{m-1} \boldsymbol A_{ki} \boldsymbol B_{jk}
          * @f]
          */
-        template<std::size_t size> RectangularMatrix<size, rows, T> operator*(const RectangularMatrix<size, cols, T>& other) const;
+        template<std::size_t size> constexpr RectangularMatrix<size, rows, T> operator*(const RectangularMatrix<size, cols, T>& other) const;
 
         /**
          * @brief Multiply vector
@@ -318,7 +318,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *      (\boldsymbol {Aa})_i = \sum_{k=0}^{m-1} \boldsymbol A_{ki} \boldsymbol a_k
          * @f]
          */
-        Vector<rows, T> operator*(const Vector<cols, T>& other) const {
+        constexpr Vector<rows, T> operator*(const Vector<cols, T>& other) const {
             return operator*(RectangularMatrix<1, cols, T>(other))[0];
         }
 
@@ -327,7 +327,7 @@ template<std::size_t cols, std::size_t rows, class T> class RectangularMatrix {
          *
          * @see @ref row()
          */
-        RectangularMatrix<rows, cols, T> transposed() const;
+        constexpr RectangularMatrix<rows, cols, T> transposed() const;
 
         /**
          * @brief Values on diagonal
@@ -425,7 +425,7 @@ template<class T> using Matrix4x3 = RectangularMatrix<4, 3, T>;
 
 Same as @ref RectangularMatrix::operator*(T) const.
 */
-template<std::size_t cols, std::size_t rows, class T> inline RectangularMatrix<cols, rows, T> operator*(
+template<std::size_t cols, std::size_t rows, class T> inline constexpr RectangularMatrix<cols, rows, T> operator*(
     #ifdef DOXYGEN_GENERATING_OUTPUT
     T
     #else
@@ -444,7 +444,7 @@ The computation is done column-wise. @f[
 @f]
 @see @ref RectangularMatrix::operator/(T) const
 */
-template<std::size_t cols, std::size_t rows, class T> inline RectangularMatrix<cols, rows, T> operator/(
+template<std::size_t cols, std::size_t rows, class T> inline constexpr RectangularMatrix<cols, rows, T> operator/(
     #ifdef DOXYGEN_GENERATING_OUTPUT
     T
     #else
@@ -452,7 +452,7 @@ template<std::size_t cols, std::size_t rows, class T> inline RectangularMatrix<c
     #endif
     number, const RectangularMatrix<cols, rows, T>& matrix)
 {
-    RectangularMatrix<cols, rows, T> out;
+    RectangularMatrix<cols, rows, T> out{};
 
     for(std::size_t i = 0; i != cols; ++i)
         out[i] = number/matrix[i];
@@ -468,7 +468,7 @@ Internally the same as multiplying one-column matrix with one-row matrix. @f[
 @f]
 @see @ref RectangularMatrix::operator*(const RectangularMatrix<size, cols, T>&) const
 */
-template<std::size_t size, std::size_t cols, class T> inline RectangularMatrix<cols, size, T> operator*(const Vector<size, T>& vector, const RectangularMatrix<cols, 1, T>& matrix) {
+template<std::size_t size, std::size_t cols, class T> inline constexpr RectangularMatrix<cols, size, T> operator*(const Vector<size, T>& vector, const RectangularMatrix<cols, 1, T>& matrix) {
     return RectangularMatrix<1, size, T>(vector)*matrix;
 }
 
@@ -527,57 +527,57 @@ extern template Corrade::Utility::Debug MAGNUM_EXPORT operator<<(Corrade::Utilit
         return Math::RectangularMatrix<cols, rows, T>::fromDiagonal(diagonal); \
     }                                                                       \
                                                                             \
-    __VA_ARGS__ operator-() const {                                         \
+    constexpr __VA_ARGS__ operator-() const {                               \
         return Math::RectangularMatrix<cols, rows, T>::operator-();         \
     }                                                                       \
-    __VA_ARGS__& operator+=(const Math::RectangularMatrix<cols, rows, T>& other) { \
+    constexpr __VA_ARGS__& operator+=(const Math::RectangularMatrix<cols, rows, T>& other) { \
         Math::RectangularMatrix<cols, rows, T>::operator+=(other);          \
         return *this;                                                       \
     }                                                                       \
-    __VA_ARGS__ operator+(const Math::RectangularMatrix<cols, rows, T>& other) const { \
+    constexpr __VA_ARGS__ operator+(const Math::RectangularMatrix<cols, rows, T>& other) const { \
         return Math::RectangularMatrix<cols, rows, T>::operator+(other);    \
     }                                                                       \
-    __VA_ARGS__& operator-=(const Math::RectangularMatrix<cols, rows, T>& other) { \
+    constexpr __VA_ARGS__& operator-=(const Math::RectangularMatrix<cols, rows, T>& other) { \
         Math::RectangularMatrix<cols, rows, T>::operator-=(other);          \
         return *this;                                                       \
     }                                                                       \
-    __VA_ARGS__ operator-(const Math::RectangularMatrix<cols, rows, T>& other) const { \
+    constexpr __VA_ARGS__ operator-(const Math::RectangularMatrix<cols, rows, T>& other) const { \
         return Math::RectangularMatrix<cols, rows, T>::operator-(other);    \
     }                                                                       \
-    __VA_ARGS__& operator*=(T number) {                                     \
+    constexpr __VA_ARGS__& operator*=(T number) {                           \
         Math::RectangularMatrix<cols, rows, T>::operator*=(number);         \
         return *this;                                                       \
     }                                                                       \
-    __VA_ARGS__ operator*(T number) const {                                 \
+    constexpr __VA_ARGS__ operator*(T number) const {                       \
         return Math::RectangularMatrix<cols, rows, T>::operator*(number);   \
     }                                                                       \
-    __VA_ARGS__& operator/=(T number) {                                     \
+    constexpr __VA_ARGS__& operator/=(T number) {                           \
         Math::RectangularMatrix<cols, rows, T>::operator/=(number);         \
         return *this;                                                       \
     }                                                                       \
-    __VA_ARGS__ operator/(T number) const {                                 \
+    constexpr __VA_ARGS__ operator/(T number) const {                       \
         return Math::RectangularMatrix<cols, rows, T>::operator/(number);   \
     }
 
 #define MAGNUM_MATRIX_OPERATOR_IMPLEMENTATION(...)                          \
-    template<std::size_t size, class T> inline __VA_ARGS__ operator*(typename std::common_type<T>::type number, const __VA_ARGS__& matrix) { \
+    template<std::size_t size, class T> inline constexpr __VA_ARGS__ operator*(typename std::common_type<T>::type number, const __VA_ARGS__& matrix) { \
         return number*static_cast<const Math::RectangularMatrix<size, size, T>&>(matrix); \
     }                                                                       \
-    template<std::size_t size, class T> inline __VA_ARGS__ operator/(typename std::common_type<T>::type number, const __VA_ARGS__& matrix) { \
+    template<std::size_t size, class T> inline constexpr __VA_ARGS__ operator/(typename std::common_type<T>::type number, const __VA_ARGS__& matrix) { \
         return number/static_cast<const Math::RectangularMatrix<size, size, T>&>(matrix); \
     }                                                                       \
-    template<std::size_t size, class T> inline __VA_ARGS__ operator*(const Vector<size, T>& vector, const RectangularMatrix<size, 1, T>& matrix) { \
+    template<std::size_t size, class T> inline constexpr __VA_ARGS__ operator*(const Vector<size, T>& vector, const RectangularMatrix<size, 1, T>& matrix) { \
         return Math::RectangularMatrix<1, size, T>(vector)*matrix;          \
     }
 
 #define MAGNUM_MATRIXn_OPERATOR_IMPLEMENTATION(size, Type)                  \
-    template<class T> inline Type<T> operator*(typename std::common_type<T>::type number, const Type<T>& matrix) { \
+    template<class T> inline constexpr Type<T> operator*(typename std::common_type<T>::type number, const Type<T>& matrix) { \
         return number*static_cast<const Math::RectangularMatrix<size, size, T>&>(matrix); \
     }                                                                       \
-    template<class T> inline Type<T> operator/(typename std::common_type<T>::type number, const Type<T>& matrix) { \
+    template<class T> inline constexpr Type<T> operator/(typename std::common_type<T>::type number, const Type<T>& matrix) { \
         return number/static_cast<const Math::RectangularMatrix<size, size, T>&>(matrix); \
     }                                                                       \
-    template<class T> inline Type<T> operator*(const Vector<size, T>& vector, const RectangularMatrix<size, 1, T>& matrix) { \
+    template<class T> inline constexpr Type<T> operator*(const Vector<size, T>& vector, const RectangularMatrix<size, 1, T>& matrix) { \
         return Math::RectangularMatrix<1, size, T>(vector)*matrix;          \
     }
 #endif
@@ -593,8 +593,8 @@ namespace Implementation {
 
 template<std::size_t cols, std::size_t rows, class T> template<std::size_t ...sequence> inline constexpr RectangularMatrix<cols, rows, T>::RectangularMatrix(Implementation::Sequence<sequence...>, const Vector<DiagonalSize, T>& diagonal): _data{Implementation::diagonalMatrixColumn<rows, sequence>(sequence < DiagonalSize ? diagonal[sequence] : T{})...} {}
 
-template<std::size_t cols, std::size_t rows, class T> inline Vector<cols, T> RectangularMatrix<cols, rows, T>::row(std::size_t row) const {
-    Vector<cols, T> out;
+template<std::size_t cols, std::size_t rows, class T> inline constexpr Vector<cols, T> RectangularMatrix<cols, rows, T>::row(std::size_t row) const {
+    Vector<cols, T> out{};
 
     for(std::size_t i = 0; i != cols; ++i)
         out[i] = _data[i][row];
@@ -602,8 +602,8 @@ template<std::size_t cols, std::size_t rows, class T> inline Vector<cols, T> Rec
     return out;
 }
 
-template<std::size_t cols, std::size_t rows, class T> inline RectangularMatrix<cols, rows, T> RectangularMatrix<cols, rows, T>::operator-() const {
-    RectangularMatrix<cols, rows, T> out;
+template<std::size_t cols, std::size_t rows, class T> inline constexpr RectangularMatrix<cols, rows, T> RectangularMatrix<cols, rows, T>::operator-() const {
+    RectangularMatrix<cols, rows, T> out{};
 
     for(std::size_t i = 0; i != cols; ++i)
         out._data[i] = -_data[i];
@@ -611,8 +611,8 @@ template<std::size_t cols, std::size_t rows, class T> inline RectangularMatrix<c
     return out;
 }
 
-template<std::size_t cols, std::size_t rows, class T> template<std::size_t size> inline RectangularMatrix<size, rows, T> RectangularMatrix<cols, rows, T>::operator*(const RectangularMatrix<size, cols, T>& other) const {
-    RectangularMatrix<size, rows, T> out;
+template<std::size_t cols, std::size_t rows, class T> template<std::size_t size> inline constexpr RectangularMatrix<size, rows, T> RectangularMatrix<cols, rows, T>::operator*(const RectangularMatrix<size, cols, T>& other) const {
+    RectangularMatrix<size, rows, T> out{};
 
     for(std::size_t col = 0; col != size; ++col)
         for(std::size_t row = 0; row != rows; ++row)
@@ -622,8 +622,8 @@ template<std::size_t cols, std::size_t rows, class T> template<std::size_t size>
     return out;
 }
 
-template<std::size_t cols, std::size_t rows, class T> inline RectangularMatrix<rows, cols, T> RectangularMatrix<cols, rows, T>::transposed() const {
-    RectangularMatrix<rows, cols, T> out;
+template<std::size_t cols, std::size_t rows, class T> inline constexpr RectangularMatrix<rows, cols, T> RectangularMatrix<cols, rows, T>::transposed() const {
+    RectangularMatrix<rows, cols, T> out{};
 
     for(std::size_t col = 0; col != cols; ++col)
         for(std::size_t row = 0; row != rows; ++row)

--- a/src/Magnum/Math/Test/BoolVectorTest.cpp
+++ b/src/Magnum/Math/Test/BoolVectorTest.cpp
@@ -136,67 +136,87 @@ void BoolVectorTest::data() {
 }
 
 void BoolVectorTest::compare() {
-    BoolVector19 a(0xa5, 0x5f, 0x07);
-    CORRADE_VERIFY(a == a);
+    constexpr BoolVector19 a(0xa5, 0x5f, 0x07);
+    constexpr auto b = a == a;
+    CORRADE_VERIFY(b);
 
     /* Change in full segments */
-    BoolVector19 b(0xa3, 0x5f, 0x07);
-    BoolVector19 c(0xa5, 0x98, 0x07);
-    CORRADE_VERIFY(a != b);
-    CORRADE_VERIFY(a != c);
+    constexpr BoolVector19 c(0xa3, 0x5f, 0x07);
+    constexpr BoolVector19 d(0xa5, 0x98, 0x07);
+    constexpr auto e = a != c;
+    constexpr auto f = a != d;
+    CORRADE_VERIFY(e);
+    CORRADE_VERIFY(f);
 
     /* Change in last bit */
-    BoolVector19 d(0xa5, 0x5f, 0x06);
-    CORRADE_VERIFY(a != d);
+    constexpr BoolVector19 g(0xa5, 0x5f, 0x06);
+    constexpr auto h = a != g;
+    CORRADE_VERIFY(h);
 }
 
 void BoolVectorTest::compareUndefined() {
-    BoolVector19 a(0xa5, 0x5f, 0x07);
+    constexpr BoolVector19 a(0xa5, 0x5f, 0x07);
 
     /* Change in unused part of last segment */
-    BoolVector19 b(0xa5, 0x5f, 0x0f);
-    CORRADE_VERIFY(a == b);
+    constexpr BoolVector19 b(0xa5, 0x5f, 0x0f);
+    constexpr auto c = a == b;
+    CORRADE_VERIFY(c);
 
     /* Change in used part of last segment */
-    BoolVector19 c(0xa5, 0x5f, 0x03);
-    CORRADE_VERIFY(a != c);
+    constexpr BoolVector19 d(0xa5, 0x5f, 0x03);
+    constexpr auto e = a != d;
+    CORRADE_VERIFY(e);
 }
 
 void BoolVectorTest::all() {
-    CORRADE_VERIFY(BoolVector19(0xff, 0xff, 0x07).all());
+    constexpr auto a = BoolVector19(0xff, 0xff, 0x07).all();
+    CORRADE_VERIFY(a);
 
     /* Last segment - bit in used and unused part */
-    CORRADE_VERIFY(BoolVector19(0xff, 0xff, 0x0f).all());
-    CORRADE_VERIFY(!BoolVector19(0xff, 0xff, 0x04).all());
+    constexpr auto b = BoolVector19(0xff, 0xff, 0x0f).all();
+    constexpr auto c = BoolVector19(0xff, 0xff, 0x04).all();
+    CORRADE_VERIFY(b);
+    CORRADE_VERIFY(!c);
 }
 
 void BoolVectorTest::none() {
-    CORRADE_VERIFY(BoolVector19(0x00, 0x00, 0x00).none());
+    constexpr auto a = BoolVector19(0x00, 0x00, 0x00).none();
+    CORRADE_VERIFY(a);
 
     /* Last segment - bit in used and unused part */
-    CORRADE_VERIFY(BoolVector19(0x00, 0x00, 0x08).none());
-    CORRADE_VERIFY(!BoolVector19(0x00, 0x00, 0x04).none());
+    constexpr auto b = BoolVector19(0x00, 0x00, 0x08).none();
+    constexpr auto c = BoolVector19(0x00, 0x00, 0x04).none();
+    CORRADE_VERIFY(b);
+    CORRADE_VERIFY(!c);
 }
 
 void BoolVectorTest::any() {
-    CORRADE_VERIFY(BoolVector19(0x00, 0x01, 0x00).any());
+    constexpr auto a = BoolVector19(0x00, 0x01, 0x00).any();
+    CORRADE_VERIFY(a);
 
     /* Last segment - bit in used and unused part */
-    CORRADE_VERIFY(BoolVector19(0x00, 0x00, 0x04).any());
-    CORRADE_VERIFY(!BoolVector19(0x00, 0x00, 0x08).any());
+    constexpr auto b = BoolVector19(0x00, 0x00, 0x04).any();
+    constexpr auto c = BoolVector19(0x00, 0x00, 0x08).any();
+    CORRADE_VERIFY(b);
+    CORRADE_VERIFY(!c);
 }
 
 void BoolVectorTest::bitInverse() {
-    CORRADE_COMPARE(~BoolVector19(0xa5, 0x5f, 0x03), BoolVector19(0x5a, 0xa0, 0x04));
+    constexpr auto a = ~BoolVector19(0xa5, 0x5f, 0x03);
+    CORRADE_COMPARE(a, BoolVector19(0x5a, 0xa0, 0x04));
 }
 
 void BoolVectorTest::bitAndOrXor() {
-    BoolVector19 a(0xa5, 0x5f, 0x03);
-    BoolVector19 b(0x37, 0xf3, 0x06);
+    constexpr BoolVector19 a(0xa5, 0x5f, 0x03);
+    constexpr BoolVector19 b(0x37, 0xf3, 0x06);
 
-    CORRADE_COMPARE(a & b, BoolVector19(0x25, 0x53, 0x02));
-    CORRADE_COMPARE(a | b, BoolVector19(0xb7, 0xff, 0x07));
-    CORRADE_COMPARE(a ^ b, BoolVector19(0x92, 0xac, 0x05));
+    constexpr auto c = a & b;
+    constexpr auto d = a | b;
+    constexpr auto e = a ^ b;
+
+    CORRADE_COMPARE(c, BoolVector19(0x25, 0x53, 0x02));
+    CORRADE_COMPARE(d, BoolVector19(0xb7, 0xff, 0x07));
+    CORRADE_COMPARE(e, BoolVector19(0x92, 0xac, 0x05));
 }
 
 void BoolVectorTest::debug() {

--- a/src/Magnum/Math/Test/Matrix3Test.cpp
+++ b/src/Magnum/Math/Test/Matrix3Test.cpp
@@ -259,7 +259,8 @@ void Matrix3Test::projection() {
                      {     0.0f, 2.0f/3.0f, 0.0f},
                      {     0.0f,      0.0f, 1.0f});
 
-    CORRADE_COMPARE(Matrix3::projection({4.0f, 3.0f}), expected);
+    constexpr auto a = Matrix3::projection({4.0f, 3.0f});
+    CORRADE_COMPARE(a, expected);
 }
 
 void Matrix3Test::fromParts() {

--- a/src/Magnum/Math/Test/Matrix4Test.cpp
+++ b/src/Magnum/Math/Test/Matrix4Test.cpp
@@ -318,19 +318,23 @@ void Matrix4Test::reflection() {
 }
 
 void Matrix4Test::orthographicProjection() {
+    constexpr auto a = Matrix4::orthographicProjection({5.0f, 4.0f}, 1, 9);
+
     Matrix4 expected({0.4f, 0.0f,   0.0f, 0.0f},
                      {0.0f, 0.5f,   0.0f, 0.0f},
                      {0.0f, 0.0f, -0.25f, 0.0f},
                      {0.0f, 0.0f, -1.25f, 1.0f});
-    CORRADE_COMPARE(Matrix4::orthographicProjection({5.0f, 4.0f}, 1, 9), expected);
+    CORRADE_COMPARE(a, expected);
 }
 
 void Matrix4Test::perspectiveProjection() {
+    constexpr auto a = Matrix4::perspectiveProjection({16.0f, 9.0f}, 32.0f, 100);
+
     Matrix4 expected({4.0f,      0.0f,         0.0f,  0.0f},
                      {0.0f, 7.111111f,         0.0f,  0.0f},
                      {0.0f,      0.0f,  -1.9411764f, -1.0f},
                      {0.0f,      0.0f, -94.1176452f,  0.0f});
-    CORRADE_COMPARE(Matrix4::perspectiveProjection({16.0f, 9.0f}, 32.0f, 100), expected);
+    CORRADE_COMPARE(a, expected);
 }
 
 void Matrix4Test::perspectiveProjectionFov() {

--- a/src/Magnum/Math/Test/MatrixTest.cpp
+++ b/src/Magnum/Math/Test/MatrixTest.cpp
@@ -214,7 +214,7 @@ void MatrixTest::isOrthogonal() {
 }
 
 void MatrixTest::trace() {
-    Matrix<5, Int> m(
+    constexpr Matrix<5, Int> m(
         Vector<5, Int>(1, 2,   3,  0,  0),
         Vector<5, Int>(2, 3,   2,  1, -2),
         Vector<5, Int>(1, 1, -20,  1,  0),
@@ -222,24 +222,27 @@ void MatrixTest::trace() {
         Vector<5, Int>(3, 1,   0,  1, -2)
     );
 
-    CORRADE_COMPARE(m.trace(), -8);
+    constexpr auto a = m.trace();
+
+    CORRADE_COMPARE(a, -8);
 }
 
 void MatrixTest::ij() {
-    Matrix4x4 original(Vector4( 0.0f,  1.0f,  2.0f,  3.0f),
-                       Vector4( 4.0f,  5.0f,  6.0f,  7.0f),
-                       Vector4( 8.0f,  9.0f, 10.0f, 11.0f),
-                       Vector4(12.0f, 13.0f, 14.0f, 15.0f));
+    constexpr Matrix4x4 original(Vector4( 0.0f,  1.0f,  2.0f,  3.0f),
+                                 Vector4( 4.0f,  5.0f,  6.0f,  7.0f),
+                                 Vector4( 8.0f,  9.0f, 10.0f, 11.0f),
+                                 Vector4(12.0f, 13.0f, 14.0f, 15.0f));
 
     Matrix3x3 skipped(Vector3( 0.0f,  1.0f,  3.0f),
                       Vector3( 8.0f,  9.0f, 11.0f),
                       Vector3(12.0f, 13.0f, 15.0f));
 
-    CORRADE_COMPARE(original.ij(1, 2), skipped);
+    constexpr auto a = original.ij(1, 2);
+    CORRADE_COMPARE(a, skipped);
 }
 
 void MatrixTest::determinant() {
-    Matrix<5, Int> m(
+    constexpr Matrix<5, Int> m(
         Vector<5, Int>(1, 2, 2, 1,  0),
         Vector<5, Int>(2, 3, 2, 1, -2),
         Vector<5, Int>(1, 1, 1, 1,  0),
@@ -247,21 +250,22 @@ void MatrixTest::determinant() {
         Vector<5, Int>(3, 1, 0, 1, -2)
     );
 
-    CORRADE_COMPARE(m.determinant(), -2);
+    constexpr auto a = m.determinant();
+    CORRADE_COMPARE(a, -2);
 }
 
 void MatrixTest::inverted() {
-    Matrix4x4 m(Vector4(3.0f,  5.0f, 8.0f, 4.0f),
-                Vector4(4.0f,  4.0f, 7.0f, 3.0f),
-                Vector4(7.0f, -1.0f, 8.0f, 0.0f),
-                Vector4(9.0f,  4.0f, 5.0f, 9.0f));
+    constexpr Matrix4x4 m(Vector4(3.0f,  5.0f, 8.0f, 4.0f),
+                          Vector4(4.0f,  4.0f, 7.0f, 3.0f),
+                          Vector4(7.0f, -1.0f, 8.0f, 0.0f),
+                          Vector4(9.0f,  4.0f, 5.0f, 9.0f));
 
-    Matrix4x4 inverse(Vector4(-60/103.0f,   71/103.0f,  -4/103.0f,  3/103.0f),
-                      Vector4(-66/103.0f,  109/103.0f, -25/103.0f, -7/103.0f),
-                      Vector4(177/412.0f,  -97/206.0f,  53/412.0f, -7/206.0f),
-                      Vector4(259/412.0f, -185/206.0f,  31/412.0f, 27/206.0f));
+    constexpr Matrix4x4 inverse(Vector4(-60/103.0f,   71/103.0f,  -4/103.0f,  3/103.0f),
+                                Vector4(-66/103.0f,  109/103.0f, -25/103.0f, -7/103.0f),
+                                Vector4(177/412.0f,  -97/206.0f,  53/412.0f, -7/206.0f),
+                                Vector4(259/412.0f, -185/206.0f,  31/412.0f, 27/206.0f));
 
-    Matrix4x4 _inverse = m.inverted();
+    constexpr Matrix4x4 _inverse = m.inverted();
 
     CORRADE_COMPARE(_inverse, inverse);
     CORRADE_COMPARE(_inverse*m, Matrix4x4());
@@ -315,26 +319,36 @@ void MatrixTest::subclassTypes() {
 }
 
 void MatrixTest::subclass() {
-    const Mat2 a(Vec2(2.0f, 3.5f),
-                 Vec2(3.0f, 1.0f));
+    constexpr Mat2 a(Vec2(2.0f, 3.5f),
+                     Vec2(3.0f, 1.0f));
+    constexpr auto a0 = a[1];
+    constexpr auto a1 = a.row(1);
+    CORRADE_COMPARE(a0, Vec2(3.0f, 1.0f));
+    CORRADE_COMPARE(a1, Vec2(3.5f, 1.0f));
+
     Mat2 b(Vec2(2.0f, 3.5f),
            Vec2(3.0f, 1.0f));
-    CORRADE_COMPARE(a[1], Vec2(3.0f, 1.0f));
     CORRADE_COMPARE(b[1], Vec2(3.0f, 1.0f));
-    CORRADE_COMPARE(a.row(1), Vec2(3.5f, 1.0f));
 
-    CORRADE_COMPARE(a*b, Mat2(Vec2(14.5f, 10.5f),
-                              Vec2(9.0f, 11.5f)));
-    CORRADE_COMPARE(a*Vec2(1.0f, 0.5f), Vec2(3.5f, 4.0f));
+    constexpr Mat2 cb(Vec2(2.0f, 3.5f),
+                      Vec2(3.0f, 1.0f));
+    constexpr auto b0 = a*cb;
+    constexpr auto b1 = a*Vec2(1.0f, 0.5f);
+    CORRADE_COMPARE(b0, Mat2(Vec2(14.5f, 10.5f),
+                             Vec2(9.0f, 11.5f)));
+    CORRADE_COMPARE(b1, Vec2(3.5f, 4.0f));
 
-    CORRADE_COMPARE(a.transposed(), Mat2(Vec2(2.0f, 3.0f),
-                                         Vec2(3.5f, 1.0f)));
-    CORRADE_COMPARE(a.diagonal(), Vec2(2.0f, 1.0f));
+    constexpr auto b2 = a.transposed();
+    constexpr auto b3 = a.diagonal();
+    CORRADE_COMPARE(b2, Mat2(Vec2(2.0f, 3.0f),
+                             Vec2(3.5f, 1.0f)));
+    CORRADE_COMPARE(b3, Vec2(2.0f, 1.0f));
 
-    Mat2 c(Vec2(Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f),
-           Vec2(-Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f));
-    CORRADE_COMPARE(c.inverted(), Mat2(Vec2(Constants::sqrt2()/2.0f, -Constants::sqrt2()/2.0f),
-                                       Vec2(Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f)));
+    constexpr Mat2 c(Vec2(Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f),
+                     Vec2(-Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f));
+    constexpr auto c0 = c.inverted();
+    CORRADE_COMPARE(c0, Mat2(Vec2(Constants::sqrt2()/2.0f, -Constants::sqrt2()/2.0f),
+                             Vec2(Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f)));
     CORRADE_COMPARE(c.invertedOrthogonal(), Mat2(Vec2(Constants::sqrt2()/2.0f, -Constants::sqrt2()/2.0f),
                                                  Vec2(Constants::sqrt2()/2.0f, Constants::sqrt2()/2.0f)));
 }

--- a/src/Magnum/Math/Test/RectangularMatrixTest.cpp
+++ b/src/Magnum/Math/Test/RectangularMatrixTest.cpp
@@ -241,23 +241,24 @@ void RectangularMatrixTest::data() {
                                  Vector4(4.0f, 5.0f, 6.0f, 7.0f)));
 
     /* Pointer chasings, i.e. *(b.data()[1]), are not possible */
-    constexpr Matrix3x4 a(Vector4(3.0f,  5.0f, 8.0f, 4.0f),
-                          Vector4(4.5f,  4.0f, 7.0f, 3.0f),
-                          Vector4(7.0f, -1.7f, 8.0f, 0.0f));
-    constexpr Vector4 b = a[2];
-    constexpr Float c = a[1][2];
-    constexpr Float d = *a.data();
+    constexpr const Matrix3x4 a(Vector4(3.0f,  5.0f, 8.0f, 4.0f),
+                                Vector4(4.5f,  4.0f, 7.0f, 3.0f),
+                                Vector4(7.0f, -1.7f, 8.0f, 0.0f));
+    constexpr auto b = a[2];
+    constexpr auto c = a[1][2];
+    constexpr auto d = *a.data();
     CORRADE_COMPARE(b, Vector4(7.0f, -1.7f, 8.0f, 0.0f));
     CORRADE_COMPARE(c, 7.0f);
     CORRADE_COMPARE(d, 3.0f);
 }
 
 void RectangularMatrixTest::row() {
-    const Matrix3x4 a(Vector4(1.0f,  2.0f,  3.0f,  4.0f),
-                      Vector4(5.0f,  6.0f,  7.0f,  8.0f),
-                      Vector4(9.0f, 10.0f, 11.0f, 12.0f));
+    constexpr Matrix3x4 a(Vector4(1.0f,  2.0f,  3.0f,  4.0f),
+                          Vector4(5.0f,  6.0f,  7.0f,  8.0f),
+                          Vector4(9.0f, 10.0f, 11.0f, 12.0f));
 
-    CORRADE_COMPARE(a.row(1), Vector3(2.0f, 6.0f, 10.0f));
+    constexpr auto b = a.row(1);
+    CORRADE_COMPARE(b, Vector3(2.0f, 6.0f, 10.0f));
 }
 
 void RectangularMatrixTest::compare() {
@@ -279,58 +280,67 @@ void RectangularMatrixTest::compare() {
 }
 
 void RectangularMatrixTest::negative() {
-    Matrix2x2 matrix(Vector2(1.0f,  -3.0f),
-                     Vector2(5.0f, -10.0f));
-    Matrix2x2 negated(Vector2(-1.0f,  3.0f),
-                      Vector2(-5.0f, 10.0f));
-    CORRADE_COMPARE(-matrix, negated);
+    constexpr Matrix2x2 matrix(Vector2(1.0f,  -3.0f),
+                               Vector2(5.0f, -10.0f));
+    constexpr Matrix2x2 negated(Vector2(-1.0f,  3.0f),
+                                Vector2(-5.0f, 10.0f));
+
+    constexpr auto a = -matrix;
+    CORRADE_COMPARE(a, negated);
 }
 
 void RectangularMatrixTest::addSubtract() {
-    Matrix4x3 a(Vector3(0.0f,   1.0f,   3.0f),
-                Vector3(4.0f,   5.0f,   7.0f),
-                Vector3(8.0f,   9.0f,   11.0f),
-                Vector3(12.0f, 13.0f,  15.0f));
-    Matrix4x3 b(Vector3(-4.0f,  0.5f,   9.0f),
-                Vector3(-9.0f, 11.0f,  0.25f),
-                Vector3( 0.0f, -8.0f,  19.0f),
-                Vector3(-3.0f, -5.0f,   2.0f));
-    Matrix4x3 c(Vector3(-4.0f,  1.5f,  12.0f),
-                Vector3(-5.0f, 16.0f,  7.25f),
-                Vector3( 8.0f,  1.0f,  30.0f),
-                Vector3( 9.0f,  8.0f,  17.0f));
+    constexpr Matrix4x3 a(Vector3(0.0f,   1.0f,   3.0f),
+                          Vector3(4.0f,   5.0f,   7.0f),
+                          Vector3(8.0f,   9.0f,  11.0f),
+                          Vector3(12.0f, 13.0f,  15.0f));
+    constexpr Matrix4x3 b(Vector3(-4.0f,  0.5f,   9.0f),
+                          Vector3(-9.0f, 11.0f,  0.25f),
+                          Vector3( 0.0f, -8.0f,  19.0f),
+                          Vector3(-3.0f, -5.0f,   2.0f));
+    constexpr Matrix4x3 c(Vector3(-4.0f,  1.5f,  12.0f),
+                          Vector3(-5.0f, 16.0f,  7.25f),
+                          Vector3( 8.0f,  1.0f,  30.0f),
+                          Vector3( 9.0f,  8.0f,  17.0f));
 
-    CORRADE_COMPARE(a + b, c);
-    CORRADE_COMPARE(c - b, a);
+    constexpr auto d = a + b;
+    constexpr auto e = c - b;
+    CORRADE_COMPARE(d, c);
+    CORRADE_COMPARE(e, a);
 }
 
 void RectangularMatrixTest::multiplyDivide() {
-    Matrix2x2 matrix(Vector2(1.0f, 2.0f),
-                     Vector2(3.0f, 4.0f));
-    Matrix2x2 multiplied(Vector2(-1.5f, -3.0f),
-                         Vector2(-4.5f, -6.0f));
+    constexpr Matrix2x2 matrix(Vector2(1.0f, 2.0f),
+                               Vector2(3.0f, 4.0f));
+    constexpr Matrix2x2 multiplied(Vector2(-1.5f, -3.0f),
+                                   Vector2(-4.5f, -6.0f));
 
-    CORRADE_COMPARE(matrix*-1.5f, multiplied);
-    CORRADE_COMPARE(-1.5f*matrix, multiplied);
-    CORRADE_COMPARE(multiplied/-1.5f, matrix);
+    constexpr auto a = matrix*-1.5f;
+    constexpr auto b = -1.5f*matrix;
+    constexpr auto c = multiplied/-1.5f;
+    CORRADE_COMPARE(a, multiplied);
+    CORRADE_COMPARE(b, multiplied);
+    CORRADE_COMPARE(c, matrix);
 
     /* Divide vector with number and inverse */
-    Matrix2x2 divisor(Vector2( 1.0f, 2.0f),
-                      Vector2(-4.0f, 8.0f));
-    Matrix2x2 result(Vector2(  1.0f,   0.5f),
-                     Vector2(-0.25f, 0.125f));
-    CORRADE_COMPARE(1.0f/divisor, result);
+    constexpr Matrix2x2 divisor(Vector2( 1.0f, 2.0f),
+                                Vector2(-4.0f, 8.0f));
+    constexpr Matrix2x2 result(Vector2(  1.0f,   0.5f),
+                               Vector2(-0.25f, 0.125f));
+
+    constexpr auto d = 1.0f/divisor;
+    CORRADE_COMPARE(d, result);
 }
 
 void RectangularMatrixTest::multiply() {
-    RectangularMatrix<4, 6, Int> left(
+    constexpr RectangularMatrix<4, 6, Int> left(
         Vector<6, Int>(-5,   27, 10,  33, 0, -15),
         Vector<6, Int>( 7,   56, 66,   1, 0, -24),
         Vector<6, Int>( 4,   41,  4,   0, 1,  -4),
         Vector<6, Int>( 9, -100, 19, -49, 1,   9)
     );
 
-    RectangularMatrix<5, 4, Int> right(
+    constexpr RectangularMatrix<5, 4, Int> right(
         Vector<4, Int>(1,  -7,  0,  158),
         Vector<4, Int>(2,  24, -3,   40),
         Vector<4, Int>(3, -15, -2,  -50),
@@ -338,7 +348,7 @@ void RectangularMatrixTest::multiply() {
         Vector<4, Int>(5,  30,  4,   18)
     );
 
-    RectangularMatrix<5, 6, Int> expected(
+    constexpr RectangularMatrix<5, 6, Int> expected(
        Vector<6, Int>( 1368, -16165,  2550, -7716,  158,  1575),
        Vector<6, Int>(  506,  -2725,  2352, -1870,   37,  -234),
        Vector<6, Int>( -578,   4159, -1918,  2534,  -52,  -127),
@@ -346,36 +356,42 @@ void RectangularMatrixTest::multiply() {
        Vector<6, Int>(  363,    179,  2388,  -687,   22,  -649)
     );
 
-    CORRADE_COMPARE(left*right, expected);
+    constexpr auto a = left*right;
+    CORRADE_COMPARE(a, expected);
 }
 
 void RectangularMatrixTest::multiplyVector() {
-    Vector4i a(-5, 27, 10, 33);
-    RectangularMatrix<3, 1, Int> b(1, 2, 3);
-    CORRADE_COMPARE(a*b, Matrix3x4i(
+    constexpr Vector4i a(-5, 27, 10, 33);
+    constexpr RectangularMatrix<3, 1, Int> b(1, 2, 3);
+
+    constexpr auto c = a*b;
+    CORRADE_COMPARE(c, Matrix3x4i(
        Vector4i( -5,  27, 10,  33),
        Vector4i(-10,  54, 20,  66),
        Vector4i(-15,  81, 30,  99)
     ));
 
-    Matrix3x4i c(Vector4i(0, 4,  8, 12),
-                 Vector4i(1, 5,  9, 13),
-                 Vector4i(3, 7, 11, 15));
-    Vector3i d(2, -2, 3);
-    CORRADE_COMPARE(c*d, Vector4i(7, 19, 31, 43));
+    constexpr Matrix3x4i d(Vector4i(0, 4,  8, 12),
+                           Vector4i(1, 5,  9, 13),
+                           Vector4i(3, 7, 11, 15));
+    constexpr Vector3i e(2, -2, 3);
+
+    constexpr auto f = d*e;
+    CORRADE_COMPARE(f, Vector4i(7, 19, 31, 43));
 }
 
 void RectangularMatrixTest::transposed() {
-    Matrix4x3 original(Vector3( 0.0f,  1.0f,  3.0f),
-                       Vector3( 4.0f,  5.0f,  7.0f),
-                       Vector3( 8.0f,  9.0f, 11.0f),
-                       Vector3(12.0f, 13.0f, 15.0f));
+    constexpr Matrix4x3 original(Vector3( 0.0f,  1.0f,  3.0f),
+                                 Vector3( 4.0f,  5.0f,  7.0f),
+                                 Vector3( 8.0f,  9.0f, 11.0f),
+                                 Vector3(12.0f, 13.0f, 15.0f));
 
-    Matrix3x4 transposed(Vector4(0.0f, 4.0f,  8.0f, 12.0f),
-                         Vector4(1.0f, 5.0f,  9.0f, 13.0f),
-                         Vector4(3.0f, 7.0f, 11.0f, 15.0f));
+    constexpr Matrix3x4 transposed(Vector4(0.0f, 4.0f,  8.0f, 12.0f),
+                                   Vector4(1.0f, 5.0f,  9.0f, 13.0f),
+                                   Vector4(3.0f, 7.0f, 11.0f, 15.0f));
 
-    CORRADE_COMPARE(original.transposed(), transposed);
+    constexpr auto a = original.transposed();
+    CORRADE_COMPARE(a, transposed);
 }
 
 void RectangularMatrixTest::diagonal() {
@@ -475,48 +491,59 @@ void RectangularMatrixTest::subclass() {
     CORRADE_COMPARE(Mat2x2::fromDiagonal({1.0f, -2.0f}), Mat2x2(Vector2(1.0f,  0.0f),
                                                                 Vector2(0.0f, -2.0f)));
 
-    const Mat2x2 a(Vector2(1.0f, -3.0f),
-                   Vector2(-3.0f, 1.0f));
-    CORRADE_COMPARE(-a, Mat2x2(Vector2(-1.0f, 3.0f),
+    constexpr const Mat2x2 a(Vector2(1.0f, -3.0f),
+                       Vector2(-3.0f, 1.0f));
+    constexpr auto a0 = -a;
+    CORRADE_COMPARE(a0, Mat2x2(Vector2(-1.0f, 3.0f),
                                Vector2(3.0f, -1.0f)));
 
-    Mat2x2 b(Vector2(-2.0f, 5.0f),
-             Vector2(5.0f, -2.0f));
-    const Mat2x2 bExpected(Vector2(-1.0f, 2.0f),
-                           Vector2(2.0f, -1.0f));
-    CORRADE_COMPARE(b + a, bExpected);
+    constexpr const Mat2x2 b(Vector2(-2.0f, 5.0f),
+                             Vector2(5.0f, -2.0f));
+    constexpr Mat2x2 bExpected(Vector2(-1.0f, 2.0f),
+                               Vector2(2.0f, -1.0f));
+    constexpr auto b0 = b + a;
+    CORRADE_COMPARE(b0, bExpected);
 
-    Mat2x2 c(Vector2(-2.0f, 5.0f),
-             Vector2(5.0f, -2.0f));
+    constexpr Mat2x2 c(Vector2(-2.0f, 5.0f),
+                       Vector2(5.0f, -2.0f));
     const Mat2x2 cExpected(Vector2(-3.0f, 8.0f),
                            Vector2(8.0f, -3.0f));
-    CORRADE_COMPARE(c - a, cExpected);
+    constexpr auto c0 = c - a;
+    CORRADE_COMPARE(c0, cExpected);
 
-    Mat2x2 d(Vector2(-2.0f, 5.0f),
-             Vector2(5.0f, -2.0f));
+    constexpr Mat2x2 d(Vector2(-2.0f, 5.0f),
+                       Vector2(5.0f, -2.0f));
     const Mat2x2 dExpected(Vector2(-4.0f, 10.0f),
                            Vector2(10.0f, -4.0f));
-    CORRADE_COMPARE(d*2.0f, dExpected);
-    CORRADE_COMPARE(2.0f*d, dExpected);
+    constexpr auto d0 = d*2.0f;
+    constexpr auto d1 = 2.0f*d;
+    CORRADE_COMPARE(d0, dExpected);
+    CORRADE_COMPARE(d1, dExpected);
 
-    Mat2x2 e(Vector2(-2.0f, 5.0f),
-             Vector2(5.0f, -2.0f));
-    CORRADE_COMPARE(e/0.5f, dExpected);
-    CORRADE_COMPARE(2.0f/e, Mat2x2(Vector2(-1.0f, 0.4f),
-                                   Vector2(0.4f, -1.0f)));
-    const Vector2 f(2.0f, 5.0f);
-    const Math::RectangularMatrix<2, 1, Float> g(3.0f, -1.0f);
-    CORRADE_COMPARE(f*g, Mat2x2(Vector2(6.0f, 15.0f),
-                                Vector2(-2.0f, -5.0f)));
+    constexpr Mat2x2 e(Vector2(-2.0f, 5.0f),
+                       Vector2(5.0f, -2.0f));
+    constexpr auto e0 = e/0.5f;
+    constexpr auto e1 = 2.0f/e;
+    CORRADE_COMPARE(e0, dExpected);
+    CORRADE_COMPARE(e1, Mat2x2(Vector2(-1.0f, 0.4f),
+                               Vector2(0.4f, -1.0f)));
+    constexpr const Vector2 f(2.0f, 5.0f);
+    constexpr const Math::RectangularMatrix<2, 1, Float> g(3.0f, -1.0f);
+    constexpr auto f0 = f*g;
+    CORRADE_COMPARE(f0, Mat2x2(Vector2(6.0f, 15.0f),
+                               Vector2(-2.0f, -5.0f)));
 
     /* Operators on variable-sized matrix */
-    const BasicMat<1, Float> h(-2.0f);
-    CORRADE_COMPARE(2.0f*h, (BasicMat<1, Float>(-4.0f)));
-    CORRADE_COMPARE(2.0f/h, (BasicMat<1, Float>(-1.0f)));
+    constexpr const BasicMat<1, Float> h(-2.0f);
+    constexpr auto h0 = 2.0f*h;
+    constexpr auto h1 = 2.0f/h;
+    CORRADE_COMPARE(h0, (BasicMat<1, Float>(-4.0f)));
+    CORRADE_COMPARE(h1, (BasicMat<1, Float>(-1.0f)));
 
-    const Math::Vector<1, Float> i(2.0f);
-    const Math::RectangularMatrix<1, 1, Float> j(3.0f);
-    CORRADE_COMPARE(i*j, (BasicMat<1, Float>(6.0f)));
+    constexpr const Math::Vector<1, Float> i(2.0f);
+    constexpr const Math::RectangularMatrix<1, 1, Float> j(3.0f);
+    constexpr auto i0 = i*j;
+    CORRADE_COMPARE(i0, (BasicMat<1, Float>(6.0f)));
 }
 
 void RectangularMatrixTest::debug() {

--- a/src/Magnum/Math/Test/Vector2Test.cpp
+++ b/src/Magnum/Math/Test/Vector2Test.cpp
@@ -157,17 +157,19 @@ void Vector2Test::access() {
     CORRADE_COMPARE(vec.y(), -2.0f);
 
     constexpr Vector2 cvec(1.0f, -2.0f);
-    constexpr Float x = cvec.x();
-    constexpr Float y = cvec.y();
-    CORRADE_COMPARE(x, 1.0f);
-    CORRADE_COMPARE(y, -2.0f);
+    constexpr auto cx = cvec.x();
+    constexpr auto cy = cvec.y();
+    CORRADE_COMPARE(cx, 1.0f);
+    CORRADE_COMPARE(cy, -2.0f);
 }
 
 void Vector2Test::cross() {
-    Vector2i a(1, -1);
-    Vector2i b(4, 3);
+    constexpr Vector2i a(1, -1);
+    constexpr Vector2i b(4, 3);
 
-    CORRADE_COMPARE(Vector2i::cross(a, b), 7);
+    constexpr auto c = Vector2i::cross(a, b);
+
+    CORRADE_COMPARE(c, 7);
     CORRADE_COMPARE(Vector3i::cross({a, 0}, {b, 0}), Vector3i(0, 0, Vector2i::cross(a, b)));
 }
 
@@ -186,14 +188,16 @@ void Vector2Test::scales() {
 }
 
 void Vector2Test::perpendicular() {
-    const Vector2 a(0.5f, -15.0f);
-    CORRADE_COMPARE(a.perpendicular(), Vector2(15.0f, 0.5f));
+    constexpr Vector2 a(0.5f, -15.0f);
+    constexpr auto b = a.perpendicular();
+    CORRADE_COMPARE(b, Vector2(15.0f, 0.5f));
     CORRADE_COMPARE(Vector2::dot(a.perpendicular(), a), 0.0f);
     CORRADE_COMPARE(Vector2::xAxis().perpendicular(), Vector2::yAxis());
 }
 
 void Vector2Test::aspectRatio() {
-    CORRADE_COMPARE(Vector2(3.0f, 4.0f).aspectRatio(), 0.75f);
+    constexpr auto a = Vector2(3.0f, 4.0f).aspectRatio();
+    CORRADE_COMPARE(a, 0.75f);
 }
 
 void Vector2Test::minmax() {

--- a/src/Magnum/Math/Test/Vector3Test.cpp
+++ b/src/Magnum/Math/Test/Vector3Test.cpp
@@ -166,25 +166,27 @@ void Vector3Test::access() {
     CORRADE_COMPARE(vec.b(), 5.0f);
 
     constexpr Vector3 cvec(1.0f, -2.0f, 5.0f);
-    constexpr Float x = cvec.x();
-    constexpr Float r = cvec.r();
-    constexpr Float y = cvec.y();
-    constexpr Float g = cvec.g();
-    constexpr Float z = cvec.z();
-    constexpr Float b = cvec.b();
-    CORRADE_COMPARE(x, 1.0f);
-    CORRADE_COMPARE(r, 1.0f);
-    CORRADE_COMPARE(y, -2.0f);
-    CORRADE_COMPARE(g, -2.0f);
-    CORRADE_COMPARE(z, 5.0f);
-    CORRADE_COMPARE(b, 5.0f);
+    constexpr auto cx = cvec.x();
+    constexpr auto cr = cvec.r();
+    constexpr auto cy = cvec.y();
+    constexpr auto cg = cvec.g();
+    constexpr auto cz = cvec.z();
+    constexpr auto cb = cvec.b();
+    CORRADE_COMPARE(cx, 1.0f);
+    CORRADE_COMPARE(cr, 1.0f);
+    CORRADE_COMPARE(cy, -2.0f);
+    CORRADE_COMPARE(cg, -2.0f);
+    CORRADE_COMPARE(cz, 5.0f);
+    CORRADE_COMPARE(cb, 5.0f);
 }
 
 void Vector3Test::cross() {
-    Vector3i a(1, -1, 1);
-    Vector3i b(4, 3, 7);
+    constexpr Vector3i a(1, -1, 1);
+    constexpr Vector3i b(4, 3, 7);
 
-    CORRADE_COMPARE(Vector3i::cross(a, b), Vector3i(-10, -3, 7));
+    constexpr auto c = Vector3i::cross(a, b);
+
+    CORRADE_COMPARE(c, Vector3i(-10, -3, 7));
 }
 
 void Vector3Test::axes() {

--- a/src/Magnum/Math/Test/Vector4Test.cpp
+++ b/src/Magnum/Math/Test/Vector4Test.cpp
@@ -155,7 +155,7 @@ void Vector4Test::convert() {
 }
 
 void Vector4Test::access() {
-    Vector4 vec(1.0f, -2.0f, 5.0f, 0.5f);
+    constexpr Vector4 vec(1.0f, -2.0f, 5.0f, 0.5f);
     CORRADE_COMPARE(vec.x(), 1.0f);
     CORRADE_COMPARE(vec.r(), 1.0f);
     CORRADE_COMPARE(vec.y(), -2.0f);
@@ -165,23 +165,23 @@ void Vector4Test::access() {
     CORRADE_COMPARE(vec.w(), 0.5f);
     CORRADE_COMPARE(vec.a(), 0.5f);
 
-    constexpr Vector4 cvec(1.0f, -2.0f, 5.0f, 0.5f);
-    constexpr Float x = cvec.x();
-    constexpr Float r = cvec.r();
-    constexpr Float y = cvec.y();
-    constexpr Float g = cvec.g();
-    constexpr Float z = cvec.z();
-    constexpr Float b = cvec.b();
-    constexpr Float w = cvec.w();
-    constexpr Float a = cvec.a();
-    CORRADE_COMPARE(x, 1.0f);
-    CORRADE_COMPARE(r, 1.0f);
-    CORRADE_COMPARE(y, -2.0f);
-    CORRADE_COMPARE(g, -2.0f);
-    CORRADE_COMPARE(z, 5.0f);
-    CORRADE_COMPARE(b, 5.0f);
-    CORRADE_COMPARE(w, 0.5f);
-    CORRADE_COMPARE(a, 0.5f);
+    constexpr const Vector4 cvec(1.0f, -2.0f, 5.0f, 0.5f);
+    constexpr auto cx = cvec.x();
+    constexpr auto cr = cvec.r();
+    constexpr auto cy = cvec.y();
+    constexpr auto cg = cvec.g();
+    constexpr auto cz = cvec.z();
+    constexpr auto cb = cvec.b();
+    constexpr auto cw = cvec.w();
+    constexpr auto ca = cvec.a();
+    CORRADE_COMPARE(cx, 1.0f);
+    CORRADE_COMPARE(cr, 1.0f);
+    CORRADE_COMPARE(cy, -2.0f);
+    CORRADE_COMPARE(cg, -2.0f);
+    CORRADE_COMPARE(cz, 5.0f);
+    CORRADE_COMPARE(cb, 5.0f);
+    CORRADE_COMPARE(cw, 0.5f);
+    CORRADE_COMPARE(ca, 0.5f);
 }
 
 void Vector4Test::threeComponent() {
@@ -189,7 +189,7 @@ void Vector4Test::threeComponent() {
     CORRADE_COMPARE(a.xyz(), Vector3(1.0f, 2.0f, 3.0f));
     CORRADE_COMPARE(a.rgb(), Vector3(1.0f, 2.0f, 3.0f));
 
-    constexpr Vector4 b(1.0f, 2.0f, 3.0f, 4.0f);
+    constexpr const Vector4 b(1.0f, 2.0f, 3.0f, 4.0f);
     constexpr Vector3 c = b.xyz();
     constexpr Float d = b.xyz().y();
     CORRADE_COMPARE(c, Vector3(1.0f, 2.0f, 3.0f));
@@ -200,7 +200,7 @@ void Vector4Test::twoComponent() {
     Vector4 a(1.0f, 2.0f, 3.0f, 4.0f);
     CORRADE_COMPARE(a.xy(), Vector2(1.0f, 2.0f));
 
-    constexpr Vector4 b(1.0f, 2.0f, 3.0f, 4.0f);
+    constexpr const Vector4 b(1.0f, 2.0f, 3.0f, 4.0f);
     constexpr Vector2 c = b.xy();
     constexpr Float d = b.xy().x();
     CORRADE_COMPARE(c, Vector2(1.0f, 2.0f));

--- a/src/Magnum/Math/Test/VectorTest.cpp
+++ b/src/Magnum/Math/Test/VectorTest.cpp
@@ -245,8 +245,8 @@ void VectorTest::data() {
 
     /* Pointer chasings, i.e. *(b.data()[3]), are not possible */
     constexpr Vector4 a(1.0f, 2.0f, -3.0f, 4.5f);
-    constexpr Float f = a[3];
-    constexpr Float g = *a.data();
+    constexpr auto f = a[3];
+    constexpr auto g = *a.data();
     CORRADE_COMPARE(f, 4.5f);
     CORRADE_COMPARE(g, 1.0f);
 }
@@ -261,101 +261,145 @@ void VectorTest::compare() {
 
 void VectorTest::compareComponentWise() {
     typedef BoolVector<3> BoolVector3;
-    CORRADE_COMPARE(Vector3(1.0f, -1.0f, 5.0f) < Vector3(1.1f, -1.0f, 3.0f), BoolVector3(0x1));
-    CORRADE_COMPARE(Vector3(1.0f, -1.0f, 5.0f) <= Vector3(1.1f, -1.0f, 3.0f), BoolVector3(0x3));
-    CORRADE_COMPARE(Vector3(1.0f, -1.0f, 5.0f) >= Vector3(1.1f, -1.0f, 3.0f), BoolVector3(0x6));
-    CORRADE_COMPARE(Vector3(1.0f, -1.0f, 5.0f) > Vector3(1.1f, -1.0f, 3.0f), BoolVector3(0x4));
+
+    constexpr auto a = Vector3(1.0f, -1.0f, 5.0f) < Vector3(1.1f, -1.0f, 3.0f);
+    constexpr auto b = Vector3(1.0f, -1.0f, 5.0f) <= Vector3(1.1f, -1.0f, 3.0f);
+    constexpr auto c = Vector3(1.0f, -1.0f, 5.0f) >= Vector3(1.1f, -1.0f, 3.0f);
+    constexpr auto d = Vector3(1.0f, -1.0f, 5.0f) > Vector3(1.1f, -1.0f, 3.0f);
+
+    CORRADE_COMPARE(a, BoolVector3(0x1));
+    CORRADE_COMPARE(b, BoolVector3(0x3));
+    CORRADE_COMPARE(c, BoolVector3(0x6));
+    CORRADE_COMPARE(d, BoolVector3(0x4));
 }
 
 void VectorTest::negative() {
-    CORRADE_COMPARE(-Vector4(1.0f, -3.0f, 5.0f, -10.0f), Vector4(-1.0f, 3.0f, -5.0f, 10.0f));
+    constexpr auto a = -Vector4(1.0f, -3.0f, 5.0f, -10.0f);
+    CORRADE_COMPARE(a, Vector4(-1.0f, 3.0f, -5.0f, 10.0f));
 }
 
 void VectorTest::addSubtract() {
-    Vector4 a(1.0f, -3.0f, 5.0f, -10.0f);
-    Vector4 b(7.5f, 33.0f, -15.0f, 0.0f);
-    Vector4 c(8.5f, 30.0f, -10.0f, -10.0f);
+    constexpr Vector4 a(1.0f, -3.0f, 5.0f, -10.0f);
+    constexpr Vector4 b(7.5f, 33.0f, -15.0f, 0.0f);
+    constexpr Vector4 c(8.5f, 30.0f, -10.0f, -10.0f);
 
-    CORRADE_COMPARE(a + b, c);
-    CORRADE_COMPARE(c - b, a);
+    constexpr auto d = a + b;
+    constexpr auto e = c - b;
+
+    CORRADE_COMPARE(d, c);
+    CORRADE_COMPARE(e, a);
 }
 
 void VectorTest::multiplyDivide() {
-    Vector4 vector(1.0f, 2.0f, 3.0f, 4.0f);
-    Vector4 multiplied(-1.5f, -3.0f, -4.5f, -6.0f);
+    constexpr Vector4 vector(1.0f, 2.0f, 3.0f, 4.0f);
+    constexpr Vector4 multiplied(-1.5f, -3.0f, -4.5f, -6.0f);
 
-    CORRADE_COMPARE(vector*-1.5f, multiplied);
-    CORRADE_COMPARE(-1.5f*vector, multiplied);
-    CORRADE_COMPARE(multiplied/-1.5f, vector);
+    constexpr auto a = vector*-1.5f;
+    constexpr auto b = -1.5f*vector;
+    constexpr auto c = multiplied/-1.5f;
+
+    CORRADE_COMPARE(a, multiplied);
+    CORRADE_COMPARE(b, multiplied);
+    CORRADE_COMPARE(c, vector);
 
     /* Divide vector with number and invert */
-    Vector4 divisor(1.0f, 2.0f, -4.0f, 8.0f);
-    Vector4 result(1.0f, 0.5f, -0.25f, 0.125f);
-    CORRADE_COMPARE(1.0f/divisor, result);
+    constexpr Vector4 divisor(1.0f, 2.0f, -4.0f, 8.0f);
+    constexpr auto d = 1.0f/divisor;
+
+    CORRADE_COMPARE(d, Vector4(1.0f, 0.5f, -0.25f, 0.125f));
 }
 
 void VectorTest::multiplyDivideIntegral() {
-    Vector4i vector(32, 10, -6, 2);
-    Vector4i multiplied(-48, -15, 9, -3);
+    constexpr Vector4i vector(32, 10, -6, 2);
+    constexpr Vector4i multiplied(-48, -15, 9, -3);
 
-    CORRADE_COMPARE(vector*-1.5f, multiplied);
-    CORRADE_COMPARE(-1.5f*vector, multiplied);
+    constexpr auto a = vector*-1.5f;
+    constexpr auto b = -1.5f*vector;
 
-    CORRADE_COMPARE(multiplied/-1.5f, vector);
+    CORRADE_COMPARE(a, multiplied);
+    CORRADE_COMPARE(b, multiplied);
+
+    constexpr auto c = multiplied/-1.5f;
+
+    CORRADE_COMPARE(c, vector);
     /* Using integer vector as divisor is not supported */
 }
 
 void VectorTest::multiplyDivideComponentWise() {
-    Vector4 vec(1.0f, 2.0f, 3.0f, 4.0f);
-    Vector4 multiplier(7.0f, -4.0f, -1.5f, 1.0f);
-    Vector4 multiplied(7.0f, -8.0f, -4.5f, 4.0f);
+    constexpr Vector4 vec(1.0f, 2.0f, 3.0f, 4.0f);
+    constexpr Vector4 multiplier(7.0f, -4.0f, -1.5f, 1.0f);
+    constexpr Vector4 multiplied(7.0f, -8.0f, -4.5f, 4.0f);
 
-    CORRADE_COMPARE(vec*multiplier, multiplied);
-    CORRADE_COMPARE(multiplied/multiplier, vec);
+    constexpr auto a = vec*multiplier;
+    constexpr auto b = multiplied/multiplier;
+
+    CORRADE_COMPARE(a, multiplied);
+    CORRADE_COMPARE(b, vec);
 }
 
 void VectorTest::multiplyDivideComponentWiseIntegral() {
-    Vector4i vec(7, 2, -16, -1);
-    Vector4 multiplier(2.0f, -1.5f, 0.5f, 10.0f);
-    Vector4i multiplied(14, -3, -8, -10);
+    constexpr Vector4i vec(7, 2, -16, -1);
+    constexpr Vector4 multiplier(2.0f, -1.5f, 0.5f, 10.0f);
+    constexpr Vector4i multiplied(14, -3, -8, -10);
 
-    CORRADE_COMPARE(vec*multiplier, multiplied);
-    CORRADE_COMPARE(multiplier*vec, multiplied);
+    constexpr auto a = vec*multiplier;
+    constexpr auto b = multiplier*vec;
 
-    CORRADE_COMPARE(multiplied/multiplier, vec);
+    CORRADE_COMPARE(a, multiplied);
+    CORRADE_COMPARE(b, multiplied);
+
+    constexpr auto c = multiplied/multiplier;
+
+    CORRADE_COMPARE(c, vec);
     /* Using integer vector as divisor is not supported */
 }
 
 void VectorTest::modulo() {
     typedef Math::Vector<2, Int> Vector2i;
 
-    const Vector2i a(4, 13);
-    const Vector2i b(2, 5);
-    CORRADE_COMPARE(a % 2, Vector2i(0, 1));
-    CORRADE_COMPARE(a % b, Vector2i(0, 3));
+    constexpr Vector2i a(4, 13);
+    constexpr Vector2i b(2, 5);
+
+    constexpr auto c = a % 2;
+    constexpr auto d = a % b;
+
+    CORRADE_COMPARE(c, Vector2i(0, 1));
+    CORRADE_COMPARE(d, Vector2i(0, 3));
 }
 
 void VectorTest::bitwise() {
     typedef Math::Vector<2, Int> Vector2i;
 
-    const Vector2i a(85, 240);
-    const Vector2i b(170, 85);
-    CORRADE_COMPARE(~a, Vector2i(-86, -241));
-    CORRADE_COMPARE(a & b, Vector2i(0, 80));
-    CORRADE_COMPARE(a | b, Vector2i(255, 245));
-    CORRADE_COMPARE(a ^ b, Vector2i(255, 165));
+    constexpr Vector2i a(85, 240);
+    constexpr Vector2i b(170, 85);
 
-    const Vector2i c(7, 32);
-    CORRADE_COMPARE(c << 2, Vector2i(28, 128));
-    CORRADE_COMPARE(c >> 2, Vector2i(1, 8));
+    constexpr auto c = ~a;
+    constexpr auto d = a & b;
+    constexpr auto e = a | b;
+    constexpr auto f = a ^ b;
+
+    CORRADE_COMPARE(c, Vector2i(-86, -241));
+    CORRADE_COMPARE(d, Vector2i(0, 80));
+    CORRADE_COMPARE(e, Vector2i(255, 245));
+    CORRADE_COMPARE(f, Vector2i(255, 165));
+
+    constexpr Vector2i g(7, 32);
+
+    constexpr auto h = g << 2;
+    constexpr auto i = g >> 2;
+
+    CORRADE_COMPARE(h, Vector2i(28, 128));
+    CORRADE_COMPARE(i, Vector2i(1, 8));
 }
 
 void VectorTest::dot() {
-    CORRADE_COMPARE(Vector4::dot({1.0f, 0.5f, 0.75f, 1.5f}, {2.0f, 4.0f, 1.0f, 7.0f}), 15.25f);
+    constexpr auto a = Vector4::dot({1.0f, 0.5f, 0.75f, 1.5f}, {2.0f, 4.0f, 1.0f, 7.0f});
+    CORRADE_COMPARE(a, 15.25f);
 }
 
 void VectorTest::dotSelf() {
-    CORRADE_COMPARE(Vector4(1.0f, 2.0f, 3.0f, 4.0f).dot(), 30.0f);
+    constexpr auto a = Vector4(1.0f, 2.0f, 3.0f, 4.0f).dot();
+    CORRADE_COMPARE(a, 30.0f);
 }
 
 void VectorTest::length() {
@@ -379,11 +423,13 @@ void VectorTest::resized() {
 }
 
 void VectorTest::sum() {
-    CORRADE_COMPARE(Vector3(1.0f, 2.0f, 4.0f).sum(), 7.0f);
+    constexpr auto a = Vector3(1.0f, 2.0f, 4.0f).sum();
+    CORRADE_COMPARE(a, 7.0f);
 }
 
 void VectorTest::product() {
-    CORRADE_COMPARE(Vector3(1.0f, 2.0f, 3.0f).product(), 6.0f);
+    constexpr auto a = Vector3(1.0f, 2.0f, 3.0f).product();
+    CORRADE_COMPARE(a, 6.0f);
 }
 
 void VectorTest::min() {
@@ -522,38 +568,60 @@ void VectorTest::subclass() {
     const Float cdata[] = {1.0f, -2.0f};
     CORRADE_COMPARE(Vec2::from(cdata), Vec2(1.0f, -2.0f));
 
-    CORRADE_COMPARE(Vec2(-2.0f, 5.0f) + Vec2(1.0f, -3.0f), Vec2(-1.0f, 2.0f));
-    CORRADE_COMPARE(Vec2(-2.0f, 5.0f) - Vec2(1.0f, -3.0f), Vec2(-3.0f, 8.0f));
+    constexpr auto a = Vec2(-2.0f, 5.0f) + Vec2(1.0f, -3.0f);
+    constexpr auto b = Vec2(-2.0f, 5.0f) - Vec2(1.0f, -3.0f);
+    CORRADE_COMPARE(a, Vec2(-1.0f, 2.0f));
+    CORRADE_COMPARE(b, Vec2(-3.0f, 8.0f));
 
-    CORRADE_COMPARE(Vec2(-2.0f, 5.0f)*2.0f, Vec2(-4.0f, 10.0f));
-    CORRADE_COMPARE(2.0f*Vec2(-2.0f, 5.0f), Vec2(-4.0f, 10.0f));
-    CORRADE_COMPARE(Vec2(-2.0f, 5.0f)/0.5f, Vec2(-4.0f, 10.0f));
-    CORRADE_COMPARE(2.0f/Vec2(-2.0f, 5.0f), Vec2(-1.0f, 0.4f));
+    constexpr auto c = Vec2(-2.0f, 5.0f)*2.0f;
+    constexpr auto d = 2.0f*Vec2(-2.0f, 5.0f);
+    constexpr auto e = Vec2(-2.0f, 5.0f)/0.5f;
+    constexpr auto f = 2.0f/Vec2(-2.0f, 5.0f);
+    CORRADE_COMPARE(c, Vec2(-4.0f, 10.0f));
+    CORRADE_COMPARE(d, Vec2(-4.0f, 10.0f));
+    CORRADE_COMPARE(e, Vec2(-4.0f, 10.0f));
+    CORRADE_COMPARE(f, Vec2(-1.0f, 0.4f));
 
-    CORRADE_COMPARE(Vec2(-2.0f, 5.0f)*Vec2(1.5f, -2.0f), Vec2(-3.0f, -10.0f));
-    CORRADE_COMPARE(Vec2(-2.0f, 5.0f)/Vec2(2.0f/3.0f, -0.5f), Vec2(-3.0f, -10.0f));
+    constexpr auto g = Vec2(-2.0f, 5.0f)*Vec2(1.5f, -2.0f);
+    constexpr auto h = Vec2(-2.0f, 5.0f)/Vec2(2.0f/3.0f, -0.5f);
+    CORRADE_COMPARE(g, Vec2(-3.0f, -10.0f));
+    CORRADE_COMPARE(h, Vec2(-3.0f, -10.0f));
 
     /* Modulo operations */
-    CORRADE_COMPARE(Vec2i(4, 13) % 2, Vec2i(0, 1));
-    CORRADE_COMPARE(Vec2i(4, 13) % Vec2i(2, 5), Vec2i(0, 3));
+    constexpr auto i = Vec2i(4, 13) % 2;
+    constexpr auto j = Vec2i(4, 13) % Vec2i(2, 5);
+    CORRADE_COMPARE(i, Vec2i(0, 1));
+    CORRADE_COMPARE(j, Vec2i(0, 3));
 
     /* Bitwise operations */
-    CORRADE_COMPARE(~Vec2i(85, 240), Vec2i(-86, -241));
-    CORRADE_COMPARE(Vec2i(85, 240) & Vec2i(170, 85), Vec2i(0, 80));
-    CORRADE_COMPARE(Vec2i(85, 240) | Vec2i(170, 85), Vec2i(255, 245));
-    CORRADE_COMPARE(Vec2i(85, 240) ^ Vec2i(170, 85), Vec2i(255, 165));
+    constexpr auto k = ~Vec2i(85, 240);
+    constexpr auto l = Vec2i(85, 240) & Vec2i(170, 85);
+    constexpr auto m = Vec2i(85, 240) | Vec2i(170, 85);
+    constexpr auto n = Vec2i(85, 240) ^ Vec2i(170, 85);
+    CORRADE_COMPARE(k, Vec2i(-86, -241));
+    CORRADE_COMPARE(l, Vec2i(0, 80));
+    CORRADE_COMPARE(m, Vec2i(255, 245));
+    CORRADE_COMPARE(n, Vec2i(255, 165));
 
-    CORRADE_COMPARE(Vec2i(7, 32) << 2, Vec2i(28, 128));
-    CORRADE_COMPARE(Vec2i(7, 32) >> 2, Vec2i(1, 8));
+    constexpr auto o = Vec2i(7, 32) << 2;
+    constexpr auto p = Vec2i(7, 32) >> 2;
+    CORRADE_COMPARE(o, Vec2i(28, 128));
+    CORRADE_COMPARE(p, Vec2i(1, 8));
 
     /* Integral multiplication/division */
-    CORRADE_COMPARE(Vec2i(2, 4)*1.5f, Vec2i(3, 6));
-    CORRADE_COMPARE(1.5f*Vec2i(2, 4), Vec2i(3, 6));
-    CORRADE_COMPARE(Vec2i(2, 4)/(2.0f/3.0f), Vec2i(3, 6));
+    constexpr auto q = Vec2i(2, 4)*1.5f;
+    constexpr auto r = 1.5f*Vec2i(2, 4);
+    constexpr auto s = Vec2i(2, 4)/(2.0f/3.0f);
+    CORRADE_COMPARE(q, Vec2i(3, 6));
+    CORRADE_COMPARE(r, Vec2i(3, 6));
+    CORRADE_COMPARE(s, Vec2i(3, 6));
 
-    CORRADE_COMPARE(Vec2i(2, 4)*Vec2(-1.5f, 0.5f), Vec2i(-3, 2));
-    CORRADE_COMPARE(Vec2(-1.5f, 0.5f)*Vec2i(2, 4), Vec2i(-3, 2));
-    CORRADE_COMPARE(Vec2i(2, 4)/Vec2(-2.0f/3.0f, 2.0f), Vec2i(-3, 2));
+    constexpr auto t = Vec2i(2, 4)*Vec2(-1.5f, 0.5f);
+    constexpr auto u = Vec2(-1.5f, 0.5f)*Vec2i(2, 4);
+    constexpr auto v = Vec2i(2, 4)/Vec2(-2.0f/3.0f, 2.0f);
+    CORRADE_COMPARE(t, Vec2i(-3, 2));
+    CORRADE_COMPARE(u, Vec2i(-3, 2));
+    CORRADE_COMPARE(v, Vec2i(-3, 2));
 
     /* Functions */
     CORRADE_COMPARE(Vec2(3.0f, 0.0f).normalized(), Vec2(1.0f, 0.0f));

--- a/src/Magnum/Math/Unit.h
+++ b/src/Magnum/Math/Unit.h
@@ -93,7 +93,7 @@ template<template<class> class Derived, class T> class Unit {
         }
 
         /** @brief Add and assign value */
-        Unit<Derived, T>& operator+=(Unit<Derived, T> other) {
+        constexpr Unit<Derived, T>& operator+=(Unit<Derived, T> other) {
             value += other.value;
             return *this;
         }
@@ -104,7 +104,7 @@ template<template<class> class Derived, class T> class Unit {
         }
 
         /** @brief Subtract and assign value */
-        Unit<Derived, T>& operator-=(Unit<Derived, T> other) {
+        constexpr Unit<Derived, T>& operator-=(Unit<Derived, T> other) {
             value -= other.value;
             return *this;
         }
@@ -115,7 +115,7 @@ template<template<class> class Derived, class T> class Unit {
         }
 
         /** @brief Multiply with number and assign */
-        Unit<Derived, T>& operator*=(T number) {
+        constexpr Unit<Derived, T>& operator*=(T number) {
             value *= number;
             return *this;
         }
@@ -126,7 +126,7 @@ template<template<class> class Derived, class T> class Unit {
         }
 
         /** @brief Divide with number and assign */
-        Unit<Derived, T>& operator/=(T number) {
+        constexpr Unit<Derived, T>& operator/=(T number) {
             value /= number;
             return *this;
         }

--- a/src/Magnum/Math/Vector.h
+++ b/src/Magnum/Math/Vector.h
@@ -91,7 +91,7 @@ template<std::size_t size, class T> class Vector {
          *      @ref Vector2::perpendicular()
          * @todoc Explicit reference when Doxygen can handle const
          */
-        static T dot(const Vector<size, T>& a, const Vector<size, T>& b) {
+        constexpr static T dot(const Vector<size, T>& a, const Vector<size, T>& b) {
             return (a*b).sum();
         }
 
@@ -155,7 +155,7 @@ template<std::size_t size, class T> class Vector {
         constexpr Vector(const Vector<size, T>&) = default;
 
         /** @brief Assignment operator */
-        Vector<size, T>& operator=(const Vector<size, T>&) = default;
+        constexpr Vector<size, T>& operator=(const Vector<size, T>&) = default;
 
         /** @brief Convert vector to external representation */
         template<class U, class V = decltype(Implementation::VectorConverter<size, T, U>::to(std::declval<Vector<size, T>>()))> constexpr explicit operator U() const {
@@ -168,7 +168,7 @@ template<std::size_t size, class T> class Vector {
          *
          * @see @ref operator[]()
          */
-        T* data() { return _data; }
+        constexpr T* data() { return _data; }
         constexpr const T* data() const { return _data; } /**< @overload */
 
         /**
@@ -176,7 +176,7 @@ template<std::size_t size, class T> class Vector {
          *
          * @see @ref data()
          */
-        T& operator[](std::size_t pos) { return _data[pos]; }
+        constexpr T& operator[](std::size_t pos) { return _data[pos]; }
         constexpr T operator[](std::size_t pos) const { return _data[pos]; } /**< @overload */
 
         /** @brief Equality comparison */
@@ -193,16 +193,16 @@ template<std::size_t size, class T> class Vector {
         }
 
         /** @brief Component-wise less than */
-        BoolVector<size> operator<(const Vector<size, T>& other) const;
+        constexpr BoolVector<size> operator<(const Vector<size, T>& other) const;
 
         /** @brief Component-wise less than or equal */
-        BoolVector<size> operator<=(const Vector<size, T>& other) const;
+        constexpr BoolVector<size> operator<=(const Vector<size, T>& other) const;
 
         /** @brief Component-wise greater than or equal */
-        BoolVector<size> operator>=(const Vector<size, T>& other) const;
+        constexpr BoolVector<size> operator>=(const Vector<size, T>& other) const;
 
         /** @brief Component-wise greater than */
-        BoolVector<size> operator>(const Vector<size, T>& other) const;
+        constexpr BoolVector<size> operator>(const Vector<size, T>& other) const;
 
         /**
          * @brief Whether the vector is zero
@@ -236,7 +236,7 @@ template<std::size_t size, class T> class Vector {
          * @f]
          * @see @ref Vector2::perpendicular()
          */
-        Vector<size, T> operator-() const;
+        constexpr Vector<size, T> operator-() const;
 
         /**
          * @brief Add and assign vector
@@ -245,7 +245,7 @@ template<std::size_t size, class T> class Vector {
          *      \boldsymbol a_i = \boldsymbol a_i + \boldsymbol b_i
          * @f]
          */
-        Vector<size, T>& operator+=(const Vector<size, T>& other) {
+        constexpr Vector<size, T>& operator+=(const Vector<size, T>& other) {
             for(std::size_t i = 0; i != size; ++i)
                 _data[i] += other._data[i];
 
@@ -257,7 +257,7 @@ template<std::size_t size, class T> class Vector {
          *
          * @see @ref operator+=(), @ref sum()
          */
-        Vector<size, T> operator+(const Vector<size, T>& other) const {
+        constexpr Vector<size, T> operator+(const Vector<size, T>& other) const {
             return Vector<size, T>(*this) += other;
         }
 
@@ -268,7 +268,7 @@ template<std::size_t size, class T> class Vector {
          *      \boldsymbol a_i = \boldsymbol a_i - \boldsymbol b_i
          * @f]
          */
-        Vector<size, T>& operator-=(const Vector<size, T>& other) {
+        constexpr Vector<size, T>& operator-=(const Vector<size, T>& other) {
             for(std::size_t i = 0; i != size; ++i)
                 _data[i] -= other._data[i];
 
@@ -280,7 +280,7 @@ template<std::size_t size, class T> class Vector {
          *
          * @see @ref operator-=()
          */
-        Vector<size, T> operator-(const Vector<size, T>& other) const {
+        constexpr Vector<size, T> operator-(const Vector<size, T>& other) const {
             return Vector<size, T>(*this) -= other;
         }
 
@@ -293,7 +293,7 @@ template<std::size_t size, class T> class Vector {
          * @see @ref operator*=(const Vector<size, T>&),
          *      @ref operator*=(Vector<size, Integral>&, FloatingPoint)
          */
-        Vector<size, T>& operator*=(T number) {
+        constexpr Vector<size, T>& operator*=(T number) {
             for(std::size_t i = 0; i != size; ++i)
                 _data[i] *= number;
 
@@ -307,7 +307,7 @@ template<std::size_t size, class T> class Vector {
          *      @ref operator*=(T), operator*(T, const Vector<size, T>&),
          *      @ref operator*(const Vector<size, Integral>&, FloatingPoint)
          */
-        Vector<size, T> operator*(T number) const {
+        constexpr Vector<size, T> operator*(T number) const {
             return Vector<size, T>(*this) *= number;
         }
 
@@ -320,7 +320,7 @@ template<std::size_t size, class T> class Vector {
          * @see @ref operator/=(const Vector<size, T>&),
          *      @ref operator/=(Vector<size, Integral>&, FloatingPoint)
          */
-        Vector<size, T>& operator/=(T number) {
+        constexpr Vector<size, T>& operator/=(T number) {
             for(std::size_t i = 0; i != size; ++i)
                 _data[i] /= number;
 
@@ -334,7 +334,7 @@ template<std::size_t size, class T> class Vector {
          *      @ref operator/=(T), operator/(T, const Vector<size, T>&),
          *      @ref operator/(const Vector<size, Integral>&, FloatingPoint)
          */
-        Vector<size, T> operator/(T number) const {
+        constexpr Vector<size, T> operator/(T number) const {
             return Vector<size, T>(*this) /= number;
         }
 
@@ -347,7 +347,7 @@ template<std::size_t size, class T> class Vector {
          * @see @ref operator*=(T),
          *      @ref operator*=(Vector<size, Integral>&, const Vector<size, FloatingPoint>&)
          */
-        Vector<size, T>& operator*=(const Vector<size, T>& other) {
+        constexpr Vector<size, T>& operator*=(const Vector<size, T>& other) {
             for(std::size_t i = 0; i != size; ++i)
                 _data[i] *= other._data[i];
 
@@ -361,7 +361,7 @@ template<std::size_t size, class T> class Vector {
          *      @ref operator*(const Vector<size, Integral>&, const Vector<size, FloatingPoint>&),
          *      @ref product()
          */
-        Vector<size, T> operator*(const Vector<size, T>& other) const {
+        constexpr Vector<size, T> operator*(const Vector<size, T>& other) const {
             return Vector<size, T>(*this) *= other;
         }
 
@@ -374,7 +374,7 @@ template<std::size_t size, class T> class Vector {
          * @see @ref operator/=(T),
          *      @ref operator/=(Vector<size, Integral>&, const Vector<size, FloatingPoint>&)
          */
-        Vector<size, T>& operator/=(const Vector<size, T>& other) {
+        constexpr Vector<size, T>& operator/=(const Vector<size, T>& other) {
             for(std::size_t i = 0; i != size; ++i)
                 _data[i] /= other._data[i];
 
@@ -387,7 +387,7 @@ template<std::size_t size, class T> class Vector {
          * @see @ref operator/(T) const, @ref operator/=(const Vector<size, T>&),
          *      @ref operator/(const Vector<size, Integral>&, const Vector<size, FloatingPoint>&)
          */
-        Vector<size, T> operator/(const Vector<size, T>& other) const {
+        constexpr Vector<size, T> operator/(const Vector<size, T>& other) const {
             return Vector<size, T>(*this) /= other;
         }
 
@@ -401,7 +401,7 @@ template<std::size_t size, class T> class Vector {
          * @see @ref dot(const Vector<size, T>&, const Vector<size, T>&),
          *      @ref isNormalized()
          */
-        T dot() const { return dot(*this, *this); }
+        constexpr T dot() const { return dot(*this, *this); }
 
         /**
          * @brief %Vector length
@@ -479,14 +479,14 @@ template<std::size_t size, class T> class Vector {
          *
          * @see @ref operator+()
          */
-        T sum() const;
+        constexpr T sum() const;
 
         /**
          * @brief Product of values in the vector
          *
          * @see @ref operator*(const Vector<size, T>&) const
          */
-        T product() const;
+        constexpr T product() const;
 
         /**
          * @brief Minimal value in the vector
@@ -517,7 +517,7 @@ template<std::size_t size, class T> class Vector {
 
 Same as @ref Vector::operator*(T) const.
 */
-template<std::size_t size, class T> inline Vector<size, T> operator*(
+template<std::size_t size, class T> inline constexpr Vector<size, T> operator*(
     #ifdef DOXYGEN_GENERATING_OUTPUT
     T
     #else
@@ -536,7 +536,7 @@ template<std::size_t size, class T> inline Vector<size, T> operator*(
 @f]
 @see @ref Vector::operator/(T) const
 */
-template<std::size_t size, class T> inline Vector<size, T> operator/(
+template<std::size_t size, class T> inline constexpr Vector<size, T> operator/(
     #ifdef DOXYGEN_GENERATING_OUTPUT
     T
     #else
@@ -544,7 +544,7 @@ template<std::size_t size, class T> inline Vector<size, T> operator/(
     #endif
     number, const Vector<size, T>& vector)
 {
-    Vector<size, T> out;
+    Vector<size, T> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out[i] = number/vector[i];
@@ -557,7 +557,7 @@ template<std::size_t size, class T> inline Vector<size, T> operator/(
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -573,7 +573,7 @@ operator%=(Vector<size, Integral>& a, Integral b) {
 /** @relates Vector
 @brief Modulo of integral vector
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -589,7 +589,7 @@ operator%(const Vector<size, Integral>& a, Integral b) {
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -605,7 +605,7 @@ operator%=(Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 /** @relates Vector
 @brief Modulo of two integral vectors
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -619,14 +619,14 @@ operator%(const Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 /** @relates Vector
 @brief Bitwise NOT of integral vector
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
 typename std::enable_if<std::is_integral<Integral>::value, Vector<size, Integral>>::type
 #endif
 operator~(const Vector<size, Integral>& vector) {
-    Vector<size, Integral> out;
+    Vector<size, Integral> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out[i] = ~vector[i];
@@ -639,7 +639,7 @@ operator~(const Vector<size, Integral>& vector) {
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -655,7 +655,7 @@ operator&=(Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 /** @relates Vector
 @brief Bitwise AND of two integral vectors
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -671,7 +671,7 @@ operator&(const Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -687,7 +687,7 @@ operator|=(Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 /** @relates Vector
 @brief Bitwise OR of two integral vectors
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -703,7 +703,7 @@ operator|(const Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -719,7 +719,7 @@ operator^=(Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 /** @relates Vector
 @brief Bitwise XOR of two integral vectors
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -735,7 +735,7 @@ operator^(const Vector<size, Integral>& a, const Vector<size, Integral>& b) {
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -758,7 +758,7 @@ operator<<=(Vector<size, Integral>& vector,
 /** @relates Vector
 @brief Bitwise left shift of integral vector
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -781,7 +781,7 @@ operator<<(const Vector<size, Integral>& vector,
 
 The computation is done in-place.
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -803,7 +803,7 @@ operator>>=(Vector<size, Integral>& vector,
 /** @relates Vector
 @brief Bitwise left shift of integral vector
 */
-template<std::size_t size, class Integral> inline
+template<std::size_t size, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -826,7 +826,7 @@ operator>>(const Vector<size, Integral>& vector,
 Similar to @ref Vector::operator*=(T), except that the multiplication is done
 in floating-point. The computation is done in-place.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -845,7 +845,7 @@ operator*=(Vector<size, Integral>& vector, FloatingPoint number) {
 Similar to @ref Vector::operator*(T) const, except that the multiplication is
 done in floating-point.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -861,7 +861,7 @@ operator*(const Vector<size, Integral>& vector, FloatingPoint number) {
 
 Same as @ref operator*(const Vector<size, Integral>&, FloatingPoint).
 */
-template<std::size_t size, class FloatingPoint, class Integral> inline
+template<std::size_t size, class FloatingPoint, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -877,7 +877,7 @@ operator*(FloatingPoint number, const Vector<size, Integral>& vector) {
 Similar to @ref Vector::operator/=(T), except that the division is done in
 floating-point. The computation is done in-place.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -896,7 +896,7 @@ operator/=(Vector<size, Integral>& vector, FloatingPoint number) {
 Similar to @ref Vector::operator/(T) const, except that the division is done in
 floating-point.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -913,7 +913,7 @@ operator/(const Vector<size, Integral>& vector, FloatingPoint number) {
 Similar to @ref Vector::operator*=(const Vector<size, T>&), except that the
 multiplication is done in floating-point. The computation is done in-place.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -934,7 +934,7 @@ the multiplication is done in floating-point. The result is always integral
 vector, convert both arguments to the same floating-point type to have
 floating-point result.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -950,7 +950,7 @@ operator*(const Vector<size, Integral>& a, const Vector<size, FloatingPoint>& b)
 
 Same as @ref operator*(const Vector<size, Integral>&, const Vector<size, FloatingPoint>&).
 */
-template<std::size_t size, class FloatingPoint, class Integral> inline
+template<std::size_t size, class FloatingPoint, class Integral> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -966,7 +966,7 @@ operator*(const Vector<size, FloatingPoint>& a, const Vector<size, Integral>& b)
 Similar to @ref Vector::operator/=(const Vector<size, T>&), except that the
 division is done in floating-point. The computation is done in-place.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>&
 #else
@@ -987,7 +987,7 @@ the division is done in floating-point. The result is always integral vector,
 convert both arguments to the same floating-point type to have floating-point
 result.
 */
-template<std::size_t size, class Integral, class FloatingPoint> inline
+template<std::size_t size, class Integral, class FloatingPoint> inline constexpr
 #ifdef DOXYGEN_GENERATING_OUTPUT
 Vector<size, Integral>
 #else
@@ -1038,54 +1038,54 @@ extern template Corrade::Utility::Debug MAGNUM_EXPORT operator<<(Corrade::Utilit
         return *reinterpret_cast<const Type<T>*>(data);                     \
     }                                                                       \
                                                                             \
-    Type<T>& operator=(const Type<T>& other) {                              \
+    constexpr Type<T>& operator=(const Type<T>& other) {                    \
         Math::Vector<size, T>::operator=(other);                            \
         return *this;                                                       \
     }                                                                       \
                                                                             \
-    Type<T> operator-() const {                                             \
+    constexpr Type<T> operator-() const {                                   \
         return Math::Vector<size, T>::operator-();                          \
     }                                                                       \
-    Type<T>& operator+=(const Math::Vector<size, T>& other) {               \
+    constexpr Type<T>& operator+=(const Math::Vector<size, T>& other) {     \
         Math::Vector<size, T>::operator+=(other);                           \
         return *this;                                                       \
     }                                                                       \
-    Type<T> operator+(const Math::Vector<size, T>& other) const {           \
+    constexpr Type<T> operator+(const Math::Vector<size, T>& other) const { \
         return Math::Vector<size, T>::operator+(other);                     \
     }                                                                       \
-    Type<T>& operator-=(const Math::Vector<size, T>& other) {               \
+    constexpr Type<T>& operator-=(const Math::Vector<size, T>& other) {     \
         Math::Vector<size, T>::operator-=(other);                           \
         return *this;                                                       \
     }                                                                       \
-    Type<T> operator-(const Math::Vector<size, T>& other) const {           \
+    constexpr Type<T> operator-(const Math::Vector<size, T>& other) const { \
         return Math::Vector<size, T>::operator-(other);                     \
     }                                                                       \
-    Type<T>& operator*=(T number) {                                         \
+    constexpr Type<T>& operator*=(T number) {                               \
         Math::Vector<size, T>::operator*=(number);                          \
         return *this;                                                       \
     }                                                                       \
-    Type<T> operator*(T number) const {                                     \
+    constexpr Type<T> operator*(T number) const {                           \
         return Math::Vector<size, T>::operator*(number);                    \
     }                                                                       \
-    Type<T>& operator/=(T number) {                                         \
+    constexpr Type<T>& operator/=(T number) {                               \
         Math::Vector<size, T>::operator/=(number);                          \
         return *this;                                                       \
     }                                                                       \
-    Type<T> operator/(T number) const {                                     \
+    constexpr Type<T> operator/(T number) const {                           \
         return Math::Vector<size, T>::operator/(number);                    \
     }                                                                       \
-    Type<T>& operator*=(const Math::Vector<size, T>& other) {               \
+    constexpr Type<T>& operator*=(const Math::Vector<size, T>& other) {     \
         Math::Vector<size, T>::operator*=(other);                           \
         return *this;                                                       \
     }                                                                       \
-    Type<T> operator*(const Math::Vector<size, T>& other) const {           \
+    constexpr Type<T> operator*(const Math::Vector<size, T>& other) const { \
         return Math::Vector<size, T>::operator*(other);                     \
     }                                                                       \
-    Type<T>& operator/=(const Math::Vector<size, T>& other) {               \
+    constexpr Type<T>& operator/=(const Math::Vector<size, T>& other) {     \
         Math::Vector<size, T>::operator/=(other);                           \
         return *this;                                                       \
     }                                                                       \
-    Type<T> operator/(const Math::Vector<size, T>& other) const {           \
+    constexpr Type<T> operator/(const Math::Vector<size, T>& other) const { \
         return Math::Vector<size, T>::operator/(other);                     \
     }                                                                       \
                                                                             \
@@ -1103,99 +1103,99 @@ extern template Corrade::Utility::Debug MAGNUM_EXPORT operator<<(Corrade::Utilit
     }
 
 #define MAGNUM_VECTORn_OPERATOR_IMPLEMENTATION(size, Type)                  \
-    template<class T> inline Type<T> operator*(typename std::common_type<T>::type number, const Type<T>& vector) { \
+    template<class T> inline constexpr Type<T> operator*(typename std::common_type<T>::type number, const Type<T>& vector) { \
         return number*static_cast<const Math::Vector<size, T>&>(vector);    \
     }                                                                       \
-    template<class T> inline Type<T> operator/(typename std::common_type<T>::type number, const Type<T>& vector) { \
+    template<class T> inline constexpr Type<T> operator/(typename std::common_type<T>::type number, const Type<T>& vector) { \
         return number/static_cast<const Math::Vector<size, T>&>(vector);    \
     }                                                                       \
                                                                             \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator%=(Type<Integral>& a, Integral b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator%=(Type<Integral>& a, Integral b) { \
         static_cast<Math::Vector<size, Integral>&>(a) %= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator%(const Type<Integral>& a, Integral b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator%(const Type<Integral>& a, Integral b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a) % b;     \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator%=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator%=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         static_cast<Math::Vector<size, Integral>&>(a) %= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator%(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator%(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a) % b;     \
     }                                                                       \
                                                                             \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator~(const Type<Integral>& vector) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator~(const Type<Integral>& vector) { \
         return ~static_cast<const Math::Vector<size, Integral>&>(vector);   \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator&=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator&=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         static_cast<Math::Vector<size, Integral>&>(a) &= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator&(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator&(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a) & b;     \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator|=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator|=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         static_cast<Math::Vector<size, Integral>&>(a) |= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator|(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator|(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a) | b;     \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator^=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator^=(Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         static_cast<Math::Vector<size, Integral>&>(a) ^= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator^(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator^(const Type<Integral>& a, const Math::Vector<size, Integral>& b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a) ^ b;     \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator<<=(Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator<<=(Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
         static_cast<Math::Vector<size, Integral>&>(vector) <<= shift;       \
         return vector;                                                      \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator<<(const Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator<<(const Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
         return static_cast<const Math::Vector<size, Integral>&>(vector) << shift; \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator>>=(Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>&>::type operator>>=(Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
         static_cast<Math::Vector<size, Integral>&>(vector) >>= shift;       \
         return vector;                                                      \
     }                                                                       \
-    template<class Integral> inline typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator>>(const Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
+    template<class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value, Type<Integral>>::type operator>>(const Type<Integral>& vector, typename std::common_type<Integral>::type shift) { \
         return static_cast<const Math::Vector<size, Integral>&>(vector) >> shift; \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator*=(Type<Integral>& vector, FloatingPoint number) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator*=(Type<Integral>& vector, FloatingPoint number) { \
         static_cast<Math::Vector<size, Integral>&>(vector) *= number;       \
         return vector;                                                      \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(const Type<Integral>& vector, FloatingPoint number) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(const Type<Integral>& vector, FloatingPoint number) { \
         return static_cast<const Math::Vector<size, Integral>&>(vector)*number; \
     }                                                                       \
-    template<class FloatingPoint, class Integral> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(FloatingPoint number, const Type<Integral>& vector) { \
+    template<class FloatingPoint, class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(FloatingPoint number, const Type<Integral>& vector) { \
         return number*static_cast<const Math::Vector<size, Integral>&>(vector); \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator/=(Type<Integral>& vector, FloatingPoint number) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator/=(Type<Integral>& vector, FloatingPoint number) { \
         static_cast<Math::Vector<size, Integral>&>(vector) /= number;       \
         return vector;                                                      \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator/(const Type<Integral>& vector, FloatingPoint number) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator/(const Type<Integral>& vector, FloatingPoint number) { \
         return static_cast<const Math::Vector<size, Integral>&>(vector)/number; \
     }                                                                       \
                                                                             \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator*=(Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator*=(Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
         static_cast<Math::Vector<size, Integral>&>(a) *= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(const Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(const Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a)*b;       \
     }                                                                       \
-    template<class FloatingPoint, class Integral> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(const Math::Vector<size, FloatingPoint>& a, const Type<Integral>& b) { \
+    template<class FloatingPoint, class Integral> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator*(const Math::Vector<size, FloatingPoint>& a, const Type<Integral>& b) { \
         return a*static_cast<const Math::Vector<size, Integral>&>(b);       \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator/=(Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>&>::type operator/=(Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
         static_cast<Math::Vector<size, Integral>&>(a) /= b;                 \
         return a;                                                           \
     }                                                                       \
-    template<class Integral, class FloatingPoint> inline typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator/(const Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
+    template<class Integral, class FloatingPoint> inline constexpr typename std::enable_if<std::is_integral<Integral>::value && std::is_floating_point<FloatingPoint>::value, Type<Integral>>::type operator/(const Type<Integral>& a, const Math::Vector<size, FloatingPoint>& b) { \
         return static_cast<const Math::Vector<size, Integral>&>(a)/b;       \
     }
 #endif
@@ -1206,8 +1206,8 @@ template<std::size_t size, class T> inline Rad<T> Vector<size, T>::angle(const V
     return Rad<T>(std::acos(dot(normalizedA, normalizedB)));
 }
 
-template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::operator<(const Vector<size, T>& other) const {
-    BoolVector<size> out;
+template<std::size_t size, class T> inline constexpr BoolVector<size> Vector<size, T>::operator<(const Vector<size, T>& other) const {
+    BoolVector<size> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out.set(i, _data[i] < other._data[i]);
@@ -1215,8 +1215,8 @@ template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::ope
     return out;
 }
 
-template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::operator<=(const Vector<size, T>& other) const {
-    BoolVector<size> out;
+template<std::size_t size, class T> inline constexpr BoolVector<size> Vector<size, T>::operator<=(const Vector<size, T>& other) const {
+    BoolVector<size> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out.set(i, _data[i] <= other._data[i]);
@@ -1224,8 +1224,8 @@ template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::ope
     return out;
 }
 
-template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::operator>=(const Vector<size, T>& other) const {
-    BoolVector<size> out;
+template<std::size_t size, class T> inline constexpr BoolVector<size> Vector<size, T>::operator>=(const Vector<size, T>& other) const {
+    BoolVector<size> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out.set(i, _data[i] >= other._data[i]);
@@ -1233,8 +1233,8 @@ template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::ope
     return out;
 }
 
-template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::operator>(const Vector<size, T>& other) const {
-    BoolVector<size> out;
+template<std::size_t size, class T> inline constexpr BoolVector<size> Vector<size, T>::operator>(const Vector<size, T>& other) const {
+    BoolVector<size> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out.set(i, _data[i] > other._data[i]);
@@ -1242,8 +1242,8 @@ template<std::size_t size, class T> inline BoolVector<size> Vector<size, T>::ope
     return out;
 }
 
-template<std::size_t size, class T> inline Vector<size, T> Vector<size, T>::operator-() const {
-    Vector<size, T> out;
+template<std::size_t size, class T> inline constexpr Vector<size, T> Vector<size, T>::operator-() const {
+    Vector<size, T> out{};
 
     for(std::size_t i = 0; i != size; ++i)
         out._data[i] = -_data[i];
@@ -1257,7 +1257,7 @@ template<std::size_t size, class T> inline Vector<size, T> Vector<size, T>::proj
     return line*dot(*this, line);
 }
 
-template<std::size_t size, class T> inline T Vector<size, T>::sum() const {
+template<std::size_t size, class T> inline constexpr T Vector<size, T>::sum() const {
     T out(_data[0]);
 
     for(std::size_t i = 1; i != size; ++i)
@@ -1266,7 +1266,7 @@ template<std::size_t size, class T> inline T Vector<size, T>::sum() const {
     return out;
 }
 
-template<std::size_t size, class T> inline T Vector<size, T>::product() const {
+template<std::size_t size, class T> inline constexpr T Vector<size, T>::product() const {
     T out(_data[0]);
 
     for(std::size_t i = 1; i != size; ++i)

--- a/src/Magnum/Math/Vector2.h
+++ b/src/Magnum/Math/Vector2.h
@@ -94,7 +94,7 @@ template<class T> class Vector2: public Vector<2, T> {
          * @see @ref perpendicular(),
          *      @ref dot(const Vector<size, T>&, const Vector<size, T>&)
          */
-        static T cross(const Vector2<T>& a, const Vector2<T>& b) {
+        constexpr static T cross(const Vector2<T>& a, const Vector2<T>& b) {
             return Vector<2, T>::dot(a.perpendicular(), b);
         }
 
@@ -122,9 +122,9 @@ template<class T> class Vector2: public Vector<2, T> {
         /** @brief Copy constructor */
         constexpr Vector2(const Vector<2, T>& other): Vector<2, T>(other) {}
 
-        T& x() { return (*this)[0]; }                   /**< @brief X component */
+        constexpr T& x() { return (*this)[0]; }         /**< @brief X component */
         constexpr T x() const { return (*this)[0]; }    /**< @overload */
-        T& y() { return (*this)[1]; }                   /**< @brief Y component */
+        constexpr T& y() { return (*this)[1]; }         /**< @brief Y component */
         constexpr T y() const { return (*this)[1]; }    /**< @overload */
 
         /**
@@ -137,7 +137,7 @@ template<class T> class Vector2: public Vector<2, T> {
          *      @ref dot(const Vector<size, T>&, const Vector<size, T>&),
          *      @ref operator-() const
          */
-        Vector2<T> perpendicular() const { return {-y(), x()}; }
+        constexpr Vector2<T> perpendicular() const { return {-y(), x()}; }
 
         /**
          * @brief Aspect ratio
@@ -146,7 +146,7 @@ template<class T> class Vector2: public Vector<2, T> {
          *      a = \frac{v_x}{v_y}
          * @f]
          */
-        T aspectRatio() const { return x()/y(); }
+        constexpr T aspectRatio() const { return x()/y(); }
 
         /**
          * @brief Minimum and maximum value

--- a/src/Magnum/Math/Vector3.h
+++ b/src/Magnum/Math/Vector3.h
@@ -110,7 +110,7 @@ template<class T> class Vector3: public Vector<3, T> {
          * @f]
          * @see @ref Vector2::cross()
          */
-        static Vector3<T> cross(const Vector3<T>& a, const Vector3<T>& b) {
+        constexpr static Vector3<T> cross(const Vector3<T>& a, const Vector3<T>& b) {
             return swizzle<'y', 'z', 'x'>(a)*swizzle<'z', 'x', 'y'>(b) -
                    swizzle<'z', 'x', 'y'>(a)*swizzle<'y', 'z', 'x'>(b);
         }
@@ -153,7 +153,7 @@ template<class T> class Vector3: public Vector<3, T> {
          *
          * @see @ref r()
          */
-        T& x() { return (*this)[0]; }
+        constexpr T& x() { return (*this)[0]; }
         constexpr T x() const { return (*this)[0]; }    /**< @overload */
 
         /**
@@ -161,7 +161,7 @@ template<class T> class Vector3: public Vector<3, T> {
          *
          * @see @ref g()
          */
-        T& y() { return (*this)[1]; }
+        constexpr T& y() { return (*this)[1]; }
         constexpr T y() const { return (*this)[1]; }    /**< @overload */
 
         /**
@@ -169,7 +169,7 @@ template<class T> class Vector3: public Vector<3, T> {
          *
          * @see @ref b()
          */
-        T& z() { return (*this)[2]; }
+        constexpr T& z() { return (*this)[2]; }
         constexpr T z() const { return (*this)[2]; }    /**< @overload */
 
         /**
@@ -177,7 +177,7 @@ template<class T> class Vector3: public Vector<3, T> {
          *
          * Equivalent to @ref x().
          */
-        T& r() { return x(); }
+        constexpr T& r() { return x(); }
         constexpr T r() const { return x(); }           /**< @overload */
 
         /**
@@ -185,7 +185,7 @@ template<class T> class Vector3: public Vector<3, T> {
          *
          * Equivalent to @ref y().
          */
-        T& g() { return y(); }
+        constexpr T& g() { return y(); }
         constexpr T g() const { return y(); }           /**< @overload */
 
         /**
@@ -193,7 +193,7 @@ template<class T> class Vector3: public Vector<3, T> {
          *
          * Equivalent to @ref z().
          */
-        T& b() { return z(); }
+        constexpr T& b() { return z(); }
         constexpr T b() const { return z(); }           /**< @overload */
 
         /**

--- a/src/Magnum/Math/Vector4.h
+++ b/src/Magnum/Math/Vector4.h
@@ -82,7 +82,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * @see @ref r()
          */
-        T& x() { return (*this)[0]; }
+        constexpr T& x() { return (*this)[0]; }
         constexpr T x() const { return (*this)[0]; }    /**< @overload */
 
         /**
@@ -90,7 +90,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * @see @ref g()
          */
-        T& y() { return (*this)[1]; }
+        constexpr T& y() { return (*this)[1]; }
         constexpr T y() const { return (*this)[1]; }    /**< @overload */
 
         /**
@@ -98,7 +98,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * @see @ref b()
          */
-        T& z() { return (*this)[2]; }
+        constexpr T& z() { return (*this)[2]; }
         constexpr T z() const { return (*this)[2]; }    /**< @overload */
 
         /**
@@ -106,7 +106,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * @see @ref a()
          */
-        T& w() { return (*this)[3]; }
+        constexpr T& w() { return (*this)[3]; }
         constexpr T w() const { return (*this)[3]; }    /**< @overload */
 
         /**
@@ -114,7 +114,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * Equivalent to @ref x().
          */
-        T& r() { return x(); }
+        constexpr T& r() { return x(); }
         constexpr T r() const { return x(); }           /**< @overload */
 
         /**
@@ -122,7 +122,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * Equivalent to @ref y().
          */
-        T& g() { return y(); }
+        constexpr T& g() { return y(); }
         constexpr T g() const { return y(); }           /**< @overload */
 
         /**
@@ -130,7 +130,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * Equivalent to @ref z().
          */
-        T& b() { return z(); }
+        constexpr T& b() { return z(); }
         constexpr T b() const { return z(); }           /**< @overload */
 
         /**
@@ -138,7 +138,7 @@ template<class T> class Vector4: public Vector<4, T> {
          *
          * Equivalent to @ref w().
          */
-        T& a() { return w(); }
+        constexpr T& a() { return w(); }
         constexpr T a() const { return w(); }           /**< @overload */
 
         /**


### PR DESCRIPTION
Code from a very old branch, could be reused instead of starting from scratch. What needs to be done:

- [ ] create some `CORRADE_CONSTEXPR14` macro that compiles to `constexpr` only under C++14
- [ ] separate tests that are built only for C++14 and testing this C++14-only functionality
- [ ] test with *both* constexpr and non-constexpr in order to get correct code coverage (and this may also uncover some bugs)