### PR TITLE
[WIP] Added shared context support

### DIFF
--- a/src/Magnum/Platform/WindowlessCglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessCglApplication.cpp
@@ -35,7 +35,7 @@
 
 namespace Magnum { namespace Platform {
 
-WindowlessCglContext::WindowlessCglContext(const Configuration&, GLContext*) {
+WindowlessCglContext::WindowlessCglContext(const Configuration & configuration, GLContext*) {
     int formatCount;
     CGLPixelFormatAttribute attributes32[] = {
         kCGLPFAAccelerated,
@@ -68,7 +68,7 @@ WindowlessCglContext::WindowlessCglContext(const Configuration&, GLContext*) {
         }
     }
 
-    if(CGLCreateContext(_pixelFormat, nullptr, &_context) != kCGLNoError)
+    if(CGLCreateContext(_pixelFormat, configuration.sharedContext(), &_context) != kCGLNoError)
         Error() << "Platform::WindowlessCglContext: cannot create context";
 }
 

--- a/src/Magnum/Platform/WindowlessCglApplication.h
+++ b/src/Magnum/Platform/WindowlessCglApplication.h
@@ -142,6 +142,28 @@ class WindowlessCglContext {
 class WindowlessCglContext::Configuration {
     public:
         constexpr /*implicit*/ Configuration() {}
+        
+        /**
+         * @brief Creates an OpenGL shared context with @param ctx instead
+         * of creating a brand new one.
+         */
+        Configuration& setSharedcontext(CGLContextObj ctx) {
+            _sharedContext = ctx;
+            return *this;
+        }
+        
+        /**
+         * @brief Returns the configuration shared context.
+         * If this has not been specified, (meaning the configuration uses a new opengl context), 
+         * then returns nullptr
+         */
+        CGLContextObj sharedContext() const {
+            return _sharedContext;
+        }
+        
+private:
+    CGLContextObj _context{};
+    CGLContextObj _sharedContext{};
 };
 
 /**

--- a/src/Magnum/Platform/WindowlessEglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessEglApplication.cpp
@@ -273,7 +273,7 @@ WindowlessEglContext::WindowlessEglContext(const Configuration& configuration, G
     }
     #endif
 
-    if(!(_context = eglCreateContext(_display, config, EGL_NO_CONTEXT, attributes))) {
+    if(!(_context = eglCreateContext(_display, config, configuration.sharedContext(), attributes))) {
         Error() << "Platform::WindowlessEglApplication::tryCreateContext(): cannot create EGL context:" << Implementation::eglErrorString(eglGetError());
         return;
     }

--- a/src/Magnum/Platform/WindowlessEglApplication.h
+++ b/src/Magnum/Platform/WindowlessEglApplication.h
@@ -183,6 +183,25 @@ class WindowlessEglContext::Configuration {
         #endif
 
         /*implicit*/ Configuration();
+        
+        /**
+         * @brief Creates an OpenGL shared context with @param ctx instead
+         * of creating a brand new one.
+         */
+        Configuration& setSharedcontext(EGLContext ctx) {
+            _sharedContext = ctx;
+            return *this;
+        }
+        
+        /**
+         * @brief Returns the configuration shared context.
+         * If this has not been specified, (meaning the configuration uses a new opengl context), 
+         * then returns nullptr
+         */
+        EGLContext sharedContext() const {
+            return _sharedContext;
+        }      
+        
 
         #ifndef MAGNUM_TARGET_WEBGL
         /**
@@ -255,28 +274,11 @@ class WindowlessEglContext::Configuration {
             _device = id;
             return *this;
         }
-        /**
-         * @brief Creates an OpenGL shared context with @param ctx instead
-         * of creating a brand new one.
-         */
-        Configuration& setSharedcontext(EGLContext ctx) {
-            _sharedContext = ctx;
-            return *this;
-        }
-        
-        /**
-         * @brief Returns the configuration shared context.
-         * If this has not been specified, (meaning the configuration uses a new opengl context), 
-         * then returns nullptr
-         */
-        EGLContext sharedContext() const {
-            return _sharedContext;
-        }       
         #endif
 
     private:
-        #ifndef MAGNUM_TARGET_WEBGL
         EGLContext _sharedContext{EGL_NO_CONTEXT};
+        #ifndef MAGNUM_TARGET_WEBGL
         Flags _flags;
         UnsignedInt _device;
         #endif

--- a/src/Magnum/Platform/WindowlessEglApplication.h
+++ b/src/Magnum/Platform/WindowlessEglApplication.h
@@ -255,10 +255,28 @@ class WindowlessEglContext::Configuration {
             _device = id;
             return *this;
         }
+        /**
+         * @brief Creates an OpenGL shared context with @param ctx instead
+         * of creating a brand new one.
+         */
+        Configuration& setSharedcontext(EGLContext ctx) {
+            _sharedContext = ctx;
+            return *this;
+        }
+        
+        /**
+         * @brief Returns the configuration shared context.
+         * If this has not been specified, (meaning the configuration uses a new opengl context), 
+         * then returns nullptr
+         */
+        EGLContext sharedContext() const {
+            return _sharedContext;
+        }       
         #endif
 
     private:
         #ifndef MAGNUM_TARGET_WEBGL
+        EGLContext _sharedContext{EGL_NO_CONTEXT};
         Flags _flags;
         UnsignedInt _device;
         #endif

--- a/src/Magnum/Platform/WindowlessGlxApplication.cpp
+++ b/src/Magnum/Platform/WindowlessGlxApplication.cpp
@@ -40,15 +40,6 @@ namespace Magnum { namespace Platform {
 WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configuration& configuration, GLContext* const magnumContext) {
     _display = XOpenDisplay(nullptr);
 
-    /**
-     * The user can choose to create a windowless application with a dedicated OpenGL context
-     * or give an OpenGL context to create a shared Context instead.
-     * 
-     * Here, we ask the configuration whether a context has been specified by the user 
-     * (!= nullptr) or not.
-     */
-    GLXContext ctx = configuration.sharedContext();
-    
     /* Check version */
     int major, minor;
     glXQueryVersion(_display, &major, &minor);
@@ -103,7 +94,7 @@ WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configura
         #endif
         0
     };
-    _context = glXCreateContextAttribsARB(_display, configs[0], ctx, True, contextAttributes);
+    _context = glXCreateContextAttribsARB(_display, configs[0], configuration.sharedContext(), True, contextAttributes);
 
     #ifndef MAGNUM_TARGET_GLES
     /* Fall back to (forward compatible) GL 2.1 if core context creation fails */
@@ -114,7 +105,7 @@ WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configura
             GLX_CONTEXT_FLAGS_ARB, GLint(flags),
             0
         };
-        _context = glXCreateContextAttribsARB(_display, configs[0], ctx, True, fallbackContextAttributes);
+        _context = glXCreateContextAttribsARB(_display, configs[0], configuration.sharedContext(), True, fallbackContextAttributes);
 
     /* Fall back to (forward compatible) GL 2.1 if we are on binary NVidia/AMD
        drivers on Linux. Instead of creating forward-compatible context with
@@ -151,7 +142,7 @@ WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configura
                 GLX_CONTEXT_FLAGS_ARB, GLint(flags & ~Configuration::Flag::ForwardCompatible),
                 0
             };
-            _context = glXCreateContextAttribsARB(_display, configs[0], ctx, True, fallbackContextAttributes);
+            _context = glXCreateContextAttribsARB(_display, configs[0], configuration.sharedContext(), True, fallbackContextAttributes);
         }
 
         /* Revert back the old context */

--- a/src/Magnum/Platform/WindowlessGlxApplication.cpp
+++ b/src/Magnum/Platform/WindowlessGlxApplication.cpp
@@ -40,6 +40,15 @@ namespace Magnum { namespace Platform {
 WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configuration& configuration, GLContext* const magnumContext) {
     _display = XOpenDisplay(nullptr);
 
+    /**
+     * The user can choose to create a windowless application with a dedicated OpenGL context
+     * or give an OpenGL context to create a shared Context instead.
+     * 
+     * Here, we ask the configuration whether a context has been specified by the user 
+     * (!= nullptr) or not.
+     */
+    GLXContext ctx = configuration.sharedContext();
+    
     /* Check version */
     int major, minor;
     glXQueryVersion(_display, &major, &minor);
@@ -94,7 +103,7 @@ WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configura
         #endif
         0
     };
-    _context = glXCreateContextAttribsARB(_display, configs[0], nullptr, True, contextAttributes);
+    _context = glXCreateContextAttribsARB(_display, configs[0], ctx, True, contextAttributes);
 
     #ifndef MAGNUM_TARGET_GLES
     /* Fall back to (forward compatible) GL 2.1 if core context creation fails */
@@ -105,7 +114,7 @@ WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configura
             GLX_CONTEXT_FLAGS_ARB, GLint(flags),
             0
         };
-        _context = glXCreateContextAttribsARB(_display, configs[0], nullptr, True, fallbackContextAttributes);
+        _context = glXCreateContextAttribsARB(_display, configs[0], ctx, True, fallbackContextAttributes);
 
     /* Fall back to (forward compatible) GL 2.1 if we are on binary NVidia/AMD
        drivers on Linux. Instead of creating forward-compatible context with
@@ -142,7 +151,7 @@ WindowlessGlxContext::WindowlessGlxContext(const WindowlessGlxContext::Configura
                 GLX_CONTEXT_FLAGS_ARB, GLint(flags & ~Configuration::Flag::ForwardCompatible),
                 0
             };
-            _context = glXCreateContextAttribsARB(_display, configs[0], nullptr, True, fallbackContextAttributes);
+            _context = glXCreateContextAttribsARB(_display, configs[0], ctx, True, fallbackContextAttributes);
         }
 
         /* Revert back the old context */

--- a/src/Magnum/Platform/WindowlessGlxApplication.h
+++ b/src/Magnum/Platform/WindowlessGlxApplication.h
@@ -238,8 +238,34 @@ class WindowlessGlxContext::Configuration {
             _flags &= ~flags;
             return *this;
         }
+        
+        /**
+         * @brief Creates an OpenGL shared context with @param ctx instead
+         * of creating a brand new one.
+         */
+        Configuration& setSharedcontext(GLXContext ctx) {
+            _sharedContext = ctx;
+            return *this;
+        }
+        
+        /**
+         * @brief Returns the configuration shared context.
+         * If this has not been specified, (meaning the configuration uses a new opengl context), 
+         * then returns nullptr
+         */
+        GLXContext sharedContext() const {
+            return _sharedContext;
+        }
 
     private:
+        /**
+         * If the @ref Configuration opengl context
+         * is shared with another context, then _sharedContext points to 
+         * this context.
+         * 
+         * Otherwise = nullptr;
+         */
+        GLXContext _sharedContext{nullptr};
         Flags _flags;
 };
 

--- a/src/Magnum/Platform/WindowlessGlxApplication.h
+++ b/src/Magnum/Platform/WindowlessGlxApplication.h
@@ -258,13 +258,7 @@ class WindowlessGlxContext::Configuration {
         }
 
     private:
-        /**
-         * If the @ref Configuration opengl context
-         * is shared with another context, then _sharedContext points to 
-         * this context.
-         * 
-         * Otherwise = nullptr;
-         */
+
         GLXContext _sharedContext{nullptr};
         Flags _flags;
 };

--- a/src/Magnum/Platform/WindowlessWglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessWglApplication.cpp
@@ -145,7 +145,7 @@ WindowlessWglContext::WindowlessWglContext(const Configuration& configuration, G
         #endif
         0
     };
-    _context = wglCreateContextAttribsARB(_deviceContext, nullptr, contextAttributes);
+    _context = wglCreateContextAttribsARB(_deviceContext, configuration.sharedContext(), contextAttributes);
 
     #ifndef MAGNUM_TARGET_GLES
     /* Fall back to (forward compatible) GL 2.1 if core context creation fails */
@@ -157,7 +157,7 @@ WindowlessWglContext::WindowlessWglContext(const Configuration& configuration, G
             WGL_CONTEXT_FLAGS_ARB, GLint(flags & ~Configuration::Flag::ForwardCompatible),
             0
         };
-        _context = wglCreateContextAttribsARB(_deviceContext, nullptr, fallbackContextAttributes);
+        _context = wglCreateContextAttribsARB(_deviceContext, configuration.sharedContext(), fallbackContextAttributes);
 
     /* Fall back to (forward compatible) GL 2.1 if we are on binary
        NVidia/AMD/Intel drivers on Windows. Instead of creating forward-compatible
@@ -196,7 +196,7 @@ WindowlessWglContext::WindowlessWglContext(const Configuration& configuration, G
                 WGL_CONTEXT_FLAGS_ARB, GLint(flags & ~Configuration::Flag::ForwardCompatible),
                 0
             };
-            _context = wglCreateContextAttribsARB(_deviceContext, nullptr, fallbackContextAttributes);
+            _context = wglCreateContextAttribsARB(_deviceContext, configuration.sharedContext(), fallbackContextAttributes);
         }
     }
     #endif

--- a/src/Magnum/Platform/WindowlessWglApplication.h
+++ b/src/Magnum/Platform/WindowlessWglApplication.h
@@ -232,9 +232,29 @@ class WindowlessWglContext::Configuration {
             _flags &= ~flags;
             return *this;
         }
+        
+                /**
+         * @brief Creates an OpenGL shared context with @param ctx instead
+         * of creating a brand new one.
+         */
+        Configuration& setSharedcontext(HGLRC ctx) {
+            _sharedContext = ctx;
+            return *this;
+        }
+        
+        /**
+         * @brief Returns the configuration shared context.
+         * If this has not been specified, (meaning the configuration uses a new opengl context), 
+         * then returns nullptr
+         */
+        HGLRC sharedContext() const {
+            return _sharedContext;
+        }
 
     private:
+        HGLRC _sharedContext;
         Flags _flags;
+        
 };
 
 CORRADE_ENUMSET_OPERATORS(WindowlessWglContext::Configuration::Flags)


### PR DESCRIPTION
Magnum provides boostrap classes to setup OpenGL context and windows (or not using  `WindowlessXXXXX`). These creates an OpenGL context from scratch.

Magnum provides also in-app multi-context support where several contexts can coexists (each 3D contexts beeing related to its magnum counterpart)

However in some application, we may need to have several coexisting OpenGL shared contexts. A potential use case is when we want to share datas between A and B (like a master-slave architecture) but we don't want to modify the state of the other (with the same context, binding a buffer in B will be bound for A and B).

Technical solutions proposed here is to add a `Configuration::setSharedContext(GLXContext ctx)` that will be passed to the platform dependent context creation function (here `glXCreateContextAttribsARB`).


This is a WIP since only WindowlessGLXApplication has been updated
