### PR TITLE
Platform: implement mouse capturing for SDL and GLFW

### DIFF
--- a/src/Magnum/Platform/GlfwApplication.h
+++ b/src/Magnum/Platform/GlfwApplication.h
@@ -625,6 +625,10 @@ class GlfwApplication {
             glfwSetCursorPos(_window, Double(position.x()), Double(position.y()));
         }
 
+        /** @todo GLFW_CURSOR_CAPTURED, currently only in a branch:
+            https://github.com/glfw/glfw/issues/58
+            https://github.com/glfw/glfw/compare/captured-cursor-mode-r2 */
+
     private:
         /** @copydoc Sdl2Application::mousePressEvent() */
         virtual void mousePressEvent(MouseEvent& event);

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -967,6 +967,26 @@ class Sdl2Application {
         void warpCursor(const Vector2i& position) {
             SDL_WarpMouseInWindow(_window, position.x(), position.y());
         }
+
+        /**
+         * @brief Whether the mouse is captured
+         * @m_since_latest
+         *
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         */
+        bool isMouseCaptured() {
+            return SDL_GetWindowFlags(_window) & SDL_WINDOW_MOUSE_CAPTURE;
+        }
+
+        /**
+         * @brief Capture mouse
+         * @m_since_latest
+         *
+         * @note Not available in @ref CORRADE_TARGET_EMSCRIPTEN "Emscripten".
+         */
+        void setMouseCaptured(bool enabled) {
+            SDL_CaptureMouse(enabled ? SDL_TRUE : SDL_FALSE);
+        }
         #endif
 
         #ifdef MAGNUM_BUILD_DEPRECATED

--- a/src/Magnum/Platform/Test/Sdl2ApplicationTest.cpp
+++ b/src/Magnum/Platform/Test/Sdl2ApplicationTest.cpp
@@ -97,7 +97,10 @@ struct Sdl2ApplicationTest: Platform::Application {
             setWindowTitle("This is a UTF-8 Window Title™!");
         }
         #ifndef CORRADE_TARGET_EMSCRIPTEN
-        else if(event.key() == KeyEvent::Key::S) {
+        else if(event.key() == KeyEvent::Key::C) {
+            Debug{} << "toggling mouse capture to" << !isMouseCaptured();
+            setMouseCaptured(!isMouseCaptured());
+        } else if(event.key() == KeyEvent::Key::S) {
             Debug{} << "setting window size, which should trigger a viewport event";
             setWindowSize(Vector2i{300, 200});
         } else if(event.key() == KeyEvent::Key::W) {


### PR DESCRIPTION
Isn't as straightforward as it originally seemed, and I don't want to push something that'd be deprecated right after in favor of a more consistent API.

TODOs: 

- [ ] GLFW has this in a branch right now, scheduled for 3.4 -- https://github.com/glfw/glfw/issues/58
- [ ] GLFW has it together with normal/hidden/locked (which would mean extending `setCursor()`) and those options are mutually exclusive, so maybe do it that way in both instead of `setMouseCaptured()` that's done in case of SDL?
- [ ] while SDL reports move event coordinates outside of the window, GLFW docs in the branch seem to indicate that the mouse position won't change -- would this mean the mouse move events won't get reported? Would need to test that branch to see.