### PR TITLE
Trade: Add (ambient|specular|diffuse|normal)CoordinateSet() properties to PhongMaterialData

### DIFF
--- a/src/Magnum/Trade/PhongMaterialData.cpp
+++ b/src/Magnum/Trade/PhongMaterialData.cpp
@@ -31,21 +31,33 @@ namespace Magnum { namespace Trade {
 
 using namespace Math::Literals;
 
-PhongMaterialData::PhongMaterialData(const Flags flags, const Color4& ambientColor, const UnsignedInt ambientTexture, const Color4& diffuseColor, const UnsignedInt diffuseTexture, const Color4& specularColor, const UnsignedInt specularTexture, const UnsignedInt normalTexture, const Matrix3& textureMatrix, const MaterialAlphaMode alphaMode, const Float alphaMask, const Float shininess, const void* const importerState) noexcept: AbstractMaterialData{MaterialType::Phong, AbstractMaterialData::Flag(UnsignedShort(flags)), alphaMode, alphaMask, importerState}, _ambientColor{ambientColor}, _diffuseColor{diffuseColor}, _specularColor{specularColor}, _shininess{shininess} {
+PhongMaterialData::PhongMaterialData(const Flags flags, const Color4& ambientColor, const UnsignedInt ambientTexture, const UnsignedInt ambientCoordinateSet, const Color4& diffuseColor, const UnsignedInt diffuseTexture, const UnsignedInt diffuseCoordinateSet, const Color4& specularColor, const UnsignedInt specularTexture, const UnsignedInt specularCoordinateSet, const UnsignedInt normalTexture, const UnsignedInt normalCoordinateSet, const Matrix3& textureMatrix, const MaterialAlphaMode alphaMode, const Float alphaMask, const Float shininess, const void* const importerState) noexcept: AbstractMaterialData{MaterialType::Phong, AbstractMaterialData::Flag(UnsignedShort(flags)), alphaMode, alphaMask, importerState}, _ambientColor{ambientColor}, _diffuseColor{diffuseColor}, _specularColor{specularColor}, _shininess{shininess} {
     CORRADE_ASSERT(!(flags & Flag::TextureTransformation) || (flags & (Flag::AmbientTexture|Flag::DiffuseTexture|Flag::SpecularTexture|Flag::NormalTexture)),
         "Trade::PhongMaterialData: texture transformation enabled but the material has no textures", );
+    CORRADE_ASSERT((flags & Flag::TextureCoordinateSets) || (ambientCoordinateSet == 0 && diffuseCoordinateSet == 0 && specularCoordinateSet == 0 && normalCoordinateSet == 0),
+        "PhongMaterialData::PhongMaterialData: non-zero texture coordinate sets require Flag::TextureCoordinateSets to be enabled", );
 
-    if(flags & Flag::AmbientTexture)
+    if(flags & Flag::AmbientTexture) {
         _ambientTexture = ambientTexture;
-    if(flags & Flag::DiffuseTexture)
+        _ambientCoordinateSet = ambientCoordinateSet;
+    }
+    if(flags & Flag::DiffuseTexture) {
         _diffuseTexture = diffuseTexture;
-    if(flags & Flag::SpecularTexture)
+        _diffuseCoordinateSet = diffuseCoordinateSet;
+    }
+    if(flags & Flag::SpecularTexture) {
         _specularTexture = specularTexture;
-    if(flags & Flag::NormalTexture)
+        _specularCoordinateSet = specularCoordinateSet;
+    }
+    if(flags & Flag::NormalTexture) {
         _normalTexture = normalTexture;
-    if(flags  & Flag::TextureTransformation)
+        _normalCoordinateSet = normalCoordinateSet;
+    }
+    if(flags & Flag::TextureTransformation)
         _textureMatrix = textureMatrix;
 }
+
+PhongMaterialData::PhongMaterialData(const Flags flags, const Color4& ambientColor, const UnsignedInt ambientTexture, const Color4& diffuseColor, const UnsignedInt diffuseTexture, const Color4& specularColor, const UnsignedInt specularTexture, const UnsignedInt normalTexture, const Matrix3& textureMatrix, const MaterialAlphaMode alphaMode, const Float alphaMask, const Float shininess, const void* const importerState) noexcept: PhongMaterialData{flags, ambientColor, ambientTexture, 0, diffuseColor, diffuseTexture, 0, specularColor, specularTexture, 0, normalTexture, 0, textureMatrix, alphaMode, alphaMask, shininess, importerState} {}
 
 #ifdef MAGNUM_BUILD_DEPRECATED
 PhongMaterialData::PhongMaterialData(const Flags flags, const MaterialAlphaMode alphaMode, const Float alphaMask, const Float shininess, const void* const importerState) noexcept: PhongMaterialData{flags, 0x000000ff_rgbaf, {}, 0xffffffff_rgbaf, {}, 0xffffffff_rgbaf, {}, {}, {}, alphaMode, alphaMask, shininess, importerState} {}
@@ -69,6 +81,11 @@ UnsignedInt& PhongMaterialData::ambientTexture() {
 }
 #endif
 
+UnsignedInt PhongMaterialData::ambientCoordinateSet() const {
+    CORRADE_ASSERT(flags() & Flag::AmbientTexture, "Trade::PhongMaterialData::ambientCoordinateSet(): the material doesn't have an ambient texture", {});
+    return _ambientCoordinateSet;
+}
+
 UnsignedInt PhongMaterialData::diffuseTexture() const {
     CORRADE_ASSERT(flags() & Flag::DiffuseTexture, "Trade::PhongMaterialData::diffuseTexture(): the material doesn't have a diffuse texture", {});
     return _diffuseTexture;
@@ -80,6 +97,11 @@ UnsignedInt& PhongMaterialData::diffuseTexture() {
     return _diffuseTexture;
 }
 #endif
+
+UnsignedInt PhongMaterialData::diffuseCoordinateSet() const {
+    CORRADE_ASSERT(flags() & Flag::DiffuseTexture, "Trade::PhongMaterialData::diffuseCoordinateSet(): the material doesn't have a diffuse texture", {});
+    return _diffuseCoordinateSet;
+}
 
 UnsignedInt PhongMaterialData::specularTexture() const {
     CORRADE_ASSERT(flags() & Flag::SpecularTexture, "Trade::PhongMaterialData::specularTexture(): the material doesn't have a specular texture", {});
@@ -93,9 +115,19 @@ UnsignedInt& PhongMaterialData::specularTexture() {
 }
 #endif
 
+UnsignedInt PhongMaterialData::specularCoordinateSet() const {
+    CORRADE_ASSERT(flags() & Flag::SpecularTexture, "Trade::PhongMaterialData::specularCoordinateSet(): the material doesn't have a specular texture", {});
+    return _specularCoordinateSet;
+}
+
 UnsignedInt PhongMaterialData::normalTexture() const {
     CORRADE_ASSERT(flags() & Flag::NormalTexture, "Trade::PhongMaterialData::normalTexture(): the material doesn't have a normal texture", {});
     return _normalTexture;
+}
+
+UnsignedInt PhongMaterialData::normalCoordinateSet() const {
+    CORRADE_ASSERT(flags() & Flag::NormalTexture, "Trade::PhongMaterialData::normalCoordinateSet(): the material doesn't have a normal texture", {});
+    return _normalCoordinateSet;
 }
 
 Debug& operator<<(Debug& debug, const PhongMaterialData::Flag value) {
@@ -110,6 +142,7 @@ Debug& operator<<(Debug& debug, const PhongMaterialData::Flag value) {
         _c(SpecularTexture)
         _c(NormalTexture)
         _c(TextureTransformation)
+        _c(TextureCoordinateSets)
         #undef _c
         /* LCOV_EXCL_STOP */
     }
@@ -124,7 +157,8 @@ Debug& operator<<(Debug& debug, const PhongMaterialData::Flags value) {
         PhongMaterialData::Flag::DiffuseTexture,
         PhongMaterialData::Flag::SpecularTexture,
         PhongMaterialData::Flag::NormalTexture,
-        PhongMaterialData::Flag::TextureTransformation});
+        PhongMaterialData::Flag::TextureTransformation,
+        PhongMaterialData::Flag::TextureCoordinateSets});
 }
 
 }}

--- a/src/Magnum/Trade/PhongMaterialData.h
+++ b/src/Magnum/Trade/PhongMaterialData.h
@@ -43,13 +43,6 @@ namespace Magnum { namespace Trade {
 */
 class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
     public:
-        /** @todo what is this for?! */
-        enum: UnsignedInt {
-            AmbientTextureID = 0,   /**< Ambient texture ID for mapping with texture coordinates */
-            DiffuseTextureID = 1,   /**< Diffuse texture ID for mapping with texture coordinates */
-            SpecularTextureID = 3   /**< Specular texture ID for mapping with texture coordinates */
-        };
-
         /**
          * @brief Material flag
          *
@@ -79,7 +72,13 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
              * The material has a texture coordinate transformation
              * @m_since_latest
              */
-            TextureTransformation = 1 << 5
+            TextureTransformation = 1 << 5,
+
+            /**
+             * The material uses non-default texture coordinate sets
+             * @m_since_latest
+             */
+            TextureCoordinateSets = 1 << 6
         };
 
         /**
@@ -123,6 +122,54 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
          * @m_since_latest
          */
         explicit PhongMaterialData(Flags flags, const Color4& ambientColor, UnsignedInt ambientTexture, const Color4& diffuseColor, UnsignedInt diffuseTexture, const Color4& specularColor, UnsignedInt specularTexture, UnsignedInt normalTexture, const Matrix3& textureMatrix, MaterialAlphaMode alphaMode, Float alphaMask, Float shininess, const void* importerState = nullptr) noexcept;
+
+        /**
+         * @brief Construct with non-zero texture coordinate sets
+         * @param flags                 Material flags
+         * @param ambientColor          Ambient color. Use
+         *      @cpp 0x000000ff_rgbaf @ce for a default value for a
+         *      non-textured material and @cpp 0xffffffff_rgbaf @ce for a
+         *      default value for a textured material.
+         * @param ambientTexture        Ambient texture ID. Ignored if @p flags
+         *      doesn't have @ref Flag::AmbientTexture
+         * @param ambientCoordinateSet  Ambient texture coordinate set. Ignored if
+         *      @p flags doesn't have @ref Flag::AmbientTexture
+         * @param diffuseColor          Diffuse color. Use
+         *      @cpp 0xffffffff_rgbaf @ce for a default value for both a
+         *      non-textured and a textured material.
+         * @param diffuseTexture        Diffuse texture ID. Ignored if @p flags
+         *      doesn't have @ref Flag::DiffuseTexture
+         * @param diffuseCoordinateSet  Diffuse texture coordinate set. Ignored if
+         *      @p flags doesn't have @ref Flag::DiffuseTexture
+         * @param specularColor         Specular color. Use
+         *      @cpp 0xffffffff_rgbaf @ce for a default value for both a
+         *      non-textured and a textured material.
+         * @param specularTexture       Specular texture ID. Ignored if @p flags
+         *      doesn't have @ref Flag::SpecularTexture.
+         * @param specularCoordinateSet Specular texture coordinate set. Ignored if
+         *      @p flags doesn't have @ref Flag::SpecularTexture.
+         * @param normalTexture         Normal texture ID. Ignored if @p flags
+         *      doesn't have @ref Flag::NormalTexture.
+         * @param normalCoordinateSet   Normal texture coordinate set. Ignored if
+         *      @p flags doesn't have @ref Flag::NormalTexture.
+         * @param textureMatrix         Texture coordinate transformation. Ignored
+         *      if @p flags doesn't have @ref Flag::TextureTransformation.
+         * @param alphaMode             Alpha mode. Use
+         *      @ref MaterialAlphaMode::Opaque for a default value.
+         * @param alphaMask             Alpha mask value. Use @cpp 0.5f @ce for a
+         *      default value.
+         * @param shininess             Shininess. Use @cpp 80.0f @ce for a default
+         *      value.
+         * @param importerState         Importer-specific state
+         * @m_since_latest
+         *
+         * If any `*CoordinateSet` is non-zero, expects
+         * @ref Flag::TextureCoordinateSets to be enabled as well.
+         *
+         * If any `*CoordinateSet` is non-zero, expects
+         * @ref Flag::TextureCoordinateSets to be enabled as well.
+         */
+        explicit PhongMaterialData(Flags flags, const Color4& ambientColor, UnsignedInt ambientTexture, UnsignedInt ambientCoordinateSet, const Color4& diffuseColor, UnsignedInt diffuseTexture, UnsignedInt diffuseCoordinateSet, const Color4& specularColor, UnsignedInt specularTexture, UnsignedInt specularCoordinateSet, UnsignedInt normalTexture, UnsignedInt normalCoordinateSet, const Matrix3& textureMatrix, MaterialAlphaMode alphaMode, Float alphaMask, Float shininess, const void* importerState = nullptr) noexcept;
 
         #ifdef MAGNUM_BUILD_DEPRECATED
         /**
@@ -201,6 +248,15 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
         #endif
 
         /**
+         * @brief Ambient texture coordinate set
+         * @m_since_latest
+         *
+         * Available only if the material has @ref Flag::AmbientTexture.
+         * @see @ref flags(), @ref AbstractImporter::texture()
+         */
+        UnsignedInt ambientCoordinateSet() const;
+
+        /**
          * @brief Diffuse color
          *
          * If the material has @ref Flag::DiffuseTexture, the color and texture
@@ -235,6 +291,15 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
         /* Not using CORRADE_DEPRECATED(), see why above */
         UnsignedInt& diffuseTexture();
         #endif
+
+        /**
+         * @brief Diffuse texture coordinate set
+         * @m_since_latest
+         *
+         * Available only if the material has @ref Flag::DiffuseTexture.
+         * @see @ref flags(), @ref AbstractImporter::texture()
+         */
+        UnsignedInt diffuseCoordinateSet() const;
 
         /**
          * @brief Specular color
@@ -273,6 +338,15 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
         #endif
 
         /**
+         * @brief Specular texture coordinate set
+         * @m_since_latest
+         *
+         * Available only if the material has @ref Flag::SpecularTexture.
+         * @see @ref flags(), @ref AbstractImporter::texture()
+         */
+        UnsignedInt specularCoordinateSet() const;
+
+        /**
          * @brief Normal texture ID
          * @m_since_latest
          *
@@ -280,6 +354,15 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
          * @see @ref flags(), @ref AbstractImporter::texture()
          */
         UnsignedInt normalTexture() const;
+
+        /**
+         * @brief Normal texture coordinate set
+         * @m_since_latest
+         *
+         * Available only if the material has @ref Flag::NormalTexture.
+         * @see @ref flags(), @ref AbstractImporter::texture()
+         */
+        UnsignedInt normalCoordinateSet() const;
 
         /**
          * @brief Texture coordinate transformation matrix
@@ -299,11 +382,15 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
            and thus better noticeable */
         Color4 _ambientColor;
         UnsignedInt _ambientTexture{~UnsignedInt{}};
+        UnsignedInt _ambientCoordinateSet;
         Color4 _diffuseColor;
         UnsignedInt _diffuseTexture{~UnsignedInt{}};
+        UnsignedInt _diffuseCoordinateSet;
         Color4 _specularColor;
         UnsignedInt _specularTexture{~UnsignedInt{}};
+        UnsignedInt _specularCoordinateSet;
         UnsignedInt _normalTexture{~UnsignedInt{}};
+        UnsignedInt _normalCoordinateSet;
         Matrix3 _textureMatrix;
         Float _shininess;
 };

--- a/src/Magnum/Trade/PhongMaterialData.h
+++ b/src/Magnum/Trade/PhongMaterialData.h
@@ -163,6 +163,9 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
          * @param importerState         Importer-specific state
          * @m_since_latest
          *
+         * If any `*CoordinateSet` is non-zero, expects 
+         * @ref Flag::TextureCoordinateSets to be enabled as well.
+         *
          * If any `*CoordinateSet` is non-zero, expects
          * @ref Flag::TextureCoordinateSets to be enabled as well.
          *

--- a/src/Magnum/Trade/PhongMaterialData.h
+++ b/src/Magnum/Trade/PhongMaterialData.h
@@ -120,6 +120,8 @@ class MAGNUM_TRADE_EXPORT PhongMaterialData: public AbstractMaterialData {
          *      value.
          * @param importerState     Importer-specific state
          * @m_since_latest
+         *
+         * All `*CoordinateSet`s are implicitly set to @cpp 0 @ce.
          */
         explicit PhongMaterialData(Flags flags, const Color4& ambientColor, UnsignedInt ambientTexture, const Color4& diffuseColor, UnsignedInt diffuseTexture, const Color4& specularColor, UnsignedInt specularTexture, UnsignedInt normalTexture, const Matrix3& textureMatrix, MaterialAlphaMode alphaMode, Float alphaMask, Float shininess, const void* importerState = nullptr) noexcept;
 

--- a/src/Magnum/Trade/Test/MaterialDataTest.cpp
+++ b/src/Magnum/Trade/Test/MaterialDataTest.cpp
@@ -38,7 +38,9 @@ class MaterialDataTest: public TestSuite::Tester {
         void constructPhong();
         void constructPhongTextured();
         void constructPhongTexturedTextureTransform();
+        void constructPhongTexturedCoordinateSets();
         void constructPhongTextureTransformNoTextures();
+        void constructPhongNoTextureCoordinateSets();
         void constructCopy();
         void constructMovePhong();
 
@@ -57,7 +59,9 @@ MaterialDataTest::MaterialDataTest() {
     addTests({&MaterialDataTest::constructPhong,
               &MaterialDataTest::constructPhongTextured,
               &MaterialDataTest::constructPhongTexturedTextureTransform,
+              &MaterialDataTest::constructPhongTexturedCoordinateSets,
               &MaterialDataTest::constructPhongTextureTransformNoTextures,
+              &MaterialDataTest::constructPhongNoTextureCoordinateSets,
               &MaterialDataTest::constructCopy,
               &MaterialDataTest::constructMovePhong,
 
@@ -113,9 +117,11 @@ void MaterialDataTest::constructPhongTextured() {
     CORRADE_COMPARE(cdata.flags(), PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::SpecularTexture);
     CORRADE_COMPARE(cdata.ambientColor(), 0x111111_rgbf);
     CORRADE_COMPARE(cdata.ambientTexture(), 42);
+    CORRADE_COMPARE(cdata.ambientCoordinateSet(), 0);
     CORRADE_COMPARE(cdata.diffuseColor(), 0xeebbff_rgbf);
     CORRADE_COMPARE(cdata.specularColor(), 0xacabad_rgbf);
     CORRADE_COMPARE(cdata.specularTexture(), 17);
+    CORRADE_COMPARE(cdata.specularCoordinateSet(), 0);
     CORRADE_COMPARE(cdata.textureMatrix(), Matrix3{});
     CORRADE_COMPARE(cdata.alphaMode(), MaterialAlphaMode::Blend);
     CORRADE_COMPARE(cdata.alphaMask(), 0.37f);
@@ -151,6 +157,37 @@ void MaterialDataTest::constructPhongTexturedTextureTransform() {
     CORRADE_COMPARE(cdata.importerState(), &a);
 }
 
+void MaterialDataTest::constructPhongTexturedCoordinateSets() {
+    using namespace Math::Literals;
+
+    const int a{};
+    PhongMaterialData data{
+        PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::TextureCoordinateSets,
+        0x111111_rgbf, 42, 3,
+        0xeebbff_rgbf, {}, 0,
+        0xacabad_rgbf, 17, 1,
+        {}, 0, {},
+        MaterialAlphaMode::Blend, 0.37f, 96.0f, &a};
+
+    /** @todo use data directly once deprecated mutable access is gone */
+    const PhongMaterialData& cdata = data;
+    CORRADE_COMPARE(cdata.type(), MaterialType::Phong);
+    CORRADE_COMPARE(cdata.flags(), PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::TextureCoordinateSets);
+    CORRADE_COMPARE(cdata.ambientColor(), 0x111111_rgbf);
+    CORRADE_COMPARE(cdata.ambientTexture(), 42);
+    CORRADE_COMPARE(cdata.ambientCoordinateSet(), 3);
+    CORRADE_COMPARE(cdata.diffuseColor(), 0xeebbff_rgbf);
+    CORRADE_COMPARE(cdata.specularColor(), 0xacabad_rgbf);
+    CORRADE_COMPARE(cdata.specularTexture(), 17);
+    CORRADE_COMPARE(cdata.specularCoordinateSet(), 1);
+    CORRADE_COMPARE(cdata.textureMatrix(), Matrix3{});
+    CORRADE_COMPARE(cdata.alphaMode(), MaterialAlphaMode::Blend);
+    CORRADE_COMPARE(cdata.alphaMask(), 0.37f);
+    CORRADE_COMPARE(cdata.shininess(), 96.0f);
+    CORRADE_COMPARE(cdata.importerState(), &a);
+}
+
+
 void MaterialDataTest::constructPhongTextureTransformNoTextures() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
@@ -167,6 +204,22 @@ void MaterialDataTest::constructPhongTextureTransformNoTextures() {
         "Trade::PhongMaterialData: texture transformation enabled but the material has no textures\n");
 }
 
+void MaterialDataTest::constructPhongNoTextureCoordinateSets() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    PhongMaterialData a{{},
+        {}, {}, 1,
+        {}, {}, 2,
+        {}, {}, 3, {}, 4, {},
+        {}, 0.5f, 80.0f};
+    CORRADE_COMPARE(out.str(),
+        "PhongMaterialData::PhongMaterialData: non-zero texture coordinate sets require Flag::TextureCoordinateSets to be enabled\n");
+}
+
 void MaterialDataTest::constructCopy() {
     CORRADE_VERIFY(!(std::is_constructible<AbstractMaterialData, const AbstractMaterialData&>{}));
     CORRADE_VERIFY(!(std::is_constructible<PhongMaterialData, const PhongMaterialData&>{}));
@@ -179,23 +232,27 @@ void MaterialDataTest::constructMovePhong() {
 
     const int a{};
     PhongMaterialData data{
-        PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::DiffuseTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::NormalTexture|PhongMaterialData::Flag::TextureTransformation,
-        0x111111_rgbf, 1,
-        0xeebbff_rgbf, 42,
-        0xacabad_rgbf, 24, 17,
+        PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::DiffuseTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::NormalTexture|PhongMaterialData::Flag::TextureTransformation|PhongMaterialData::Flag::TextureCoordinateSets,
+        0x111111_rgbf, 1, 0,
+        0xeebbff_rgbf, 42, 1,
+        0xacabad_rgbf, 24, 2, 17, 3,
         Matrix3::rotation(90.0_degf),
         MaterialAlphaMode::Blend, 0.55f, 13.0f, &a};
 
     PhongMaterialData b{std::move(data)};
     CORRADE_COMPARE(b.type(), MaterialType::Phong);
-    CORRADE_COMPARE(b.flags(), PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::DiffuseTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::NormalTexture|PhongMaterialData::Flag::TextureTransformation);
+    CORRADE_COMPARE(b.flags(), PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::DiffuseTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::NormalTexture|PhongMaterialData::Flag::TextureTransformation|PhongMaterialData::Flag::TextureCoordinateSets);
     CORRADE_COMPARE(b.ambientColor(), 0x111111_rgbf);
     CORRADE_COMPARE(b.ambientTexture(), 1);
+    CORRADE_COMPARE(b.ambientCoordinateSet(), 0);
     CORRADE_COMPARE(b.diffuseColor(), 0xeebbff_rgbf);
     CORRADE_COMPARE(b.diffuseTexture(), 42);
+    CORRADE_COMPARE(b.diffuseCoordinateSet(), 1);
     CORRADE_COMPARE(b.specularColor(), 0xacabad_rgbf);
     CORRADE_COMPARE(b.specularTexture(), 24);
+    CORRADE_COMPARE(b.specularCoordinateSet(), 2);
     CORRADE_COMPARE(b.normalTexture(), 17);
+    CORRADE_COMPARE(b.normalCoordinateSet(), 3);
     CORRADE_COMPARE(b.textureMatrix(), Matrix3::rotation(90.0_degf));
     CORRADE_COMPARE(b.alphaMode(), MaterialAlphaMode::Blend);
     CORRADE_COMPARE(b.alphaMask(), 0.55f);
@@ -211,14 +268,18 @@ void MaterialDataTest::constructMovePhong() {
     d = std::move(b);
 
     CORRADE_COMPARE(d.type(), MaterialType::Phong);
-    CORRADE_COMPARE(d.flags(), PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::DiffuseTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::NormalTexture|PhongMaterialData::Flag::TextureTransformation);
+    CORRADE_COMPARE(d.flags(), PhongMaterialData::Flag::AmbientTexture|PhongMaterialData::Flag::DiffuseTexture|PhongMaterialData::Flag::SpecularTexture|PhongMaterialData::Flag::NormalTexture|PhongMaterialData::Flag::TextureTransformation|PhongMaterialData::Flag::TextureCoordinateSets);
     CORRADE_COMPARE(d.ambientColor(), 0x111111_rgbf);
     CORRADE_COMPARE(d.ambientTexture(), 1);
+    CORRADE_COMPARE(d.ambientCoordinateSet(), 0);
     CORRADE_COMPARE(d.diffuseColor(), 0xeebbff_rgbf);
     CORRADE_COMPARE(d.diffuseTexture(), 42);
+    CORRADE_COMPARE(d.diffuseCoordinateSet(), 1);
     CORRADE_COMPARE(d.specularColor(), 0xacabad_rgbf);
     CORRADE_COMPARE(d.specularTexture(), 24);
+    CORRADE_COMPARE(d.specularCoordinateSet(), 2);
     CORRADE_COMPARE(d.normalTexture(), 17);
+    CORRADE_COMPARE(d.normalCoordinateSet(), 3);
     CORRADE_COMPARE(d.textureMatrix(), Matrix3::rotation(90.0_degf));
     CORRADE_COMPARE(d.alphaMode(), MaterialAlphaMode::Blend);
     CORRADE_COMPARE(d.alphaMask(), 0.55f);
@@ -243,14 +304,22 @@ void MaterialDataTest::accessInvalidTextures() {
     std::ostringstream out;
     Error redirectError{&out};
     a.ambientTexture();
+    a.ambientCoordinateSet();
     a.diffuseTexture();
+    a.diffuseCoordinateSet();
     a.specularTexture();
+    a.specularCoordinateSet();
     a.normalTexture();
+    a.normalCoordinateSet();
     CORRADE_COMPARE(out.str(),
         "Trade::PhongMaterialData::ambientTexture(): the material doesn't have an ambient texture\n"
+        "Trade::PhongMaterialData::ambientCoordinateSet(): the material doesn't have an ambient texture\n"
         "Trade::PhongMaterialData::diffuseTexture(): the material doesn't have a diffuse texture\n"
+        "Trade::PhongMaterialData::diffuseCoordinateSet(): the material doesn't have a diffuse texture\n"
         "Trade::PhongMaterialData::specularTexture(): the material doesn't have a specular texture\n"
-        "Trade::PhongMaterialData::normalTexture(): the material doesn't have a normal texture\n");
+        "Trade::PhongMaterialData::specularCoordinateSet(): the material doesn't have a specular texture\n"
+        "Trade::PhongMaterialData::normalTexture(): the material doesn't have a normal texture\n"
+        "Trade::PhongMaterialData::normalCoordinateSet(): the material doesn't have a normal texture\n");
 }
 
 void MaterialDataTest::debugType() {


### PR DESCRIPTION
Hi @mosra !

As promised, here's the PR for the texture layer property for material data.
PR for TinyGltf incoming! :)

Cheers,
Jonathan