### PR TITLE
Expose SDL2_BIN_DIR on FindSDL2.cmake

### DIFF
--- a/modules/FindSDL2.cmake
+++ b/modules/FindSDL2.cmake
@@ -13,6 +13,7 @@
 #  SDL2_LIBRARY_RELEASE     - SDL2 release library, if found
 #  SDL2_INCLUDE_DIR         - Root include dir
 #  SDL2_BIN_DIR             - Root bin dir
+#
 
 #
 #   This file is part of Magnum.
@@ -78,10 +79,12 @@ else()
         # the dylib first so it is preferred. Not sure how this maps to debug
         # config though :/
         NAMES SDL2-2.0 SDL2
+        HINTS ${SDL2_PATH}
         PATH_SUFFIXES ${_SDL2_LIBRARY_PATH_SUFFIX})
 
     find_library(SDL2_LIBRARY_DEBUG
         NAMES SDL2d
+        HINTS ${SDL2_PATH}
         PATH_SUFFIXES ${_SDL2_LIBRARY_PATH_SUFFIX})
 
     # FPHSA needs one of the _DEBUG/_RELEASE variables to check that the
@@ -103,11 +106,13 @@ find_path(SDL2_INCLUDE_DIR
     # solve this issue), but rather SDL2.framework/Headers/SDL.h, CMake might
     # find SDL.framework/Headers/SDL.h if SDL1 is installed, which is wrong.
     NAMES SDL_scancode.h
+    HINTS ${SDL2_PATH}
     PATH_SUFFIXES ${_SDL2_PATH_SUFFIXES})
     
 # Bin dir
 find_path(SDL2_BIN_DIR
-    NAMES *.dll
+    NAMES SDL2.dll
+    HINTS ${SDL2_PATH}
     PATH_SUFFIXES ${_SDL2_BIN_PATH_SUFFIX} ${_SDL2_LIBRARY_PATH_SUFFIX})
 
 # iOS dependencies

--- a/modules/FindSDL2.cmake
+++ b/modules/FindSDL2.cmake
@@ -12,7 +12,7 @@
 #  SDL2_LIBRARY_DEBUG       - SDL2 debug library, if found
 #  SDL2_LIBRARY_RELEASE     - SDL2 release library, if found
 #  SDL2_INCLUDE_DIR         - Root include dir
-#
+#  SDL2_BIN_DIR             - Root bin dir
 
 #
 #   This file is part of Magnum.
@@ -62,9 +62,11 @@ else()
         elseif(MINGW)
             if(CMAKE_SIZEOF_VOID_P EQUAL 8)
                 set(_SDL2_LIBRARY_PATH_SUFFIX x86_64-w64-mingw32/lib)
+                set(_SDL2_BIN_PATH_SUFFIX x86_64-w64-mingw32/bin)
                 list(APPEND _SDL2_PATH_SUFFIXES x86_64-w64-mingw32/include/SDL2)
             elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
                 set(_SDL2_LIBRARY_PATH_SUFFIX i686-w64-mingw32/lib)
+                set(_SDL2_BIN_PATH_SUFFIX i686-w64-mingw32/bin)
                 list(APPEND _SDL2_PATH_SUFFIXES i686-w64-mingw32/include/SDL2)
             endif()
         endif()
@@ -77,9 +79,11 @@ else()
         # config though :/
         NAMES SDL2-2.0 SDL2
         PATH_SUFFIXES ${_SDL2_LIBRARY_PATH_SUFFIX})
+
     find_library(SDL2_LIBRARY_DEBUG
         NAMES SDL2d
         PATH_SUFFIXES ${_SDL2_LIBRARY_PATH_SUFFIX})
+
     # FPHSA needs one of the _DEBUG/_RELEASE variables to check that the
     # library was found -- using SDL_LIBRARY, which will get populated by
     # select_library_configurations() below.
@@ -100,6 +104,11 @@ find_path(SDL2_INCLUDE_DIR
     # find SDL.framework/Headers/SDL.h if SDL1 is installed, which is wrong.
     NAMES SDL_scancode.h
     PATH_SUFFIXES ${_SDL2_PATH_SUFFIXES})
+    
+# Bin dir
+find_path(SDL2_BIN_DIR
+    NAMES *.dll
+    PATH_SUFFIXES ${_SDL2_BIN_PATH_SUFFIX} ${_SDL2_LIBRARY_PATH_SUFFIX})
 
 # iOS dependencies
 if(CORRADE_TARGET_IOS)


### PR DESCRIPTION
Hi, this change aims to help windows users that use `Sdl2Application`.

First, it makes use of `SDL2_PATH` (if set) as a HINT path for finding the library instead of always relying on `CMAKE_PREFIX_PATH`.

Then, it also exposes `SDL2_BIN_DIR` if SDL is found.
This way, the windows users can decide if they want to copy the SDL DLLs automatically with the following (or similar) snippet:

    # Copy SDL2 DLL to output folder on Windows
    if(NOT CORRADE_TARGET_EMSCRIPTEN AND WIN32)
        add_custom_command(TARGET Game
            POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SDL2_BIN_DIR}/SDL2.dll $<TARGET_FILE_DIR:Game>)
    endif()

Without this change, detecting the bin folder while allowing crosscompiling (vs, mingw, clang, etc) isn't trivial.
Thanks!