### PR TITLE
GL: fix segfault in Context destructor if constructed with NoCreate

### DIFF
--- a/src/Magnum/GL/Context.cpp
+++ b/src/Magnum/GL/Context.cpp
@@ -495,20 +495,17 @@ Context::Context(Context&& other): _version{other._version},
     _extensionRequiredVersion{Containers::NoInit},
     _extensionStatus{other._extensionStatus},
     _supportedExtensions{std::move(other._supportedExtensions)},
-    _state{other._state},
+    _state{std::move(other._state)},
     _detectedDrivers{std::move(other._detectedDrivers)}
 {
     /* StaticArray is deliberately non-copyable */
     for(std::size_t i = 0; i != Implementation::ExtensionCount; ++i)
         _extensionRequiredVersion[i] = other._extensionRequiredVersion[i];
 
-    other._state = nullptr;
     if(currentContext == &other) currentContext = this;
 }
 
 Context::~Context() {
-    delete _state;
-
     if(currentContext == this) currentContext = nullptr;
 }
 
@@ -731,7 +728,7 @@ bool Context::tryCreate() {
         }
     }
 
-    _state = new Implementation::State{*this, output};
+    _state.emplace(*this, output);
 
     /* Print a list of used workarounds */
     if(!_driverWorkarounds.empty()) {

--- a/src/Magnum/GL/Context.h
+++ b/src/Magnum/GL/Context.h
@@ -33,6 +33,7 @@
 #include <vector>
 #include <Corrade/Containers/EnumSet.h>
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/Containers/Pointer.h>
 #include <Corrade/Containers/StaticArray.h>
 
 #include "Magnum/Magnum.h"
@@ -708,7 +709,7 @@ class MAGNUM_GL_EXPORT Context {
         Math::BoolVector<Implementation::ExtensionCount> _extensionStatus;
         std::vector<Extension> _supportedExtensions;
 
-        Implementation::State* _state;
+        Containers::Pointer<Implementation::State> _state;
 
         Containers::Optional<DetectedDrivers> _detectedDrivers;
 

--- a/src/Magnum/GL/Test/ContextGLTest.cpp
+++ b/src/Magnum/GL/Test/ContextGLTest.cpp
@@ -29,10 +29,14 @@
 #include "Magnum/GL/Extensions.h"
 #include "Magnum/GL/OpenGLTester.h"
 
+#include "Magnum/Platform/GLContext.h"
+
 namespace Magnum { namespace GL { namespace Test { namespace {
 
 struct ContextGLTest: OpenGLTester {
     explicit ContextGLTest();
+
+    void constructNoCreate();
 
     void isVersionSupported();
     #ifndef MAGNUM_TARGET_GLES
@@ -44,13 +48,24 @@ struct ContextGLTest: OpenGLTester {
 };
 
 ContextGLTest::ContextGLTest() {
-    addTests({&ContextGLTest::isVersionSupported,
+    addTests({&ContextGLTest::constructNoCreate,
+              &ContextGLTest::isVersionSupported,
               #ifndef MAGNUM_TARGET_GLES
               &ContextGLTest::isVersionSupportedES,
               #endif
               &ContextGLTest::supportedVersion,
               &ContextGLTest::isExtensionSupported,
               &ContextGLTest::isExtensionDisabled});
+}
+
+void ContextGLTest::constructNoCreate() {
+    {
+        char dummyArgv[] = "dummy";
+        char* argv[] = {dummyArgv};
+        Platform::GLContext context{NoCreate, 1, argv};
+    }
+
+    CORRADE_VERIFY(true);
 }
 
 void ContextGLTest::isVersionSupported() {


### PR DESCRIPTION
If we use the `GL::Context(NoCreate, ...)` constructor and never actually create it, the destructor will segfault, since it unconditionally deletes `_state`.

In my code, it happens like this:
```
Platform::GLContext context{NoCreate, argc, argv.data()};
...
if(somethingFailed)
   return; // segfault here

context.tryCreate();
```