### PR TITLE
EGLDisplay non-terminating when mixing WindowlessEGL and sharedContexts

### DIFF
--- a/src/Magnum/Platform/WindowlessEglApplication.h
+++ b/src/Magnum/Platform/WindowlessEglApplication.h
@@ -132,6 +132,9 @@ class WindowlessEglContext {
         EGLContext glContext() { return _context; }
 
     private:
+        /* Stores whether the EGL context is shared or not */
+    	bool _sharedContext = false;
+    	
         EGLDisplay _display{};
         EGLContext _context{};
         #if defined(MAGNUM_TARGET_GLES) && !defined(MAGNUM_TARGET_WEBGL)

--- a/src/Magnum/Platform/WindowlessEglApplication.h
+++ b/src/Magnum/Platform/WindowlessEglApplication.h
@@ -276,16 +276,21 @@ class WindowlessEglContext::Configuration {
          * @m_since_latest
          *
          * When set, the created context will share a subset of OpenGL objects
-         * with @p context, instead of being independent. Many caveats and
+         * with @p context whose associated display is @p display, instead of being independent. 
+         * Many caveats and
          * limitations apply to shared OpenGL contexts, please consult the
          * OpenGL specification for details. Default is `EGL_NO_CONTEXT`, i.e.
          * no sharing.
+         *
+         * @note @p display must be provided to avoid errors on destruction, since 
+         * the display is shared among shared-context on EGL.
          * @see @ref WindowlessEglContext::glContext(),
          *      @ref WindowlessEglApplication::glContext()
          * @requires_gles Context sharing is not available in WebGL.
          */
-        Configuration& setSharedContext(EGLContext context) {
+        Configuration& setSharedContext(EGLContext context, EGLDisplay display) {
             _sharedContext = context;
+            _sharedDisplay = display;
             return *this;
         }
 
@@ -296,6 +301,14 @@ class WindowlessEglContext::Configuration {
          * @requires_gles Context sharing is not available in WebGL.
          */
         EGLContext sharedContext() const { return _sharedContext; }
+        
+        /**
+         * @brief Shared display
+         * @m_since_latest
+         *
+         * @requires_gles Context sharing is not available in WebGL.
+         */
+        EGLContext sharedDisplay() const { return _sharedDisplay; } 
         #endif
 
     private:
@@ -303,6 +316,7 @@ class WindowlessEglContext::Configuration {
         Flags _flags;
         UnsignedInt _device;
         EGLContext _sharedContext = EGL_NO_CONTEXT;
+        EGLDisplay _sharedDisplay = EGL_NO_DISPLAY;
         #endif
 };
 


### PR DESCRIPTION
When using `WindowlessEGLApplication` (context A) as main context with another WindowlessEGLApplication (context B) sharing context with A, everything runs fine until destroying B. In my case, recreating and destroying several time B in our testsuite crashes. 
Enabling debug output shows `eglMakeCurrent(): EGL_NOT_INITIALIZED error: In eglMakeCurrent: EGLDisplay (0x560efcf486c0) not intiialized` when trying to make current A's EGL context after destroying B.

My research shows that EGL has a specific way to handle the display variable: 
- When creating a GLXwindowless application, an associated display is created: https://github.com/mosra/magnum/blob/ec3e308c9be2fa3168954e5a6dc5ed87c0c70fbe/src/Magnum/Platform/WindowlessGlxApplication.cpp#L78. On destruction, it is destroyed : https://github.com/mosra/magnum/blob/ec3e308c9be2fa3168954e5a6dc5ed87c0c70fbe/src/Magnum/Platform/WindowlessGlxApplication.cpp#L243 . Eveyrhing is fine in this case
- When creating a EGLWindowless application, an associated display is created: https://github.com/mosra/magnum/blob/ec3e308c9be2fa3168954e5a6dc5ed87c0c70fbe/src/Magnum/Platform/WindowlessEglApplication.cpp#L153. However, from https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_base.txt, Multiple calls made to eglGetPlatformDisplayEXT with the same <platform> and <native_display> will return the same EGLDisplay handle.. This means A and B both shares the same display which is destroyed when destroying one of them: https://github.com/mosra/magnum/blob/ec3e308c9be2fa3168954e5a6dc5ed87c0c70fbe/src/Magnum/Platform/WindowlessEglApplication.cpp#L312. Afterwards, it is not possible to make the context of the other current because the EGLDisplay is terminated. Reinitializing the EGLDisplay with `eglInitialize` does not work also with `EGL_BAD_CONTEXT` error (internal state mismatche certainly) 

From my discussion with @mosra, the proposed solution is : 
 - Any `WindowlessEGLApplication` not sharing contexts with another `eglInitialize()` and will  `eglTerminate()` the display
  - Any `WindowlessEGLApplication` sharing context with another won't `eglTerminate()` the display. `eglInitialize` is not needed to be reworked since from the documentation, `initializing an already initialized EGLDisplay is a no-op`

However, to properly shutdown all contexts and related-datas (i.e `EGLDisplay`), we must first shutdown all the `WindowlessEGLApplications` sharing contexts, and finally the one (or another 3rd party EGL-context) who don't.

