### PR TITLE
Audio: add support for buffer loop points.

### DIFF
--- a/src/Magnum/Audio/Buffer.cpp
+++ b/src/Magnum/Audio/Buffer.cpp
@@ -3,7 +3,6 @@
 
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
               Vladimír Vondruš <mosra@centrum.cz>
-    Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
     Copyright © 2019 Guillaume Jacquemin <williamjcm@users.noreply.github.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
@@ -25,41 +24,31 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-namespace Magnum {
+#include "Buffer.h"
 
-/** @page openal-support OpenAL support state
-@brief List of (un)supported OpenAL features and extensions.
+#include "Magnum/Math/Functions.h"
 
-@tableofcontents
-@m_footernavigation
+namespace Magnum { namespace Audio {
 
-@section openal-support-state OpenAL implementation state
+Buffer& Buffer::setLoopPoints(Int loopStart, Int loopEnd) {
+    ALint sizeInBytes;
+    ALint channels;
+    ALint bits;
 
-The extension implementation is considered complete if all its defined types,
-functions and enum values are exposed through the API.
+    alGetBufferi(_id, AL_SIZE, &sizeInBytes);
+    alGetBufferi(_id, AL_CHANNELS, &channels);
+    alGetBufferi(_id, AL_BITS, &bits);
 
-@subsection openal-extension-support Extensions
+    ALint lengthInSamples = sizeInBytes * 8 / (channels * bits);
 
-@m_class{m-fullwidth}
+    ALint loopPoints[2] = {
+        Math::max<ALint>(0, loopStart),
+        Math::min<ALint>(loopEnd, lengthInSamples)
+    };
 
-Extension                                   | Status
-------------------------------------------- | ------
-@alc_extension{ENUMERATION,EXT}             | done
-@al_extension{EXT,double}                   | done
-@al_extension{EXT,float32}                  | done
-@al_extension{EXT,ALAW}                     | done
-@al_extension{EXT,MULAW}                    | done
-@al_extension{EXT,MCFORMATS}                | done
+    alBufferiv(_id, AL_LOOP_POINTS_SOFT, &loopPoints[0]);
 
-@subsection openal-extension-support-soft OpenAL Soft Extensions
-
-@m_class{m-fullwidth}
-
-Extension                                   | Status
-------------------------------------------- | ------
-@alc_extension{SOFTX,HRTF}                  | done
-@alc_extension{SOFT,HRTF}                   | done
-@al_extension{SOFT,loop_points}             | done
-
-*/
+    return *this;
 }
+
+}}

--- a/src/Magnum/Audio/Buffer.cpp
+++ b/src/Magnum/Audio/Buffer.cpp
@@ -31,19 +31,9 @@
 namespace Magnum { namespace Audio {
 
 Buffer& Buffer::setLoopPoints(Int loopStart, Int loopEnd) {
-    ALint sizeInBytes;
-    ALint channels;
-    ALint bits;
-
-    alGetBufferi(_id, AL_SIZE, &sizeInBytes);
-    alGetBufferi(_id, AL_CHANNELS, &channels);
-    alGetBufferi(_id, AL_BITS, &bits);
-
-    ALint lengthInSamples = sizeInBytes * 8 / (channels * bits);
-
     ALint loopPoints[2] = {
         Math::max<ALint>(0, loopStart),
-        Math::min<ALint>(loopEnd, lengthInSamples)
+        Math::min<ALint>(loopEnd, length())
     };
 
     alBufferiv(_id, AL_LOOP_POINTS_SOFT, &loopPoints[0]);

--- a/src/Magnum/Audio/Buffer.h
+++ b/src/Magnum/Audio/Buffer.h
@@ -105,22 +105,74 @@ class MAGNUM_AUDIO_EXPORT Buffer {
         }
 
         /**
+         * @brief Get buffer size
+         * @return The buffer's size in bytes
+         */
+        ALint size() {
+            ALint size;
+            alGetBufferi(_id, AL_SIZE, &size);
+            return size;
+        }
+
+        /**
+         * @brief Get buffer channels
+         * @return The buffer's number of channels
+         */
+        ALint channels() {
+            ALint channels;
+            alGetBufferi(_id, AL_CHANNELS, &channels);
+            return channels;
+        }
+
+        /**
+         * @brief Get buffer bit depth
+         * @return The buffer's bit depth
+         */
+        ALint bitDepth() {
+            ALint bitDepth;
+            alGetBufferi(_id, AL_BITS, &bitDepth);
+            return bitDepth;
+        }
+
+        /**
+         * @brief Get buffer length
+         * @return The buffer's length in samples
+         */
+        ALint length() {
+            return size() * 8 / (channels() * bitDepth());
+        }
+
+        /**
+         * @brief Get buffer loop points
+         * @return A @ref std::pair containing the start and end loop points
+         *
+         * @requires_al_extension Extension @al_extension{SOFT,loop_points}
+         */
+        std::pair<ALint, ALint> loopPoints() {
+            std::pair<ALint, ALint> points{0, 0};
+            alGetBufferiv(_id, AL_LOOP_POINTS_SOFT, &(points.first));
+            return points;
+        }
+
+        /**
          * @brief Set buffer loop points
          * @param loopStart The loop's start point in samples
          * @param loopEnd   The loop's end point in samples
          * @return Reference to self (for method chaining)
          *
+         * The buffer needs to not be attached to a source for this operation to
+         * succeed.
          * @requires_al_extension Extension @al_extension{SOFT,loop_points}
          */
         Buffer& setLoopPoints(Int loopStart, Int loopEnd);
 
         /**
          * @brief Set buffer to loop from the beginning until a certain point
+         * @param loopEnd   The loop's end point in samples
+         * @return Reference to self (for method chaining)
          *
          * Equivalent to calling @ref setLoopPoints() with @p loopStart equal to
          * 0.
-         * @param loopEnd   The loop's end point in samples
-         * @return Reference to self (for method chaining)
          *
          * @requires_al_extension Extension @al_extension{SOFT,loop_points}
          */
@@ -130,11 +182,11 @@ class MAGNUM_AUDIO_EXPORT Buffer {
 
         /**
          * @brief Set buffer to loop from the a certain point until the end
+         * @param loopStart The loop's start point in samples
+         * @return Reference to self (for method chaining)
          *
          * Equivalent to calling @ref setLoopPoints() with @p loopEnd equal to
          * @p INT_MAX.
-         * @param loopStart The loop's start point in samples
-         * @return Reference to self (for method chaining)
          *
          * @requires_al_extension Extension @al_extension{SOFT,loop_points}
          */
@@ -144,10 +196,10 @@ class MAGNUM_AUDIO_EXPORT Buffer {
 
         /**
          * @brief Resets the loop points
+         * @return Reference to self (for method chaining)
          *
          * Equivalent to calling @ref setLoopPoints() with @p loopStart equal to
          * 0, and @p loopEnd equal to @p INT_MAX.
-         * @return Reference to self (for method chaining)
          *
          * @requires_al_extension Extension @al_extension{SOFT,loop_points}
          */

--- a/src/Magnum/Audio/Buffer.h
+++ b/src/Magnum/Audio/Buffer.h
@@ -5,6 +5,7 @@
 
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
               Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2019 Guillaume Jacquemin <williamjcm@users.noreply.github.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -29,6 +30,7 @@
  * @brief Class @ref Magnum::Audio::Buffer
  */
 
+#include <climits>
 #include <utility>
 #include <al.h>
 #include <alc.h>
@@ -48,7 +50,7 @@
 namespace Magnum { namespace Audio {
 
 /** @brief Sample buffer */
-class Buffer {
+class MAGNUM_AUDIO_EXPORT Buffer {
     public:
         #ifdef MAGNUM_BUILD_DEPRECATED
         /** @brief @copybrief BufferFormat
@@ -100,6 +102,57 @@ class Buffer {
         Buffer& setData(BufferFormat format, Containers::ArrayView<const void> data, ALsizei frequency) {
             alBufferData(_id, ALenum(format), data, data.size(), frequency);
             return *this;
+        }
+
+        /**
+         * @brief Set buffer loop points
+         * @param loopStart The loop's start point in samples
+         * @param loopEnd   The loop's end point in samples
+         * @return Reference to self (for method chaining)
+         *
+         * @requires_al_extension Extension @al_extension{SOFT,loop_points}
+         */
+        Buffer& setLoopPoints(Int loopStart, Int loopEnd);
+
+        /**
+         * @brief Set buffer to loop from the beginning until a certain point
+         *
+         * Equivalent to calling @ref setLoopPoints() with @p loopStart equal to
+         * 0.
+         * @param loopEnd   The loop's end point in samples
+         * @return Reference to self (for method chaining)
+         *
+         * @requires_al_extension Extension @al_extension{SOFT,loop_points}
+         */
+        Buffer& setLoopUntil(Int loopEnd) {
+            return setLoopPoints(0, loopEnd);
+        }
+
+        /**
+         * @brief Set buffer to loop from the a certain point until the end
+         *
+         * Equivalent to calling @ref setLoopPoints() with @p loopEnd equal to
+         * @p INT_MAX.
+         * @param loopStart The loop's start point in samples
+         * @return Reference to self (for method chaining)
+         *
+         * @requires_al_extension Extension @al_extension{SOFT,loop_points}
+         */
+        Buffer& setLoopSince(Int loopStart) {
+            return setLoopPoints(loopStart, INT_MAX);
+        }
+
+        /**
+         * @brief Resets the loop points
+         *
+         * Equivalent to calling @ref setLoopPoints() with @p loopStart equal to
+         * 0, and @p loopEnd equal to @p INT_MAX.
+         * @return Reference to self (for method chaining)
+         *
+         * @requires_al_extension Extension @al_extension{SOFT,loop_points}
+         */
+        Buffer& resetLoopPoints() {
+            return setLoopPoints(0, INT_MAX);
         }
 
     private:

--- a/src/Magnum/Audio/CMakeLists.txt
+++ b/src/Magnum/Audio/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(OpenAL REQUIRED)
 set(MagnumAudio_SRCS
     AbstractImporter.cpp
     Audio.cpp
+    Buffer.cpp
     BufferFormat.cpp
     Context.cpp
     Renderer.cpp

--- a/src/Magnum/Audio/Context.cpp
+++ b/src/Magnum/Audio/Context.cpp
@@ -50,6 +50,7 @@ constexpr Extension ExtensionList[]{
     _extension(AL,EXT,ALAW),
     _extension(AL,EXT,MULAW),
     _extension(AL,EXT,MCFORMATS),
+    _extension(AL,SOFT,loop_points),
     _extension(ALC,EXT,ENUMERATION),
     _extension(ALC,SOFTX,HRTF),
     _extension(ALC,SOFT,HRTF)

--- a/src/Magnum/Audio/Extensions.h
+++ b/src/Magnum/Audio/Extensions.h
@@ -84,15 +84,18 @@ namespace AL {
         _extension(4,AL,EXT,MULAW) // #???
         _extension(5,AL,EXT,MCFORMATS) // #???
     }
+    namespace SOFT {
+        _extension(6,AL,SOFT,loop_points) // #???
+    }
 } namespace ALC {
     namespace EXT {
-        _extension_rev(6,ALC,EXT,ENUMERATION) // #???
+        _extension_rev(7,ALC,EXT,ENUMERATION) // #???
     }
     namespace SOFTX {
-        _extension(7,ALC,SOFTX,HRTF) // #???
+        _extension(8,ALC,SOFTX,HRTF) // #???
     }
     namespace SOFT {
-        _extension(8,ALC,SOFT,HRTF) // #???
+        _extension(9,ALC,SOFT,HRTF) // #???
     }
 }
 #undef _extension

--- a/src/Magnum/Audio/Test/BufferALTest.cpp
+++ b/src/Magnum/Audio/Test/BufferALTest.cpp
@@ -3,6 +3,7 @@
 
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
               Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2019 Guillaume Jacquemin <williamjcm@users.noreply.github.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -23,10 +24,14 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#include <Corrade/Containers/Array.h>
+#include <Corrade/TestSuite/Compare/Container.h>
 #include <Corrade/TestSuite/Tester.h>
 
 #include "Magnum/Audio/Buffer.h"
+#include "Magnum/Audio/BufferFormat.h"
 #include "Magnum/Audio/Context.h"
+#include "Magnum/Audio/Extensions.h"
 
 namespace Magnum { namespace Audio { namespace Test { namespace {
 
@@ -35,16 +40,107 @@ struct BufferALTest: TestSuite::Tester {
 
     void construct();
 
+    void setData();
+    void setLoopPoints();
+    void setLoopSince();
+    void setLoopUntil();
+    void resetLoopPoints();
+
     Context _context;
 };
 
 BufferALTest::BufferALTest() {
-    addTests({&BufferALTest::construct});
+    addTests({&BufferALTest::construct,
+
+              &BufferALTest::setData,
+              &BufferALTest::setLoopPoints,
+              &BufferALTest::setLoopSince,
+              &BufferALTest::setLoopUntil,
+              &BufferALTest::resetLoopPoints});
 }
 
 void BufferALTest::construct() {
     Buffer buf;
     CORRADE_VERIFY(buf.id() != 0);
+}
+
+void BufferALTest::setData() {
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050);
+
+    ALint bufSize;
+    alGetBufferi(buf.id(), AL_SIZE, &bufSize);
+    CORRADE_VERIFY(bufSize == 8);
+}
+
+void BufferALTest::setLoopPoints() {
+    if(!_context.isExtensionSupported<Audio::Extensions::AL::SOFT::loop_points>()) {
+        CORRADE_SKIP("Extension AL_SOFT_loop_points isn't supported on this system.");
+    }
+
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050).setLoopPoints(1, 6);
+
+    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
+    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
+    CORRADE_COMPARE_AS(points,
+        (Containers::Array<ALint>{Containers::InPlaceInit, { 1, 6 }}),
+        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+}
+
+void BufferALTest::setLoopSince() {
+    if(!_context.isExtensionSupported<Audio::Extensions::AL::SOFT::loop_points>()) {
+        CORRADE_SKIP("Extension AL_SOFT_loop_points isn't supported on this system.");
+    }
+
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050).setLoopSince(3);
+
+    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
+    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
+    CORRADE_COMPARE_AS(points,
+        (Containers::Array<ALint>{Containers::InPlaceInit, { 3, 8 }}),
+        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+}
+
+void BufferALTest::setLoopUntil() {
+    if(!_context.isExtensionSupported<Audio::Extensions::AL::SOFT::loop_points>()) {
+        CORRADE_SKIP("Extension AL_SOFT_loop_points isn't supported on this system.");
+    }
+
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050).setLoopUntil(5);
+
+    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
+    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
+    CORRADE_COMPARE_AS(points,
+        (Containers::Array<ALint>{Containers::InPlaceInit, { 0, 5 }}),
+        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+}
+
+void BufferALTest::resetLoopPoints() {
+    if(!_context.isExtensionSupported<Audio::Extensions::AL::SOFT::loop_points>()) {
+        CORRADE_SKIP("Extension AL_SOFT_loop_points isn't supported on this system.");
+    }
+
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050).resetLoopPoints();
+
+    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
+    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
+    CORRADE_COMPARE_AS(points,
+        (Containers::Array<ALint>{Containers::InPlaceInit, { 0, 8 }}),
+        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
 }
 
 }}}}

--- a/src/Magnum/Audio/Test/BufferALTest.cpp
+++ b/src/Magnum/Audio/Test/BufferALTest.cpp
@@ -40,7 +40,11 @@ struct BufferALTest: TestSuite::Tester {
 
     void construct();
 
-    void setData();
+    void size();
+    void channels();
+    void bitDepth();
+    void length();
+    void loopPoints();
     void setLoopPoints();
     void setLoopSince();
     void setLoopUntil();
@@ -52,7 +56,11 @@ struct BufferALTest: TestSuite::Tester {
 BufferALTest::BufferALTest() {
     addTests({&BufferALTest::construct,
 
-              &BufferALTest::setData,
+              &BufferALTest::size,
+              &BufferALTest::channels,
+              &BufferALTest::bitDepth,
+              &BufferALTest::length,
+              &BufferALTest::loopPoints,
               &BufferALTest::setLoopPoints,
               &BufferALTest::setLoopSince,
               &BufferALTest::setLoopUntil,
@@ -64,15 +72,52 @@ void BufferALTest::construct() {
     CORRADE_VERIFY(buf.id() != 0);
 }
 
-void BufferALTest::setData() {
+void BufferALTest::size() {
     Buffer buf;
     constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
 
     buf.setData(BufferFormat::Mono8, data, 22050);
 
-    ALint bufSize;
-    alGetBufferi(buf.id(), AL_SIZE, &bufSize);
-    CORRADE_VERIFY(bufSize == 8);
+    CORRADE_COMPARE(buf.size(), 8);
+}
+
+void BufferALTest::channels() {
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050);
+
+    CORRADE_COMPARE(buf.channels(), 1);
+}
+
+void BufferALTest::bitDepth() {
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050);
+
+    CORRADE_COMPARE(buf.bitDepth(), 8);
+}
+
+void BufferALTest::length() {
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050);
+
+    CORRADE_COMPARE(buf.length(), 8);
+}
+
+void BufferALTest::loopPoints() {
+    if(!_context.isExtensionSupported<Audio::Extensions::AL::SOFT::loop_points>()) {
+        CORRADE_SKIP("Extension AL_SOFT_loop_points isn't supported on this system.");
+    }
+
+    Buffer buf;
+    constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
+
+    buf.setData(BufferFormat::Mono8, data, 22050);
+    CORRADE_COMPARE(buf.loopPoints(), std::make_pair(0, 8));
 }
 
 void BufferALTest::setLoopPoints() {
@@ -84,12 +129,7 @@ void BufferALTest::setLoopPoints() {
     constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
 
     buf.setData(BufferFormat::Mono8, data, 22050).setLoopPoints(1, 6);
-
-    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
-    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
-    CORRADE_COMPARE_AS(points,
-        (Containers::Array<ALint>{Containers::InPlaceInit, { 1, 6 }}),
-        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+    CORRADE_COMPARE(buf.loopPoints(), std::make_pair(1, 6));
 }
 
 void BufferALTest::setLoopSince() {
@@ -101,12 +141,7 @@ void BufferALTest::setLoopSince() {
     constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
 
     buf.setData(BufferFormat::Mono8, data, 22050).setLoopSince(3);
-
-    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
-    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
-    CORRADE_COMPARE_AS(points,
-        (Containers::Array<ALint>{Containers::InPlaceInit, { 3, 8 }}),
-        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+    CORRADE_COMPARE(buf.loopPoints(), std::make_pair(3, 8));
 }
 
 void BufferALTest::setLoopUntil() {
@@ -118,12 +153,7 @@ void BufferALTest::setLoopUntil() {
     constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
 
     buf.setData(BufferFormat::Mono8, data, 22050).setLoopUntil(5);
-
-    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
-    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
-    CORRADE_COMPARE_AS(points,
-        (Containers::Array<ALint>{Containers::InPlaceInit, { 0, 5 }}),
-        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+    CORRADE_COMPARE(buf.loopPoints(), std::make_pair(0, 5));
 }
 
 void BufferALTest::resetLoopPoints() {
@@ -135,12 +165,7 @@ void BufferALTest::resetLoopPoints() {
     constexpr char data[] { 25, 17, 24, 122, 67, 24, 48, 96 };
 
     buf.setData(BufferFormat::Mono8, data, 22050).resetLoopPoints();
-
-    Containers::Array<ALint> points{Containers::InPlaceInit, { 0, 0 }};
-    alGetBufferiv(buf.id(), AL_LOOP_POINTS_SOFT, points.data());
-    CORRADE_COMPARE_AS(points,
-        (Containers::Array<ALint>{Containers::InPlaceInit, { 0, 8 }}),
-        TestSuite::Compare::Container<Containers::ArrayView<const ALint>>);
+    CORRADE_COMPARE(buf.loopPoints(), std::make_pair(0, 8));
 }
 
 }}}}

--- a/src/MagnumExternal/OpenAL/extensions.h
+++ b/src/MagnumExternal/OpenAL/extensions.h
@@ -6,6 +6,7 @@
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
               Vladimír Vondruš <mosra@centrum.cz>
     Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
+    Copyright © 2019 Guillaume Jacquemin <williamjcm@users.noreply.github.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -86,6 +87,12 @@ extern "C" {
 #define AL_FORMAT_71CHN8                         0x1210
 #define AL_FORMAT_71CHN16                        0x1211
 #define AL_FORMAT_71CHN32                        0x1212
+#endif
+
+/* AL_SOFT_loop_points */
+#ifndef AL_SOFT_loop_points
+#define AL_SOFT_loop_points 1
+#define AL_LOOP_POINTS_SOFT                      0x2015
 #endif
 
 /* ALC_SOFTX_HRTF */


### PR DESCRIPTION
This feature requires the `AL_SOFT_loop_points` extension.

Also, a test for `Buffer::setData()` was added to `BufferALTest`, along with the tests for the new functions.

Review/feedback welcome!