### PR TITLE
GL: Add ArrayView<AbstractTexture*> overrides to bind and bindImages

### DIFF
--- a/src/Magnum/GL/AbstractTexture.cpp
+++ b/src/Magnum/GL/AbstractTexture.cpp
@@ -156,7 +156,7 @@ void AbstractTexture::unbind(const Int firstTextureUnit, const std::size_t count
 }
 
 /** @todoc const std::initializer_list makes Doxygen grumpy */
-void AbstractTexture::bind(const Int firstTextureUnit, std::initializer_list<AbstractTexture*> textures) {
+void AbstractTexture::bind(const Int firstTextureUnit, Containers::ArrayView<AbstractTexture* const> textures) {
     /* State tracker is updated in the implementations */
     Context::current().state().texture->bindMultiImplementation(firstTextureUnit, {textures.begin(), textures.size()});
 }
@@ -289,7 +289,7 @@ void AbstractTexture::unbindImage(const Int imageUnit) {
 
 #ifndef MAGNUM_TARGET_GLES
 /** @todoc const Containers::ArrayView makes Doxygen grumpy */
-void AbstractTexture::bindImagesInternal(const Int firstImageUnit, Containers::ArrayView<AbstractTexture* const> textures) {
+void AbstractTexture::bindImages(const Int firstImageUnit, Containers::ArrayView<AbstractTexture* const> textures) {
     Implementation::TextureState& textureState = *Context::current().state().texture;
 
     /* Create array of IDs and also update bindings in state tracker */

--- a/src/Magnum/GL/AbstractTexture.h
+++ b/src/Magnum/GL/AbstractTexture.h
@@ -244,7 +244,12 @@ class MAGNUM_GL_EXPORT AbstractTexture: public AbstractObject {
          * @see @ref Shader::maxCombinedTextureImageUnits(),
          *      @fn_gl_keyword{BindTextures}
          */
-        static void bind(Int firstTextureUnit, std::initializer_list<AbstractTexture*> textures);
+        static void bind(Int firstTextureUnit, Containers::ArrayView<AbstractTexture* const> textures);
+
+        /** @overload */
+        static void bind(Int firstTextureUnit, std::initializer_list<AbstractTexture*> textures) {
+            AbstractTexture::bind(firstTextureUnit, Containers::arrayView(textures.begin(), textures.size()));
+        }
 
         #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
         /**
@@ -284,7 +289,7 @@ class MAGNUM_GL_EXPORT AbstractTexture: public AbstractObject {
          * @requires_gl Multi bind is not available in OpenGL ES and WebGL.
          */
         static void unbindImages(Int firstImageUnit, std::size_t count) {
-            bindImagesInternal(firstImageUnit, {nullptr, count});
+            bindImages(firstImageUnit, {nullptr, count});
         }
 
         /**
@@ -306,8 +311,11 @@ class MAGNUM_GL_EXPORT AbstractTexture: public AbstractObject {
          * @requires_gl44 Extension @gl_extension{ARB,multi_bind}
          * @requires_gl Multi bind is not available in OpenGL ES and WebGL.
          */
+        static void bindImages(Int firstImageUnit, Containers::ArrayView<AbstractTexture* const> textures);
+
+        /** @overload */
         static void bindImages(Int firstImageUnit, std::initializer_list<AbstractTexture*> textures) {
-            bindImagesInternal(firstImageUnit, {textures.begin(), textures.size()});
+            bindImages(firstImageUnit, Containers::arrayView(textures.begin(), textures.size()));
         }
         #endif
 
@@ -425,10 +433,6 @@ class MAGNUM_GL_EXPORT AbstractTexture: public AbstractObject {
 
         #ifndef MAGNUM_TARGET_GLES
         static Int compressedBlockDataSize(GLenum target, TextureFormat format);
-        #endif
-
-        #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
-        static void bindImagesInternal(Int firstImageUnit, Containers::ArrayView<AbstractTexture* const> textures);
         #endif
 
         explicit AbstractTexture(GLenum target);


### PR DESCRIPTION
Hi @mosra !

As promised, here the PR for the ArrayView overrides in AbstractTexture.
I checked building with doxygen, that is still running, but seems to still be able to resolve references correctly. I removed a couple of todos that referenced doxygen in the process, though, so there might be errors further down the line.
I'll ping once that has run through.

Best, Jonathan