### PR TITLE
Avoid using 100% CPU in an idle GlfwApplication

### DIFF
--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -505,6 +505,8 @@ See also:
     class construction, potentially causing crashes or
     `pure virtual method call` aborts. To prevent these issues, event callback
     setup is delayed to the first time the application main loop is entered.
+-   @ref Platform::GlfwApplication was polling for events instead of waiting,
+    using 100% CPU even if not constantly redrawing
 -   In 2019.01 @ref Magnum/Platform/Sdl2Application.h went through an include
     cleanup, removing 50k lines; but unfortunately we forgot to add back
     @cpp #include <SDL_main.h> @ce, causing iOS builds to fail to initialize.

--- a/src/Magnum/Platform/GlfwApplication.cpp
+++ b/src/Magnum/Platform/GlfwApplication.cpp
@@ -741,11 +741,14 @@ bool GlfwApplication::mainLoopIteration() {
     */
     if(glfwGetWindowUserPointer(_window) != this) setupCallbacks();
 
+    /* If redrawing, poll for events immediately after drawEvent() (which could
+       be setting the Redraw flag again, thus doing constant redraw). If not,
+       avoid spinning the CPU by waiting for the next input event. */
     if(_flags & Flag::Redraw) {
         _flags &= ~Flag::Redraw;
         drawEvent();
-    }
-    glfwPollEvents();
+        glfwPollEvents();
+    } else glfwWaitEvents();
 
     return !glfwWindowShouldClose(_window);
 }


### PR DESCRIPTION
Interestingly enough this went unnoticed since the very first implementation in 2016.

While I'm pretty sure this works, I'm not sure about possible bad interactions, so I'll merge to master only after I have enough confirmations that this still works as expected. Testers welcome, thanks in advance :+1: 

Cc: @Squareys 