### PR TITLE
Math: add fmod function

### DIFF
--- a/src/Magnum/Math/Functions.h
+++ b/src/Magnum/Math/Functions.h
@@ -409,6 +409,32 @@ template<std::size_t size, class T> inline Vector<size, T> ceil(const Vector<siz
 }
 
 /**
+@brief Floating point division remainder
+@param a     Numerator
+@param b     Denumerator
+
+Calculates the remainder @f$ r @f$ of a floating point division: @f[
+    r = a - b * \operatorname{trunc}(a/b)
+@f]
+
+@attention This function differs from the GLSL `mod` function when @f$ a/b @f$ is negative.
+The return value has the same sign as the numerator, whereas `mod` keeps the denumerator's sign.
+
+@m_keyword{mod(),GLSL mod(),}
+*/
+template<class T> inline typename std::enable_if<IsScalar<T>::value, T>::type fmod(T a, T b) {
+    return T(std::fmod(UnderlyingTypeOf<T>(a), UnderlyingTypeOf<T>(b)));
+}
+
+/** @overload */
+template<std::size_t size, class T> inline Vector<size, T> fmod(const Vector<size, T>& a, const Vector<size, T>& b) {
+    Vector<size, T> out{Magnum::NoInit};
+    for(std::size_t i = 0; i != size; ++i)
+        out[i] = Math::fmod(a[i], b[i]);
+    return out;
+}
+
+/**
 @brief Linear interpolation of two values
 @param a     First value
 @param b     Second value

--- a/src/Magnum/Math/Test/FunctionsTest.cpp
+++ b/src/Magnum/Math/Test/FunctionsTest.cpp
@@ -51,6 +51,7 @@ struct FunctionsTest: Corrade::TestSuite::Tester {
     void floor();
     void round();
     void ceil();
+    void fmod();
 
     void sqrt();
     void sqrtInverted();
@@ -112,6 +113,7 @@ FunctionsTest::FunctionsTest() {
               &FunctionsTest::floor,
               &FunctionsTest::round,
               &FunctionsTest::ceil,
+              &FunctionsTest::fmod,
 
               &FunctionsTest::sqrt,
               &FunctionsTest::sqrtInverted,
@@ -289,6 +291,14 @@ void FunctionsTest::ceil() {
 
     /* Wrapped types */
     CORRADE_COMPARE(Math::ceil(2.7_degf), 3.0_degf);
+}
+
+void FunctionsTest::fmod() {
+    CORRADE_COMPARE(Math::fmod(5.1f, 3.0f), 2.1f);
+    CORRADE_COMPARE(Math::fmod(Vector3(5.1f, -5.1f, 6.8f), Vector3(3.0f, 3.0f, 1.1f)), Vector3(2.1f, -2.1f, 0.2f));
+
+    /* Wrapped types */
+    CORRADE_COMPARE(Math::fmod(2.7_degf, 1.3_degf), 0.1_degf);
 }
 
 void FunctionsTest::sqrt() {


### PR DESCRIPTION
This adds `Math::fmod()` to calculate a floating point division remainder for scalar and vector Math types by wrapping `std::fmod`.

Not entirely sure about the docs portion and especially the Latex (is `\operatorname` supported?).