### PR TITLE
Fixing gentoo build instructions

### DIFF
--- a/doc/building.dox
+++ b/doc/building.dox
@@ -270,7 +270,7 @@ build and install Magnum like this:
 @code{.sh}
 git clone git://github.com/mosra/magnum && cd magnum
 cd package/gentoo
-sudo ebuild dev-libs/magnum/magnum-99999.ebuild manifest clean merge
+sudo ebuild dev-libs/magnum/magnum-9999.ebuild manifest clean merge
 @endcode
 
 If you want to pass additional flags to CMake or

--- a/package/gentoo/dev-libs/magnum/magnum-9999.ebuild
+++ b/package/gentoo/dev-libs/magnum/magnum-9999.ebuild
@@ -17,7 +17,6 @@ RDEPEND="
 	media-libs/openal
 	media-libs/glfw
 	media-libs/libsdl2
-	media-libs/openal
 "
 DEPEND="${RDEPEND}"
 

--- a/package/gentoo/dev-libs/magnum/magnum-9999.ebuild
+++ b/package/gentoo/dev-libs/magnum/magnum-9999.ebuild
@@ -17,6 +17,7 @@ RDEPEND="
 	media-libs/openal
 	media-libs/glfw
 	media-libs/libsdl2
+	media-libs/openal
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
Fixing gentoo build instructions ( -99999 -> 9999 in the ebuild path…); added media-libs/openal dependency to the ebuild