### PR TITLE
Make SDL2_INCLUDE_DIR point to the root

### DIFF
--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -547,6 +547,9 @@ See also:
 -   `FindSDL2.cmake` was updated to work with MinGW version 2.0.5 and newer,
     since these dropped the old directory hierarchy. Older versions have both
     the original and the new hierarchy, so it should work with these as well.
+-   `FindSDL2.cmake` now points `SDL2_INCLUDE_DIR` to the root and the
+    @ref Platform::Sdl2Application was updated to follow that; people using
+    custom buildsystems don't need to add `SDL2/` to their include path anymore
 -   When using Magnum as a CMake subproject, @ref Platform::GlfwApplication and
     @ref Platform::Sdl2Application now copy the GLFW / SDL2 DLLs to
     `CMAKE_RUNTIME_OUTPUT_DIRECTORY` (if set) as a post-build step. The DLL

--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -26,10 +26,11 @@
 #include "Sdl2Application.h"
 
 #include <cstring>
-#include <SDL.h>
 #ifndef CORRADE_TARGET_EMSCRIPTEN
 #include <tuple>
+#include <SDL2/SDL.h>
 #else
+#include <SDL/SDL.h>
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 #endif

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -47,10 +47,18 @@
 #define SDL_MAIN_HANDLED
 #endif
 /* SDL.h includes the world, adding 50k LOC. We don't want that either. */
-#include <SDL_keycode.h>
-#include <SDL_mouse.h>
-#include <SDL_video.h>
-#include <SDL_scancode.h>
+#ifndef CORRADE_TARGET_EMSCRIPTEN
+#include <SDL2/SDL_keycode.h>
+#include <SDL2/SDL_mouse.h>
+#include <SDL2/SDL_video.h>
+#include <SDL2/SDL_scancode.h>
+#else
+/* Emscripten has a SDL1/2 hybrid, with includes in SDL/ instead of SDL2/ */
+#include <SDL/SDL_keycode.h>
+#include <SDL/SDL_mouse.h>
+#include <SDL/SDL_video.h>
+#include <SDL/SDL_scancode.h>
+#endif
 
 #ifdef CORRADE_TARGET_WINDOWS_RT
 #include <SDL_main.h> /* For SDL_WinRTRunApp */

--- a/src/Magnum/Platform/Test/Sdl2ApplicationTest.cpp
+++ b/src/Magnum/Platform/Test/Sdl2ApplicationTest.cpp
@@ -27,7 +27,11 @@
 
 #include "Magnum/Platform/Sdl2Application.h"
 
-#include <SDL_events.h>
+#ifndef CORRADE_TARGET_EMSCRIPTEN
+#include <SDL2/SDL_events.h>
+#else
+#include <SDL/SDL_events.h>
+#endif
 
 namespace Magnum { namespace Platform { namespace Test { namespace {
 


### PR DESCRIPTION
So people using custom buildsystems don't need to add `SDL2/` into the include path, and also would make a [vcpkg patch](https://github.com/microsoft/vcpkg/blob/master/ports/magnum/001-sdl-includes.patch) obsolete. However, it's ... an unsolvable mess:

- Sane distributions and packages have includes with a `SDL2/` prefix (yay)
- The Emscripten SDL1/2 hybrid uses `SDL/`. Fortunately that's "just" an `#ifdef`.
- The Windows binary SDL distribution has the includes without the `SDL2/` prefix. One option would be to detect this via CMake and then expose that in the global `configure.h`, but that's very ugly. Another option would be to use `__has_include()`, but on the only system where this matters, MSVC supports that only since 2017 17.3 or something, would need to have an ugly fallback on older versions.

Keeping it as-is right now, may revisit this when I get a better idea on how to fix it.