### PR TITLE
Ability to control GPU preference on Windows and Linux/BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,14 @@ endif()
 # OpenGLTester library, built by default only if GL tests are enabled
 cmake_dependent_option(WITH_OPENGLTESTER "Build OpenGLTester library" OFF "NOT BUILD_GL_TESTS" ON)
 
+# GPU preference symbols (NvOptimusEnablement etc.) on Windows, enabled by
+# default so the --magnum-gpu-preference switching works out of the box. The
+# application or a 3rd party library might be already defining these, in which
+# case we want to be able to disable them.
+if(CORRADE_TARGET_WINDOWS)
+    option(BUILD_GPU_PREFERENCE_SYMBOLS "Build context and application libraries with exported GPU preference symbols" ON)
+endif()
+
 # Dynamic linking is meaningless on Emscripten and too inconvenient on Android
 if(CORRADE_TARGET_EMSCRIPTEN OR CORRADE_TARGET_ANDROID)
     set(BUILD_STATIC ON)

--- a/doc/building.dox
+++ b/doc/building.dox
@@ -480,13 +480,20 @@ available for desktop OpenGL only, see @ref requires-gl.
     enabled.
 -   `TARGET_VK` --- Build libraries with Vulkan interoperability enabled.
     Enabled by default when `WITH_VK` is enabled. Disabling this will cause
-    libraries to not depend on the @ref Vk library, but  doesn't affect the
+    libraries to not depend on the @ref Vk library, but doesn't affect the
     @ref Vk library itself.
 
-By default the engine is built in a way that allows having multiple independent
-thread-local Magnum contents. This might cause some performance penalties ---
-if you are sure that you will never need such feature, you can disable it via
-the `BUILD_MULTITHREADED` option.
+There are further options affecting to engine behavior, all enabled by default:
+
+-   `BUILD_MULTITHREADED` --- Allow having multiple independent thread-local
+    Magnum contents. This might cause some performance penalties --- if you are
+    sure that you will never need such feature, disable this option.
+-   `BUILD_GPU_PREFERENCE_SYMBOLS` --- Export symbols used to control GPU
+    preference on Windows, using the `--magnum-gpu-preference`
+    @ref GL-Context-command-line "command-line option". If your application (or
+    another 3rd party lib you use) already exports symbols like
+    `NvOptimusEnablement` and you're getting linker errors due to that, disable
+    this option.
 
 The features used can be conveniently detected in depending projects both in
 CMake and C++ sources, see @ref cmake and @ref Magnum/Magnum.h for more

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -55,6 +55,10 @@ See also:
     and @cpp "mesa-implementation-color-read-format-dsa-explicit-binding" @ce,
     because it's 2019 and GL drivers are *still* awful. See
     @ref opengl-workarounds for more information.
+-   Ability to control GPU preference (integrated/dedicated) using the
+    `--magnum-gpu-preference` command-line option and environment variables on
+    Windows and Linux/BSD systems. See @ref GL-Context-command-line for more
+    information.
 
 @subsection changelog-latest-changes Changes and improvements
 

--- a/src/Magnum/GL/Context.h
+++ b/src/Magnum/GL/Context.h
@@ -134,11 +134,30 @@ Arguments:
     (environment: `MAGNUM_DISABLE_EXTENSIONS`)
 -   `--magnum-log default|quiet|verbose` --- console logging
     (environment: `MAGNUM_LOG`) (default: `default`)
+-   `--magnum-gpu-preference none|integrated|dedicated`  GPU preference
+    (environment: `MAGNUM_GPU_PREFERENCE`) (default: `none`)
 
 Note that all options are prefixed with `--magnum-` to avoid conflicts with
 options passed to the application itself. Options that don't have this prefix
 are completely ignored, see documentation of the
 @ref Utility-Arguments-delegating "Utility::Arguments" class for details.
+
+The GPU preference allows you to request either the integrated or dedicated GPU
+on systems having both onboard and dedicated GPUs. Currently this works only
+on Windows and Linux / BSD systems, on other systems this option prints a
+warning and otherwise does nothing.
+
+-   On Windows this is done by querying the `NvOptimusEnablement` and
+    `AmdPowerXpressRequestHighPerformance` symbols in the application
+    executable and, if they exist, setting them to either `0` for the
+    `integrated` option or `1` for the `dedicated` option. The symbols have to
+    be exported by the application executable (not a dynamic library). These
+    symbols are exported by default when you link to one of the (static)
+    `*Context` or `*Application` libraries, and can be controlled using the
+    `BUILD_GPU_PREFERENCE_SYMBOLS` CMake option when building Magnum (see
+    @ref building-features for more information).
+-   On Linux and BSD this affects the `DRI_PRIME` environment variable that's
+    used by Mesa drivers that support PRIME.
 */
 class MAGNUM_GL_EXPORT Context {
     public:

--- a/src/Magnum/Platform/CMakeLists.txt
+++ b/src/Magnum/Platform/CMakeLists.txt
@@ -662,6 +662,15 @@ endif()
 set(MagnumContext_SRCS )
 if(NOT CORRADE_TARGET_IOS)
     list(APPEND MagnumContext_SRCS Implementation/OpenGLFunctionLoader.cpp)
+
+    if(CORRADE_TARGET_WINDOWS)
+        # GPU preference symbol export in OpenGLFunctionLoader.cpp
+        if(BUILD_GPU_PREFERENCE_SYMBOLS)
+            set(_MAGNUM_BUILD_GPU_PREFERENCE_SYMBOLS 1)
+        endif()
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Implementation/configure.h.cmake
+                       ${CMAKE_CURRENT_BINARY_DIR}/Implementation/configure.h)
+    endif()
 endif()
 if(NOT MAGNUM_TARGET_GLES)
     list(APPEND MagnumContext_SRCS ../../MagnumExternal/OpenGL/GL/flextGLPlatform.cpp)

--- a/src/Magnum/Platform/Implementation/configure.h.cmake
+++ b/src/Magnum/Platform/Implementation/configure.h.cmake
@@ -1,0 +1,26 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#cmakedefine _MAGNUM_BUILD_GPU_PREFERENCE_SYMBOLS


### PR DESCRIPTION
It's using the `NvOptimusEnablement` and `AmdPowerXpressRequestHighPerformance` executable-local symbols on Windows and the `DRI_PRIME` environment variable on Linux to control whether to use the integrated or the dedicated GPU. The `DRI_PRIME` part works as expected.

Problem is, according to our tests, simply adding the `NvOptimusEnablement` to application sources, will force the app to use the dedicated GPU, **no matter what the value is**:

```cpp
// has to be in the main exe sources, not in any static library or DLL

extern "C" {
    __declspec(dllexport) int NvOptimusEnablement = 0;
}
```

Which ... makes this quite useless, as the switch between integrated/dedicated GPU is done *at compile time*.

Things to do:

- [ ] extract just the `DRI_PRIME` part and commit it to `master`, since that works correctly
- [ ] test on AMD PowerXpress, maybe *at least* there it works?
- [ ] turn this into a compile-time option on the CMake user side (not library builder side), at least (some target property, for example)?