### PR TITLE
Fix compil error in GlyphCache.cpp + hunter

### DIFF
--- a/src/Magnum/Text/GlyphCache.cpp
+++ b/src/Magnum/Text/GlyphCache.cpp
@@ -65,7 +65,7 @@ void GlyphCache::initialize(const GL::TextureFormat internalFormat, const Vector
         .setStorage(1, internalFormat, size);
 
     /* Default "Not Found" glyph */
-    glyphs.insert({0, {}});
+    glyphs.insert({0,  {{}, {}}  });
 }
 
 std::vector<Range2Di> GlyphCache::reserve(const std::vector<Vector2i>& sizes) {


### PR DESCRIPTION
Hi,

I am trying to add corrade and a magnum package to hunter. 
I will tell you more about it in the next days.

While compiling magnum inside the hunter CI, I encountered a compilation error inside GlyphCache.cpp : 

````cpp
src/Magnum/Text/GlyphCache.cpp:68:12: error: call to member function 'insert' is ambiguous
    glyphs.insert({0, {}});
    ~~~~~~~^~~~~~
/usr/lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unordered_map.h:436:7: note: candidate function
      insert(node_type&& __nh)
      ^
/usr/lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unordered_map.h:584:7: note: candidate function
      insert(value_type&& __x)
      ^
/usr/lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unordered_map.h:578:7: note: candidate function
      insert(const value_type& __x)
      ^
etc
etc
etc
````

There is however something strange : I cannot reproduce this compilation error on my computer, it only happens inside hunter's CI.

It happens under MSVC (see https://travis-ci.org/pthom/hunter/jobs/461046587) and under clang (see https://travis-ci.org/pthom/hunter/jobs/461046587) .

I could solve this problem with this patch (see https://ci.appveyor.com/project/pthom/hunter/builds/20633842/job/bjsy2ke0kn1v46cw and https://travis-ci.org/pthom/hunter/jobs/461064174 ). You wil see that I am still struggling with hunter :-), but this file now compiles correctly.

I know that my correction could have been more terse, with something like : 

````cpp
glyphs.insert({0,  {{}, {}}  });
````

However, the CI testing process with hunter is quite tedious, so that I did not want to risk another failure due to initializer lists.

Did you encounter this error on another compiler ? I am surprised it was caught only by hunter's CI.

Thanks