### PR TITLE
GL: imageSize is not available for GLES < 3.1

### DIFF
--- a/src/Magnum/GL/Texture.h
+++ b/src/Magnum/GL/Texture.h
@@ -724,7 +724,7 @@ template<UnsignedInt dimensions> class Texture: public AbstractTexture {
             return *this;
         }
 
-        #ifndef MAGNUM_TARGET_GLES2
+        #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
         /**
          * @brief Image size in given mip level
          *


### PR DESCRIPTION
Fixes the following compile error:

magnum/src/Magnum/GL/Texture.h:747:44: error: no member named 'imageSize' in 'Magnum::GL::AbstractTexture::DataHelper<2>'
            return DataHelper<dimensions>::imageSize(*this, level);
                                           ^