### PR TITLE
Fix: can not create gl context with GLFW3 + ANGLE on Windows

### DIFF
--- a/src/Magnum/Platform/GlfwApplication.cpp
+++ b/src/Magnum/Platform/GlfwApplication.cpp
@@ -451,6 +451,7 @@ bool GlfwApplication::tryCreate(const Configuration& configuration, const GLConf
         }
         #else
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
         #endif
 
     /* Request usable version otherwise */
@@ -475,6 +476,7 @@ bool GlfwApplication::tryCreate(const Configuration& configuration, const GLConf
         #endif
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
         #endif
     }
 

--- a/src/Magnum/Platform/GlfwApplication.cpp
+++ b/src/Magnum/Platform/GlfwApplication.cpp
@@ -451,7 +451,9 @@ bool GlfwApplication::tryCreate(const Configuration& configuration, const GLConf
         }
         #else
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+        #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_DESKTOP_GLES)
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+        #endif
         #endif
 
     /* Request usable version otherwise */
@@ -476,7 +478,9 @@ bool GlfwApplication::tryCreate(const Configuration& configuration, const GLConf
         #endif
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+        #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_DESKTOP_GLES)
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+        #endif
         #endif
     }
 


### PR DESCRIPTION
EGL Context can not be created correctly without `glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);`:
```
GL::Context: unsupported OpenGL ES version (0, 0)
```

Have tested on Win64 and passed.