### PR TITLE
Sdl2Application: add glContext() accessor.

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -529,6 +529,18 @@ class Sdl2Application {
          */
         SDL_Window* window() { return _window; }
         #endif
+    
+        #ifdef MAGNUM_TARGET_GL
+        /**
+         * @brief Underlying context
+         *
+         * Use in case you need to call SDL functionality directly.
+         * @note This function is available only if Magnum is compiled with
+         *      @ref MAGNUM_TARGET_GL enabled (done by default). See @ref building-features
+         *      for more information.
+         */
+        SDL_GLContext glContext() { return _glContext; }
+        #endif
 
     protected:
         /* Nobody will need to have (and delete) Sdl2Application*, thus this is


### PR DESCRIPTION
Some SDL2 functions, like [`SDL_GL_MakeCurrent()`](https://wiki.libsdl.org/SDL_GL_MakeCurrent), take a `SDL_GL_Context` as part of their arguments.