### PR TITLE
Use eglGetCurrentDisplay

### DIFF
--- a/src/MagnumExternal/OpenGL/GL/flextGLPlatform.cpp
+++ b/src/MagnumExternal/OpenGL/GL/flextGLPlatform.cpp
@@ -44,7 +44,7 @@ void flextGLInit(Magnum::GL::Context& context) {
         /* EGL contexts on NVidia 390 drivers don't have correct statically
            linked GL 1.0 and 1.1 functions (such as glGetString()) and one has
            to retrieve them explicitly using eglGetProcAddress(). */
-        EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+        EGLDisplay display = eglGetCurrentDisplay();
         const char* vendor = eglQueryString(display, EGL_VENDOR);
         if(std::strcmp(vendor, "NVIDIA") == 0 && !context.isDriverWorkaroundDisabled("nv-egl-incorrect-gl11-function-pointers")) {
 

--- a/src/MagnumExternal/OpenGL/GL/flextGLPlatform.cpp.template
+++ b/src/MagnumExternal/OpenGL/GL/flextGLPlatform.cpp.template
@@ -45,7 +45,7 @@ void flextGLInit(Magnum::GL::Context& context) {
         /* EGL contexts on NVidia 390 drivers don't have correct statically
            linked GL 1.0 and 1.1 functions (such as glGetString()) and one has
            to retrieve them explicitly using eglGetProcAddress(). */
-        EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+        EGLDisplay display = eglGetCurrentDisplay();
         const char* vendor = eglQueryString(display, EGL_VENDOR);
         if(std::strcmp(vendor, "NVIDIA") == 0 && !context.isDriverWorkaroundDisabled("nv-egl-incorrect-gl11-function-pointers")) {
             @for category,funcs in functions:


### PR DESCRIPTION
# Changes
On multi gpu machines, `eglGetDisplay(EGL_DEFAULT_DISPLAY)` returns the display on GPU0.  If there is no valid EGL context on GPU0, `eglQueryString(display, EGL_VENDOR)` will return the null pointer and `std::strcmp(vendor, "NVIDIA") == 0` will segfault!

Instead, `eglGetCurrentDisplay` should be used instead as this returns the EGL display that has been most recently made current by `eglMakeCurrent`.

# Testing

Pre-change:

```
I0126 07:50:04.296272 20411 WindowlessContext.cpp:86] [EGL] Detected 2 EGL devices
I0126 07:50:04.308815 20411 WindowlessContext.cpp:107] [EGL] Selected EGL device 1 for CUDA device 1
I0126 07:50:04.320178 20411 WindowlessContext.cpp:121] [EGL] Version: 1.4
I0126 07:50:04.320204 20411 WindowlessContext.cpp:122] [EGL] Vendor: NVIDIA
zsh: segmentation fault
```

Post-change:

```
I0126 07:48:17.909481 19493 WindowlessContext.cpp:86] [EGL] Detected 2 EGL devices
I0126 07:48:17.922724 19493 WindowlessContext.cpp:107] [EGL] Selected EGL device 1 for CUDA device 1
I0126 07:48:17.933991 19493 WindowlessContext.cpp:121] [EGL] Version: 1.4
I0126 07:48:17.934017 19493 WindowlessContext.cpp:122] [EGL] Vendor: NVIDIA
Renderer: Quadro GP100/PCIe/SSE2 by NVIDIA Corporation
OpenGL version: 4.6.0 NVIDIA 396.51
Using optional features:
    GL_ARB_ES2_compatibility
    GL_ARB_direct_state_access
    GL_ARB_get_texture_sub_image
    GL_ARB_invalidate_subdata
    GL_ARB_multi_bind
    GL_ARB_robustness
    GL_ARB_separate_shader_objects
    GL_ARB_texture_filter_anisotropic
    GL_ARB_texture_storage
    GL_ARB_texture_storage_multisample
    GL_ARB_vertex_array_object
    GL_EXT_direct_state_access
    GL_KHR_debug
Using driver workarounds:
    nv-egl-incorrect-gl11-function-pointers
    no-layout-qualifiers-on-old-glsl
    nv-zero-context-profile-mask
    nv-cubemap-inconsistent-compressed-image-size
    nv-cubemap-broken-full-compressed-image-query
    nv-compressed-block-size-in-bits
```