### PR TITLE
Fix linking to the library on MSYS2/Clang.

### DIFF
--- a/src/Magnum/Animation/Player.h
+++ b/src/Magnum/Animation/Player.h
@@ -876,7 +876,7 @@ template<class T, class K> template<class V, class R, class Callback> Player<T, 
 }
 #endif
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_EXPORT Player<Float, Float>;
 extern template class MAGNUM_EXPORT Player<std::chrono::nanoseconds, Float>;
 #endif

--- a/src/Magnum/SceneGraph/AbstractFeature.h
+++ b/src/Magnum/SceneGraph/AbstractFeature.h
@@ -312,7 +312,7 @@ template<class T> using AbstractBasicFeature3D = AbstractFeature<3, T>;
 */
 typedef AbstractBasicFeature3D<Float> AbstractFeature3D;
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractFeature<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractFeature<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/AbstractObject.h
+++ b/src/Magnum/SceneGraph/AbstractObject.h
@@ -305,7 +305,7 @@ typedef AbstractBasicObject3D<Float> AbstractObject3D;
 typedef AbstractObject<3, Float> AbstractObject3D;
 #endif
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractObject<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractObject<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/AbstractTransformation.h
+++ b/src/Magnum/SceneGraph/AbstractTransformation.h
@@ -122,7 +122,7 @@ template<class T> using AbstractBasicTransformation3D = AbstractTransformation<3
 */
 typedef AbstractBasicTransformation3D<Float> AbstractTransformation3D;
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractTransformation<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractTransformation<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/Animable.h
+++ b/src/Magnum/SceneGraph/Animable.h
@@ -339,7 +339,7 @@ template<class T> using BasicAnimable3D = Animable<3, T>;
 */
 typedef BasicAnimable3D<Float> Animable3D;
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Animable<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT Animable<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/AnimableGroup.h
+++ b/src/Magnum/SceneGraph/AnimableGroup.h
@@ -109,7 +109,7 @@ template<class T> using BasicAnimableGroup3D = AnimableGroup<3, T>;
 */
 typedef BasicAnimableGroup3D<Float> AnimableGroup3D;
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT AnimableGroup<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT AnimableGroup<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/Camera.h
+++ b/src/Magnum/SceneGraph/Camera.h
@@ -266,7 +266,7 @@ template<class T> using BasicCamera3D = Camera<3, T>;
 */
 typedef BasicCamera3D<Float> Camera3D;
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Camera<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT Camera<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/Drawable.h
+++ b/src/Magnum/SceneGraph/Drawable.h
@@ -272,7 +272,7 @@ template<class T> using BasicDrawableGroup3D = DrawableGroup<3, T>;
 */
 typedef BasicDrawableGroup3D<Float> DrawableGroup3D;
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Drawable<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT Drawable<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/DualComplexTransformation.h
+++ b/src/Magnum/SceneGraph/DualComplexTransformation.h
@@ -224,7 +224,7 @@ template<class T> struct Transformation<BasicDualComplexTransformation<T>> {
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicDualComplexTransformation<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/DualQuaternionTransformation.h
+++ b/src/Magnum/SceneGraph/DualQuaternionTransformation.h
@@ -254,7 +254,7 @@ template<class T> struct Transformation<BasicDualQuaternionTransformation<T>> {
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicDualQuaternionTransformation<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/FeatureGroup.h
+++ b/src/Magnum/SceneGraph/FeatureGroup.h
@@ -197,7 +197,7 @@ template<UnsignedInt dimensions, class Feature, class T> FeatureGroup<dimensions
     return *this;
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractFeatureGroup<2, Float>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT AbstractFeatureGroup<3, Float>;
 #endif

--- a/src/Magnum/SceneGraph/MatrixTransformation2D.h
+++ b/src/Magnum/SceneGraph/MatrixTransformation2D.h
@@ -233,7 +233,7 @@ template<class T> struct Transformation<BasicMatrixTransformation2D<T>> {
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicMatrixTransformation2D<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/MatrixTransformation3D.h
+++ b/src/Magnum/SceneGraph/MatrixTransformation3D.h
@@ -317,7 +317,7 @@ template<class T> struct Transformation<BasicMatrixTransformation3D<T>> {
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicMatrixTransformation3D<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/RigidMatrixTransformation2D.h
+++ b/src/Magnum/SceneGraph/RigidMatrixTransformation2D.h
@@ -253,7 +253,7 @@ template<class T> struct Transformation<BasicRigidMatrixTransformation2D<T>> {
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicRigidMatrixTransformation2D<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/RigidMatrixTransformation3D.h
+++ b/src/Magnum/SceneGraph/RigidMatrixTransformation3D.h
@@ -337,7 +337,7 @@ template<class T> struct Transformation<BasicRigidMatrixTransformation3D<T>> {
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicRigidMatrixTransformation3D<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/TranslationRotationScalingTransformation2D.h
+++ b/src/Magnum/SceneGraph/TranslationRotationScalingTransformation2D.h
@@ -314,7 +314,7 @@ template<class T> struct Transformation<BasicTranslationRotationScalingTransform
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicTranslationRotationScalingTransformation2D<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/TranslationRotationScalingTransformation3D.h
+++ b/src/Magnum/SceneGraph/TranslationRotationScalingTransformation3D.h
@@ -404,7 +404,7 @@ template<class T> struct Transformation<BasicTranslationRotationScalingTransform
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<BasicTranslationRotationScalingTransformation3D<Float>>;
 #endif
 

--- a/src/Magnum/SceneGraph/TranslationTransformation.h
+++ b/src/Magnum/SceneGraph/TranslationTransformation.h
@@ -195,7 +195,7 @@ template<UnsignedInt dimensions, class T, class TranslationType> struct Transfor
 
 }
 
-#if defined(CORRADE_TARGET_WINDOWS) && !defined(__MINGW32__)
+#if defined(CORRADE_TARGET_WINDOWS) && !(defined(CORRADE_TARGET_MINGW) && !defined(CORRADE_TARGET_CLANG))
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<TranslationTransformation<2, Float>>;
 extern template class MAGNUM_SCENEGRAPH_EXPORT Object<TranslationTransformation<3, Float>>;
 #endif


### PR DESCRIPTION
As you asked on Gitter, mosra, this is the PR containing the fix to errors when linking with the SceneGraph library on MSYS2's build of Clang.