### PR TITLE
[WIP] Trade: add texture coordinate bindings to MeshObjectData

### DIFF
--- a/src/Trade/MeshObjectData2D.cpp
+++ b/src/Trade/MeshObjectData2D.cpp
@@ -26,6 +26,12 @@
 
 namespace Magnum { namespace Trade {
 
-MeshObjectData2D::MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, UnsignedInt instance, UnsignedInt material): ObjectData2D(std::move(children), transformation, InstanceType::Mesh, instance), _material(material) {}
+MeshObjectData2D::MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, UnsignedInt instance, UnsignedInt material, std::vector<std::pair<UnsignedInt, UnsignedInt>> textureCoordinate2DBindings): ObjectData2D(std::move(children), transformation, InstanceType::Mesh, instance), _material(material), _textureCoordinate2DBindings(std::move(textureCoordinate2DBindings)) {}
+
+MeshObjectData2D::MeshObjectData2D(MeshObjectData2D&&) = default;
+
+MeshObjectData2D::~MeshObjectData2D() = default;
+
+MeshObjectData2D& MeshObjectData2D::operator=(MeshObjectData2D&&) = default;
 
 }}

--- a/src/Trade/MeshObjectData2D.h
+++ b/src/Trade/MeshObjectData2D.h
@@ -46,28 +46,47 @@ class MAGNUM_EXPORT MeshObjectData2D: public ObjectData2D {
          * @param transformation    Transformation (relative to parent)
          * @param instance          Instance ID
          * @param material          Material ID
+         * @param textureCoordinate2DBindings 2D texture coordinate bindings
          *
          * Creates object with mesh instance type.
          */
-        explicit MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, UnsignedInt instance, UnsignedInt material);
+        explicit MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, UnsignedInt instance, UnsignedInt material, std::vector<std::pair<UnsignedInt, UnsignedInt>> textureCoordinate2DBindings);
 
         /** @brief Copying is not allowed */
         MeshObjectData2D(const MeshObjectData2D&) = delete;
 
         /** @brief Move constructor */
-        MeshObjectData2D(MeshObjectData2D&&) = default;
+        MeshObjectData2D(MeshObjectData2D&&);
+
+        ~MeshObjectData2D();
 
         /** @brief Copying is not allowed */
         MeshObjectData2D& operator=(const MeshObjectData2D&) = delete;
 
         /** @brief Move assignment */
-        MeshObjectData2D& operator=(MeshObjectData2D&&) = default;
+        MeshObjectData2D& operator=(MeshObjectData2D&&);
 
         /** @brief Material ID */
         UnsignedInt material() const { return _material; }
 
+        /**
+         * @brief 2D texture coordinate bindings
+         *
+         * First item of the pair is 2D texture coodinate ID, second is
+         * material texture ID (e.g. @ref PhongMaterialData "PhongMaterialData::DiffuseTextureID").
+         */
+        std::vector<std::pair<UnsignedInt, UnsignedInt>>& textureCoordinate2DBindings() {
+            return _textureCoordinate2DBindings;
+        }
+
+        /** @overload */
+        const std::vector<std::pair<UnsignedInt, UnsignedInt>>& textureCoordinate2DBindings() const {
+            return _textureCoordinate2DBindings;
+        }
+
     private:
         UnsignedInt _material;
+        std::vector<std::pair<UnsignedInt, UnsignedInt>> _textureCoordinate2DBindings;
 };
 
 }}

--- a/src/Trade/MeshObjectData3D.cpp
+++ b/src/Trade/MeshObjectData3D.cpp
@@ -26,6 +26,12 @@
 
 namespace Magnum { namespace Trade {
 
-MeshObjectData3D::MeshObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, UnsignedInt instance, UnsignedInt material): ObjectData3D(std::move(children), transformation, InstanceType::Mesh, instance), _material(material) {}
+MeshObjectData3D::MeshObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, UnsignedInt instance, UnsignedInt material, std::vector<std::pair<UnsignedInt, UnsignedInt>> textureCoordinate2DBindings): ObjectData3D(std::move(children), transformation, InstanceType::Mesh, instance), _material(material), _textureCoordinate2DBindings(std::move(textureCoordinate2DBindings)) {}
+
+MeshObjectData3D::MeshObjectData3D(MeshObjectData3D&&) = default;
+
+MeshObjectData3D::~MeshObjectData3D() = default;
+
+MeshObjectData3D& MeshObjectData3D::operator=(MeshObjectData3D&&) = default;
 
 }}

--- a/src/Trade/MeshObjectData3D.h
+++ b/src/Trade/MeshObjectData3D.h
@@ -46,28 +46,47 @@ class MAGNUM_EXPORT MeshObjectData3D: public ObjectData3D {
          * @param transformation    Transformation (relative to parent)
          * @param instance          Instance ID
          * @param material          Material ID
+         * @param textureCoordinate2DBindings 2D texture coordinate bindings
          *
          * Creates object with mesh instance type.
          */
-        explicit MeshObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, UnsignedInt instance, UnsignedInt material);
+        explicit MeshObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, UnsignedInt instance, UnsignedInt material, std::vector<std::pair<UnsignedInt, UnsignedInt>> textureCoordinate2DBindings);
 
         /** @brief Copying is not allowed */
         MeshObjectData3D(const MeshObjectData3D&) = delete;
 
         /** @brief Move constructor */
-        MeshObjectData3D(MeshObjectData3D&&) = default;
+        MeshObjectData3D(MeshObjectData3D&&);
+
+        ~MeshObjectData3D();
 
         /** @brief Copying is not allowed */
         MeshObjectData3D& operator=(const MeshObjectData3D&) = delete;
 
         /** @brief Move assignment */
-        MeshObjectData3D& operator=(MeshObjectData3D&&) = default;
+        MeshObjectData3D& operator=(MeshObjectData3D&&);
 
         /** @brief Material ID */
         UnsignedInt material() const { return _material; }
 
+        /**
+         * @brief 2D texture coordinate bindings
+         *
+         * First item of the pair is 2D texture coodinate ID, second is
+         * material texture ID (e.g. @ref PhongMaterialData "PhongMaterialData::DiffuseTextureID").
+         */
+        std::vector<std::pair<UnsignedInt, UnsignedInt>>& textureCoordinate2DBindings() {
+            return _textureCoordinate2DBindings;
+        }
+
+        /** @overload */
+        const std::vector<std::pair<UnsignedInt, UnsignedInt>>& textureCoordinate2DBindings() const {
+            return _textureCoordinate2DBindings;
+        }
+
     private:
         UnsignedInt _material;
+        std::vector<std::pair<UnsignedInt, UnsignedInt>> _textureCoordinate2DBindings;
 };
 
 }}


### PR DESCRIPTION
Another WIP back from 2013, adds an ability to specify which texture uses which texture coordinate array. Also not present in `master` yet.