### PR TITLE
Fix DistanceFieldVector on WebGL iOS

### DIFF
--- a/src/Magnum/Shaders/AbstractVector.h
+++ b/src/Magnum/Shaders/AbstractVector.h
@@ -91,7 +91,7 @@ template<UnsignedInt dimensions> class AbstractVector: public GL::AbstractShader
     #else
     private:
     #endif
-        enum: Int { VectorTextureLayer = 15 };
+        enum: Int { VectorTextureLayer = 0 };
 
         explicit AbstractVector(NoCreateT) noexcept: GL::AbstractShaderProgram{NoCreate} {}
         explicit AbstractVector() = default;

--- a/src/Magnum/Shaders/DistanceFieldVector.frag
+++ b/src/Magnum/Shaders/DistanceFieldVector.frag
@@ -62,7 +62,7 @@ uniform lowp float smoothness
     ;
 
 #ifdef EXPLICIT_TEXTURE_LAYER
-layout(binding = 15)
+layout(binding = 0)
 #endif
 uniform lowp sampler2D vectorTexture;
 
@@ -80,8 +80,8 @@ void main() {
 
     /* Outline */
     if(outlineRange.x > outlineRange.y) {
-        lowp float mid = (outlineRange.x + outlineRange.y)/2.0;
-        lowp float halfRange = (outlineRange.x - outlineRange.y)/2.0;
+        lowp float mid = (outlineRange.x + outlineRange.y)*0.5;
+        lowp float halfRange = (outlineRange.x - outlineRange.y)*0.5;
         fragmentColor += smoothstep(halfRange+smoothness, halfRange-smoothness, distance(mid, intensity))*outlineColor;
     }
 }

--- a/src/Magnum/Shaders/Vector.frag
+++ b/src/Magnum/Shaders/Vector.frag
@@ -44,7 +44,7 @@ uniform lowp vec4 color
     ;
 
 #ifdef EXPLICIT_TEXTURE_LAYER
-layout(binding = 15)
+layout(binding = 0)
 #endif
 uniform lowp sampler2D vectorTexture;
 


### PR DESCRIPTION
Hi mosra,

I've finally found a fix for this issue: https://github.com/mosra/magnum-examples/issues/65 !
This commit fixes all the errors and warnings of `ShadersDistanceFieldVectorGLTest`.

For some reason, iOS doesn't like that texture binding to 15. I've set it to 0, like in Flat. Is there any reason why it wasn't set to 0 in the first place?

Also, I've replaced `/2.0` with `*0.5` so as to fix that `Overflow in implicit constant conversion, minimum range for lowp float is (-2,2)` warning without altering float precision.

I haven't tried to build the text example with this fix, but I can tell you it works for my project as it's now finally able to render everything correctly :).