### PR TITLE
distance field: fix distance field cache on OpenGL ES

### DIFF
--- a/src/Magnum/Text/DistanceFieldGlyphCache.cpp
+++ b/src/Magnum/Text/DistanceFieldGlyphCache.cpp
@@ -42,7 +42,7 @@ DistanceFieldGlyphCache::DistanceFieldGlyphCache(const Vector2i& originalSize, c
     #elif !defined(MAGNUM_TARGET_WEBGL)
     /* Luminance is not renderable in most cases */
     GlyphCache(GL::Context::current().isExtensionSupported<GL::Extensions::EXT::texture_rg>() ?
-        GL::TextureFormat::Red : GL::TextureFormat::RGB, originalSize, size, Vector2i(radius)),
+        GL::TextureFormat::R8 : GL::TextureFormat::RGB, originalSize, size, Vector2i(radius)),
     #else
     GlyphCache(GL::TextureFormat::RGB, originalSize, size, Vector2i(radius)),
     #endif


### PR DESCRIPTION
## Motivations
Distance field text is not rendering on some Huawei devices since the OpenGL renderer will complain about an incomplete framebuffer attachment.

## Proposed solution
This pull request fixes the distance field cache generation on Huawei devices by changing the `TextureFormat` from `GL::TextureFormat::Red` to `GL::TextureFormat::R8`.

## Testing done
On-device testing on both iOS and Android.
