### PR TITLE
Platform: improve {Glfw,Sdl2}Application::exit().

### DIFF
--- a/src/Magnum/Platform/GlfwApplication.cpp
+++ b/src/Magnum/Platform/GlfwApplication.cpp
@@ -558,7 +558,7 @@ int GlfwApplication::exec() {
         }
         glfwPollEvents();
     }
-    return 0;
+    return _exitCode;
 }
 
 auto GlfwApplication::MouseMoveEvent::buttons() -> Buttons {

--- a/src/Magnum/Platform/GlfwApplication.h
+++ b/src/Magnum/Platform/GlfwApplication.h
@@ -232,9 +232,13 @@ class GlfwApplication {
          */
         int exec();
 
-        /** @brief Exit application main loop */
-        void exit() {
+        /**
+         * @brief Exit application main loop
+         * @param exitCode  The exit code the application should return
+         */
+        void exit(int exitCode = 0) {
             glfwSetWindowShouldClose(_window, true);
+            _exitCode = exitCode;
         }
 
         /**
@@ -547,6 +551,7 @@ class GlfwApplication {
         #ifdef MAGNUM_TARGET_GL
         Containers::Pointer<Platform::GLContext> _context;
         #endif
+        int _exitCode;
 };
 
 CORRADE_ENUMSET_OPERATORS(GlfwApplication::Flags)

--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -627,15 +627,16 @@ int Sdl2Application::exec() {
         static_cast<Sdl2Application*>(arg)->mainLoopIteration();
     }, this, 0, true);
     #endif
-    return 0;
+    return _exitCode;
 }
 
-void Sdl2Application::exit() {
+void Sdl2Application::exit(int exitCode) {
     #ifndef CORRADE_TARGET_EMSCRIPTEN
     _flags |= Flag::Exit;
     #else
     emscripten_cancel_main_loop();
     #endif
+    _exitCode = exitCode;
 }
 
 void Sdl2Application::mainLoopIteration() {

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -509,10 +509,11 @@ class Sdl2Application {
 
         /**
          * @brief Exit application main loop
+         * @param exitCode  The exit code the application should return
          *
          * Stops main loop started by @ref exec().
          */
-        void exit();
+        void exit(int exitCode = 0);
 
         /**
          * @brief Run one iteration of application main loop
@@ -1013,6 +1014,8 @@ class Sdl2Application {
         #endif
 
         Flags _flags;
+        
+        int _exitCode;
 };
 
 #ifdef MAGNUM_TARGET_GL


### PR DESCRIPTION
Now, it's possible to exit an application properly with a non-zero exit code.

On my end, I could only test the `Sdl2Application` version.

Review and feedback are welcome!