### PR TITLE
Stop Swizzle.h(75): warning C4389: '==': signed/unsigned mismatch

### DIFF
--- a/src/Magnum/Math/Swizzle.h
+++ b/src/Magnum/Math/Swizzle.h
@@ -72,7 +72,7 @@ namespace Implementation {
             return vector._data[i];
         }
     };
-    template<std::size_t size, char component, std::size_t i> struct ScatterComponent: ScatterComponentOr<size, i, component == i> {
+    template<std::size_t size, char component, std::size_t i> struct ScatterComponent: ScatterComponentOr<size, i, static_cast<std::size_t>(component) == i> {
         static_assert(component == 'x' || component == 'r' ||
                     ((component == 'y' || component == 'g') && size > 1) ||
                     ((component == 'z' || component == 'b') && size > 2) ||


### PR DESCRIPTION
Tiny fix, to suppress that annoying warning.