### PR TITLE
[WIP] SIMD playground

### DIFF
--- a/doc/snippets/MagnumMath.cpp
+++ b/doc/snippets/MagnumMath.cpp
@@ -878,6 +878,40 @@ Debug{} << Math::Vector3<UnsignedShort>{a};  // prints {16968, 48552, 15993}
 }
 
 {
+/* [unpack-template-explicit] */
+// Literal type is (signed) char, but we assumed unsigned char, a != 1.0f
+Float a = Math::unpack<Float>('\xFF');
+
+// b = 1.0f
+Float b = Math::unpack<Float, UnsignedByte>('\xFF');
+/* [unpack-template-explicit] */
+static_cast<void>(a);
+static_cast<void>(b);
+}
+
+{
+/* [unpack] */
+Float a = Math::unpack<Float, UnsignedShort>(8191);     // 0.124987f
+Float b = Math::unpack<Float, UnsignedShort, 14>(8191); // 0.499969f
+Float c = Math::unpack<Float, 14>(8191u);               // 0.499969f
+Float d = Math::unpack<Float, 14>(8191);                // 1.0f
+/* [unpack] */
+static_cast<void>(a);
+static_cast<void>(b);
+static_cast<void>(c);
+static_cast<void>(d);
+}
+
+{
+/* [pack] */
+auto a = Math::pack<UnsignedShort>(0.5f);     // 32767
+auto b = Math::pack<UnsignedShort, 14>(0.5f); // 8191
+/* [pack] */
+static_cast<void>(a);
+static_cast<void>(b);
+}
+
+{
 Range1D range, a, b;
 constexpr UnsignedInt dimensions = 1;
 typedef Float T;

--- a/src/Magnum/Math/CMakeLists.txt
+++ b/src/Magnum/Math/CMakeLists.txt
@@ -48,6 +48,7 @@ set(MagnumMath_HEADERS
     Packing.h
     Range.h
     RectangularMatrix.h
+    Simd.h
     StrictWeakOrdering.h
     Swizzle.h
     Tags.h

--- a/src/Magnum/Math/Packing.h
+++ b/src/Magnum/Math/Packing.h
@@ -57,13 +57,7 @@ value in range @f$ [0, 1] @f$ or from *signed* integral to range @f$ [-1, 1] @f$
     To ensure the integral type is correctly detected when using literals, this
     function should be called with both template parameters explicit, e.g.:
 @attention
-    @code{.cpp}
-    // Literal type is (signed) char, but we assumed unsigned char, a != 1.0f
-    Float a = Math::unpack<Float>('\xFF');
-
-    // b = 1.0f
-    Float b = Math::unpack<Float, UnsignedByte>('\xFF');
-    @endcode
+    @snippet MagnumMath.cpp unpack-template-explicit
 
 @see @ref pack()
 */
@@ -75,12 +69,7 @@ template<class FloatingPoint, class Integral> inline FloatingPoint unpack(const 
 Alternative to the above with ability to specify how many bits of the integral
 representation to use. Example usage:
 
-@code{.cpp}
-Float a = Math::unpack<Float, UnsignedShort>(8191);     // 0.124987f
-Float b = Math::unpack<Float, UnsignedShort, 14>(8191); // 0.499969f
-Float b = Math::unpack<Float, 14>(8191u);               // 0.499969f
-Float b = Math::unpack<Float, 14>(8191);                // 1.0f
-@endcode
+@snippet MagnumMath.cpp unpack
 */
 template<class FloatingPoint, class Integral, UnsignedInt bits> inline FloatingPoint unpack(const Integral& value);
 #else
@@ -124,14 +113,14 @@ template<class FloatingPoint, UnsignedInt bits, std::size_t size, class Integral
 /**
 @brief Pack floating-point value into an integer representation
 
-Converts floating-point value in range @f$ [0, 1] @f$ to full range of given
-*unsigned* integral type or range @f$ [-1, 1] @f$ to full range of given *signed*
-integral type.
+Converts floating-point value in range @f$ [0, 1] @f$ to full range of
+given *unsigned* integral type or range @f$ [-1, 1] @f$ to full range of
+given *signed* integral type.
 
 @note For best precision, `FloatingPoint` type should be always larger that
     resulting `Integral` type (e.g. @ref Magnum::Float "Float" to
-    @ref Magnum::Short "Short", @ref Magnum::Double "Double" to @ref Magnum::Int "Int"
-    and similarly for vector types).
+    @ref Magnum::Short "Short", @ref Magnum::Double "Double" to
+    @ref Magnum::Int "Int" and similarly for vector types).
 
 @attention Return value for floating point numbers outside the normalized
     range is undefined.
@@ -164,10 +153,7 @@ template<class Integral, std::size_t size, class FloatingPoint, UnsignedInt bits
 Alternative to the above with ability to specify how many bits of the integral
 representation to use. Example usage:
 
-@code{.cpp}
-auto a = Math::pack<UnsignedShort>(0.5f);     // 32767
-auto b = Math::pack<UnsignedShort, 14>(0.5f); // 8191
-@endcode
+@snippet MagnumMath.cpp pack
 */
 #ifdef DOXYGEN_GENERATING_OUTPUT
 template<class Integral, UnsignedInt bits, class FloatingPoint> inline Integral pack(FloatingPoint value);

--- a/src/Magnum/Math/Packing.h
+++ b/src/Magnum/Math/Packing.h
@@ -30,6 +30,7 @@
  */
 
 #include "Magnum/Math/Functions.h"
+#include "Magnum/Math/Simd.h"
 
 namespace Magnum { namespace Math {
 
@@ -208,6 +209,39 @@ template<std::size_t size> Vector<size, Float> unpackHalf(const Vector<size, Uns
         out[i] = unpackHalf(value[i]);
     return out;
 }
+
+namespace Implementation {
+    // TODO: expose these publicly? would make sense, otherwise the tags are useless
+    MAGNUM_EXPORT void unpackUnsignedByteToShort(Simd::NoneT, Corrade::Containers::ArrayView<const UnsignedByte> in, Corrade::Containers::ArrayView<UnsignedShort> out);
+    MAGNUM_EXPORT void unpackUnsignedByteToShort(Simd::Sse2T, Corrade::Containers::ArrayView<const UnsignedByte> in, Corrade::Containers::ArrayView<UnsignedShort> out);
+    MAGNUM_EXPORT void unpackUnsignedByteToShort(Simd::Sse41T, Corrade::Containers::ArrayView<const UnsignedByte> in, Corrade::Containers::ArrayView<UnsignedShort> out);
+    MAGNUM_EXPORT void unpackUnsignedByteToShort(Simd::Avx2T, Corrade::Containers::ArrayView<const UnsignedByte> in, Corrade::Containers::ArrayView<UnsignedShort> out);
+}
+
+/**
+@brief Unpack an array of 8-bit unsigned integers to 16-bit
+
+The @p in and @p out are expected to have the same size and be aligned to 16
+bytes.
+*/
+// TODO: mention SIMD?
+MAGNUM_EXPORT void unpackUnsignedByteToShort(Corrade::Containers::ArrayView<const UnsignedByte> in, Corrade::Containers::ArrayView<UnsignedShort> out);
+
+/**
+@brief Unpack an array of 8-bit unsigned integers to 32-bit
+
+The @p in and @p out are expected to have the same size and be aligned to 16
+bytes.
+*/
+MAGNUM_EXPORT void unpackUnsignedByteToInt(Corrade::Containers::ArrayView<const UnsignedByte> in, Corrade::Containers::ArrayView<UnsignedInt> out);
+
+/**
+@brief Unpack an array of 16-bit unsigned integers to 32-bit
+
+The @p in and @p out are expected to have the same size and be aligned to 16
+bytes.
+*/
+MAGNUM_EXPORT void unpackUnsignedShortToInt(Corrade::Containers::ArrayView<const UnsignedShort> in, Corrade::Containers::ArrayView<UnsignedInt> out);
 
 }}
 

--- a/src/Magnum/Math/Simd.h
+++ b/src/Magnum/Math/Simd.h
@@ -1,0 +1,148 @@
+#ifndef Magnum_Math_Simd_h
+#define Magnum_Math_Simd_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Namespace @ref Magnum::Math::Simd
+ */
+
+/** @namespace Magnum::Math::Simd
+@brief SIMD dispatch tags
+
+Tags for dispatching to particular SIMD-optimized versions of batch math
+algorithms.
+
+This library is built as part of Magnum by default. To use this library with
+CMake, you need to find the `Magnum` package and link to the `Magnum::Magnum`
+target:
+
+@code{.cmake}
+find_package(Magnum REQUIRED)
+
+# ...
+target_link_libraries(your-app Magnum::Magnum)
+@endcode
+
+See @ref building and @ref cmake for more information.
+*/
+namespace Magnum { namespace Math { namespace Simd {
+
+/**
+@brief No SIMD acceleration tag type
+
+Used to distinguish algorithms that have no explicit SIMD optimizations, apart
+from compiler magic.
+@see @ref None
+*/
+/* Explicit constructor to avoid ambiguous calls when using {} */
+struct NoneT {
+    #ifndef DOXYGEN_GENERATING_OUTPUT
+    struct Init{};
+    constexpr explicit NoneT(Init) {}
+    #endif
+};
+
+/**
+@brief SSE2 SIMD acceleration tag type
+
+Used to distinguish algorithms that use at most the
+[SSE2](https://en.wikipedia.org/wiki/SSE2) instruction set.
+@see @ref Sse2
+*/
+/* Explicit constructor to avoid ambiguous calls when using {} */
+struct Sse2T {
+    #ifndef DOXYGEN_GENERATING_OUTPUT
+    struct Init{};
+    constexpr explicit Sse2T(Init) {}
+    #endif
+};
+
+/**
+@brief SSE4.1 SIMD acceleration tag type
+
+Used to distinguish algorithms that use at most the
+[SSE4.1](https://en.wikipedia.org/wiki/SSE4#SSE4.1) instruction set.
+@see @ref Sse41
+*/
+/* Explicit constructor to avoid ambiguous calls when using {} */
+struct Sse41T {
+    #ifndef DOXYGEN_GENERATING_OUTPUT
+    struct Init{};
+    constexpr explicit Sse41T(Init) {}
+    #endif
+};
+
+/**
+@brief AVX2 SIMD acceleration tag type
+
+Used to distinguish algorithms that use at most the
+[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2)
+instruction set.
+@see @ref Avx2
+*/
+/* Explicit constructor to avoid ambiguous calls when using {} */
+struct Avx2T {
+    #ifndef DOXYGEN_GENERATING_OUTPUT
+    struct Init{};
+    constexpr explicit Avx2T(Init) {}
+    #endif
+};
+
+/**
+@brief No SIMD acceleration tag
+
+Use for selecting algorithms with no explicit SIMD optimizations.
+*/
+constexpr NoneT None{NoneT::Init{}};
+
+/**
+@brief SSE2 SIMD acceleration tag
+
+Use for selecting algorithms that use at most the
+[SSE2](https://en.wikipedia.org/wiki/SSE2) instruction set.
+*/
+constexpr Sse2T Sse2{Sse2T::Init{}};
+
+/**
+@brief SSE4.1 SIMD acceleration tag
+
+Use for selecting algorithms that use at most the
+[SSE4.1](https://en.wikipedia.org/wiki/SSE4#SSE4.1) instruction set.
+*/
+constexpr Sse41T Sse41{Sse41T::Init{}};
+
+/**
+@brief AVX2 SIMD acceleration tag type
+
+Use for selecting algorithms that use at most the
+[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2)
+instruction set.
+*/
+constexpr Avx2T Avx2{Avx2T::Init{}};
+
+}}}
+
+#endif


### PR DESCRIPTION
Right now this is rather an experiment investigating possibilities of integrating SIMD-enabled algorithms into the math library. Currently there's the simplest algorithms ever, packing and unpacking index arrays to larger/smaller representations (and I was not able to beat the compiler, my AVX2 version was as what GCC managed to optimize out of the scalar implementation). It also shows how GCC function multi-versioning could be used to have multiple implementations in the same binary instead of compiling always only for one target.

Things to do:

- [ ] implement some `Utility::System::alignedAllocation()` that uses [posix_memalign](https://stackoverflow.com/a/6974037) (or the Windows equivalent), since aligned allocations are not available until C++17
- [ ] Think more about the design of the SIMD dispatch tags (should they have its own namespace? should I name them `Math::SseSimdT` instead to avoid colon cancer? should I put them into the Tags.h header to avoid having an excessive number of extremely small headers? how to make the templated benchmarks nicer without using the ugly `T{typename T::Init{}}`?)
- [ ] Should the particular tagged implementations be exposed as well? (if not, then the SIMD tags are useless to have publicly) Combine their docs into a single documented function explaining what tags can be used instead of having it repeated 4+ times?
- [ ] make the algorithms behave properly with "leftovers" (not a full block of 16 elements at the end)
- [ ] investigate [perf effects of aligned/unaligned loads and stores](https://stackoverflow.com/questions/20259694/is-the-sse-unaligned-load-intrinsic-any-slower-than-the-aligned-load-intrinsic-o) (this is where it could be possible to beat the compiler, if I force the input data to be aligned)
- [ ] investigate possible slowdowns due to [accidental leftovers in AVX registers](https://github.com/Kobzol/hardware-effects/tree/master/floating-point#mixing-sse-and-avx-instructions)
- [ ] GCC is warning about unused functions in the multi-versioned case, not sure why? is that a bug?
- [ ] investigate what subset of FMV is available on GCC 4.8 (is AVX2 there?)
- [ ] investigate how to do intrinsics on MSVC, if there's any possibility of FMV-like functionality or we need to select at compile time (using some builtin defines? which defines?)
- [ ] look into ARM NEON for these simple cases
- [ ] ryg has SIMD-enabled half->float variants on https://gist.github.com/rygorous/2144712, implement them? is there also float->half?