### PR TITLE
Added equal and not equal operators in Magnum::Resource

### DIFF
--- a/src/Magnum/Resource.h
+++ b/src/Magnum/Resource.h
@@ -150,6 +150,12 @@ class Resource {
         /** @brief Move assignment */
         Resource<T, U>& operator=(Resource<T, U>&& other);
 
+        /** @brief Equal operator */
+        bool operator==(const Resource<T, U>& other) const;
+
+        /** @brief Not equal operator */
+        bool operator!=(const Resource<T, U>& other) const;
+
         /** @brief Resource key */
         ResourceKey key() const { return _key; }
 
@@ -255,6 +261,14 @@ template<class T, class U> Resource<T, U>& Resource<T, U>::operator=(Resource<T,
 
     other.manager = nullptr;
     return *this;
+}
+
+template<class T, class U> bool Resource<T, U>::operator==(const Resource<T, U>& other) const {
+    return manager == other.manager && _key == other._key;
+}
+
+template<class T, class U> bool Resource<T, U>::operator!=(const Resource<T, U>& other) const {
+    return !(*this == other);
 }
 
 template<class T, class U> void Resource<T, U>::acquire() {

--- a/src/Magnum/Test/ResourceManagerTest.cpp
+++ b/src/Magnum/Test/ResourceManagerTest.cpp
@@ -34,6 +34,7 @@ namespace Magnum { namespace Test { namespace {
 struct ResourceManagerTest: TestSuite::Tester {
     explicit ResourceManagerTest();
 
+    void compare();
     void state();
     void stateFallback();
     void stateDisallowed();
@@ -61,7 +62,8 @@ typedef Magnum::ResourceManager<Int, Data> ResourceManager;
 size_t Data::count = 0;
 
 ResourceManagerTest::ResourceManagerTest() {
-    addTests({&ResourceManagerTest::state,
+    addTests({&ResourceManagerTest::compare,
+              &ResourceManagerTest::state,
               &ResourceManagerTest::stateFallback,
               &ResourceManagerTest::stateDisallowed,
               &ResourceManagerTest::basic,
@@ -74,6 +76,23 @@ ResourceManagerTest::ResourceManagerTest() {
               &ResourceManagerTest::loader,
 
               &ResourceManagerTest::debugResourceState});
+}
+
+void ResourceManagerTest::compare() {
+    ResourceManager rm;
+    
+    ResourceKey resKeyA("keyA");
+    ResourceKey resKeyB("keyB");
+    rm.set(resKeyA, 1);
+    rm.set(resKeyB, 0);
+    
+    Resource<Int> resA = rm.get<Int>(resKeyA);
+    Resource<Int> resA2 = rm.get<Int>(resKeyA);
+    Resource<Int> resB = rm.get<Int>(resKeyB);
+
+    CORRADE_VERIFY(resA == resA);
+    CORRADE_VERIFY(resA == resA2);
+    CORRADE_VERIFY(resA != resB);
 }
 
 void ResourceManagerTest::state() {


### PR DESCRIPTION
I added the equal and not equal operators to check if a resource is equal or not to another Resource.

My use case was this:
```
void Sprite::setTexture(const Magnum::Resource<Magnum::GL::Texture2D>& texture) {
	if (texture != _texture) {
		_texture = texture;
		updateVertices();
		updateUVs();
	}
}
```