### PR TITLE
zero-initialize utf8 buffer.

### DIFF
--- a/src/Magnum/Platform/GlfwApplication.cpp
+++ b/src/Magnum/Platform/GlfwApplication.cpp
@@ -504,6 +504,7 @@ void GlfwApplication::setupCallbacks() {
         if(!(app._flags & Flag::TextInputActive)) return;
 
         char utf8[4];
+        memset(utf8, 0, 4);
         const std::size_t size = Utility::Unicode::utf8(codepoint, utf8);
         TextInputEvent e{{utf8, size}};
         app.textInputEvent(e);


### PR DESCRIPTION
I noticed that imgui text input behave wrongly with GLFW app, here's a fix.