### PR TITLE
Math: Add DualQuaternion::from(rotation, translation)

### DIFF
--- a/src/Magnum/Math/DualComplex.h
+++ b/src/Magnum/Math/DualComplex.h
@@ -107,6 +107,22 @@ template<class T> class DualComplex: public Dual<Complex<T>> {
         }
 
         /**
+         * @brief Create dual complext from rotation complex and translation vector
+         *
+         * @f[
+         *      \hat c = r + \epsilon (r(v_x + iv_y))
+         * @f]
+         *
+         * @see @ref translation(), @ref rotation()
+         *      @ref Matrix3::from(const Matrix2x2<T>&, const Vector2<T>&),
+         *      @ref Matrix4::from(const Matrix3x3<T>&, const Vector3<T>&),
+         *      @ref DualQuaternion::from(const Quaternion<T>&, const Vector3<T>&)
+         */
+        static DualComplex<T> from(const Complex<T>& rotation, const Vector2<T>& translation) {
+            return DualComplex<T>::translation(translation)*DualComplex<T>(rotation, {{}, {}});
+        }
+
+        /**
          * @brief Default constructor
          *
          * Equivalent to @ref DualComplex(IdentityInitT).

--- a/src/Magnum/Math/DualQuaternion.h
+++ b/src/Magnum/Math/DualQuaternion.h
@@ -247,6 +247,22 @@ template<class T> class DualQuaternion: public Dual<Quaternion<T>> {
         }
 
         /**
+         * @brief Create dual quaternion from rotation quaternion and translation vector
+         *
+         * @f[
+         *      \hat q = r + \epsilon (r[\frac{\boldsymbol t}{2}, 0])
+         * @f]
+         *
+         * @see @ref translation(), @ref rotation(),
+         *      @ref Matrix3::from(const Matrix2x2<T>&, const Vector2<T>&),
+         *      @ref Matrix4::from(const Matrix3x3<T>&, const Vector3<T>&),
+         *      @ref DualComplex::from(const Complex<T>&, const Vector2<T>&)
+         */
+        static DualQuaternion<T> from(const Quaternion<T>& rotation, const Vector3<T>& translation) {
+            return {rotation, Quaternion<T>(translation/T(2))*rotation};
+        }
+
+        /**
          * @brief Default constructor
          *
          * Equivalent to @ref DualQuaternion(IdentityInitT).

--- a/src/Magnum/Math/Matrix3.h
+++ b/src/Magnum/Math/Matrix3.h
@@ -188,7 +188,10 @@ template<class T> class Matrix3: public Matrix3x3<T> {
          * @param translation       Translation part (first two elements of
          *      third column)
          *
-         * @see @ref rotationScaling(), @ref translation() const
+         * @see @ref rotationScaling(), @ref translation() const,
+         *      @ref Matrix4::from(const Matrix3x3<T>&, const Vector3<T>&),
+         *      @ref DualComplex::from(const Complex<T>&, const Vector2<T>&),
+         *      @ref DualQuaternion::from(const Quaternion<T>&, const Vector3<T>&)
          */
         constexpr static Matrix3<T> from(const Matrix2x2<T>& rotationScaling, const Vector2<T>& translation) {
             return {{rotationScaling[0], T(0)},

--- a/src/Magnum/Math/Matrix4.h
+++ b/src/Magnum/Math/Matrix4.h
@@ -421,7 +421,10 @@ template<class T> class Matrix4: public Matrix4x4<T> {
          * @param translation       Translation part (first three elements of
          *      fourth column)
          *
-         * @see @ref rotationScaling(), @ref translation() const
+         * @see @ref rotationScaling(), @ref translation() const,
+         *      @ref Matrix3::from(const Matrix2x2<T>&, const Vector2<T>&),
+         *      @ref DualComplex::from(const Complex<T>&, const Vector2<T>&),
+         *      @ref DualQuaternion::from(const Quaternion<T>&, const Vector3<T>&)
          */
         constexpr static Matrix4<T> from(const Matrix3x3<T>& rotationScaling, const Vector3<T>& translation) {
             return {{rotationScaling[0], T(0)},

--- a/src/Magnum/Math/Test/DualComplexTest.cpp
+++ b/src/Magnum/Math/Test/DualComplexTest.cpp
@@ -87,6 +87,7 @@ struct DualComplexTest: Corrade::TestSuite::Tester {
 
     void rotation();
     void translation();
+    void rotationTranslation();
     void combinedTransformParts();
     void matrix();
     void matrixNotOrthogonal();
@@ -145,6 +146,7 @@ DualComplexTest::DualComplexTest() {
 
               &DualComplexTest::rotation,
               &DualComplexTest::translation,
+              &DualComplexTest::rotationTranslation,
               &DualComplexTest::combinedTransformParts,
               &DualComplexTest::matrix,
               &DualComplexTest::matrixNotOrthogonal,
@@ -413,6 +415,17 @@ void DualComplexTest::translation() {
     CORRADE_COMPARE(a, DualComplex({}, {1.5f, -3.5f}));
     CORRADE_COMPARE(a.translation(), vec);
 }
+
+void DualComplexTest::rotationTranslation() {
+    const Complex r = Complex::rotation(120.0_degf);
+
+    const Vector2 vec(1.0f, -3.5f);
+    const DualComplex t = DualComplex::translation(vec);
+
+    const DualComplex rt = t*DualComplex{r};
+    CORRADE_COMPARE(DualComplex::from(r, vec), rt);
+}
+
 
 void DualComplexTest::combinedTransformParts() {
     Vector2 translation = Vector2(-1.5f, 2.75f);

--- a/src/Magnum/Math/Test/DualComplexTest.cpp
+++ b/src/Magnum/Math/Test/DualComplexTest.cpp
@@ -283,7 +283,7 @@ void DualComplexTest::data() {
 
 void DualComplexTest::isNormalized() {
     CORRADE_VERIFY(!DualComplex({2.0f, 1.0f}, {}).isNormalized());
-    CORRADE_VERIFY((DualComplex::rotation(Deg(23.0f))*DualComplex::translation({6.0f, 3.0f})).isNormalized());
+    CORRADE_VERIFY((DualComplex::rotation(23.0_degf)*DualComplex::translation({6.0f, 3.0f})).isNormalized());
 }
 
 template<class T> void DualComplexTest::isNormalizedEpsilonRotation() {
@@ -392,10 +392,10 @@ void DualComplexTest::invertedNormalizedNotNormalized() {
 }
 
 void DualComplexTest::rotation() {
-    DualComplex a = DualComplex::rotation(Deg(120.0f));
+    DualComplex a = DualComplex::rotation(120.0_degf);
     CORRADE_COMPARE(a.length(), 1.0f);
     CORRADE_COMPARE(a, DualComplex({-0.5f, 0.8660254f}, {0.0f, 0.0f}));
-    CORRADE_COMPARE_AS(a.rotation().angle(), Deg(120.0f), Rad);
+    CORRADE_COMPARE_AS(a.rotation().angle(), 120.0_degf, Rad);
 
     /* Constexpr access to rotation */
     constexpr DualComplex b({-1.0f, 2.0f}, {});
@@ -416,18 +416,18 @@ void DualComplexTest::translation() {
 
 void DualComplexTest::combinedTransformParts() {
     Vector2 translation = Vector2(-1.5f, 2.75f);
-    DualComplex a = DualComplex::translation(translation)*DualComplex::rotation(Deg(23.0f));
-    DualComplex b = DualComplex::rotation(Deg(23.0f))*DualComplex::translation(translation);
+    DualComplex a = DualComplex::translation(translation)*DualComplex::rotation(23.0_degf);
+    DualComplex b = DualComplex::rotation(23.0_degf)*DualComplex::translation(translation);
 
-    CORRADE_COMPARE_AS(a.rotation().angle(), Deg(23.0f), Rad);
-    CORRADE_COMPARE_AS(b.rotation().angle(), Deg(23.0f), Rad);
+    CORRADE_COMPARE_AS(a.rotation().angle(), 23.0_degf, Rad);
+    CORRADE_COMPARE_AS(b.rotation().angle(), 23.0_degf, Rad);
     CORRADE_COMPARE(a.translation(), translation);
-    CORRADE_COMPARE(b.translation(), Complex::rotation(Deg(23.0f)).transformVector(translation));
+    CORRADE_COMPARE(b.translation(), Complex::rotation(23.0_degf).transformVector(translation));
 }
 
 void DualComplexTest::matrix() {
-    DualComplex a = DualComplex::rotation(Deg(23.0f))*DualComplex::translation({2.0f, 3.0f});
-    Matrix3 m = Matrix3::rotation(Deg(23.0f))*Matrix3::translation({2.0f, 3.0f});
+    DualComplex a = DualComplex::rotation(23.0_degf)*DualComplex::translation({2.0f, 3.0f});
+    Matrix3 m = Matrix3::rotation(23.0_degf)*Matrix3::translation({2.0f, 3.0f});
 
     CORRADE_COMPARE(a.toMatrix(), m);
     CORRADE_COMPARE(DualComplex::fromMatrix(m), a);
@@ -461,10 +461,10 @@ void DualComplexTest::transformVector() {
 }
 
 void DualComplexTest::transformPoint() {
-    DualComplex a = DualComplex::translation({2.0f, 3.0f})*DualComplex::rotation(Deg(23.0f));
-    DualComplex b = DualComplex::rotation(Deg(23.0f))*DualComplex::translation({2.0f, 3.0f});
-    Matrix3 m = Matrix3::translation({2.0f, 3.0f})*Matrix3::rotation(Deg(23.0f));
-    Matrix3 n = Matrix3::rotation(Deg(23.0f))*Matrix3::translation({2.0f, 3.0f});
+    DualComplex a = DualComplex::translation({2.0f, 3.0f})*DualComplex::rotation(23.0_degf);
+    DualComplex b = DualComplex::rotation(23.0_degf)*DualComplex::translation({2.0f, 3.0f});
+    Matrix3 m = Matrix3::translation({2.0f, 3.0f})*Matrix3::rotation(23.0_degf);
+    Matrix3 n = Matrix3::rotation(23.0_degf)*Matrix3::translation({2.0f, 3.0f});
     Vector2 v(-3.6f, 0.7f);
 
     Vector2 transformedA = a.transformPoint(v);

--- a/src/Magnum/Math/Test/DualQuaternionTest.cpp
+++ b/src/Magnum/Math/Test/DualQuaternionTest.cpp
@@ -89,6 +89,7 @@ struct DualQuaternionTest: Corrade::TestSuite::Tester {
     void rotation();
     void rotationNotNormalized();
     void translation();
+    void rotationTranslation();
     void combinedTransformParts();
     void matrix();
     void matrixNotOrthogonal();
@@ -154,6 +155,7 @@ DualQuaternionTest::DualQuaternionTest() {
               &DualQuaternionTest::rotation,
               &DualQuaternionTest::rotationNotNormalized,
               &DualQuaternionTest::translation,
+              &DualQuaternionTest::rotationTranslation,
               &DualQuaternionTest::combinedTransformParts,
               &DualQuaternionTest::matrix,
               &DualQuaternionTest::matrixNotOrthogonal,
@@ -467,6 +469,17 @@ void DualQuaternionTest::translation() {
     CORRADE_COMPARE(q.length(), 1.0f);
     CORRADE_COMPARE(q, DualQuaternion({}, {{0.5f, -1.75f, 0.25f}, 0.0f}));
     CORRADE_COMPARE(q.translation(), vec);
+}
+
+void DualQuaternionTest::rotationTranslation() {
+    Vector3 axis(1.0f/Constants<Float>::sqrt3());
+    Quaternion r = Quaternion::rotation(120.0_degf, axis);
+
+    Vector3 vec(1.0f, -3.5f, 0.5f);
+    DualQuaternion t = DualQuaternion::translation(vec);
+
+    DualQuaternion rt = t*DualQuaternion{r};
+    CORRADE_COMPARE(DualQuaternion::from(r, vec), rt);
 }
 
 void DualQuaternionTest::combinedTransformParts() {

--- a/src/Magnum/Math/Test/DualQuaternionTest.cpp
+++ b/src/Magnum/Math/Test/DualQuaternionTest.cpp
@@ -320,7 +320,7 @@ void DualQuaternionTest::data() {
 
 void DualQuaternionTest::isNormalized() {
     CORRADE_VERIFY(!DualQuaternion({{1.0f, 2.0f, 3.0f}, 4.0f}, {}).isNormalized());
-    CORRADE_VERIFY((DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis())*DualQuaternion::translation({0.9f, -1.0f, -0.5f})).isNormalized());
+    CORRADE_VERIFY((DualQuaternion::rotation(23.0_degf, Vector3::xAxis())*DualQuaternion::translation({0.9f, -1.0f, -0.5f})).isNormalized());
 }
 
 template<class T> void DualQuaternionTest::isNormalizedEpsilonRotation() {
@@ -434,10 +434,10 @@ void DualQuaternionTest::invertedNormalizedNotNormalized() {
 void DualQuaternionTest::rotation() {
     Vector3 axis(1.0f/Constants<Float>::sqrt3());
 
-    DualQuaternion q = DualQuaternion::rotation(Deg(120.0f), axis);
+    DualQuaternion q = DualQuaternion::rotation(120.0_degf, axis);
     CORRADE_COMPARE(q.length(), 1.0f);
     CORRADE_COMPARE(q, DualQuaternion({Vector3(0.5f, 0.5f, 0.5f), 0.5f}, {{}, 0.0f}));
-    CORRADE_COMPARE_AS(q.rotation().angle(), Deg(120.0f), Deg);
+    CORRADE_COMPARE_AS(q.rotation().angle(), 120.0_degf, Deg);
     CORRADE_COMPARE(q.rotation().axis(), axis);
 
     /* Constexpr access to rotation */
@@ -471,21 +471,21 @@ void DualQuaternionTest::translation() {
 
 void DualQuaternionTest::combinedTransformParts() {
     Vector3 translation = Vector3(-1.0f, 2.0f, 3.0f);
-    DualQuaternion a = DualQuaternion::translation(translation)*DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis());
-    DualQuaternion b = DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis())*DualQuaternion::translation(translation);
+    DualQuaternion a = DualQuaternion::translation(translation)*DualQuaternion::rotation(23.0_degf, Vector3::xAxis());
+    DualQuaternion b = DualQuaternion::rotation(23.0_degf, Vector3::xAxis())*DualQuaternion::translation(translation);
 
     CORRADE_COMPARE(a.rotation().axis(), Vector3::xAxis());
     CORRADE_COMPARE(b.rotation().axis(), Vector3::xAxis());
-    CORRADE_COMPARE_AS(a.rotation().angle(), Deg(23.0f), Rad);
-    CORRADE_COMPARE_AS(b.rotation().angle(), Deg(23.0f), Rad);
+    CORRADE_COMPARE_AS(a.rotation().angle(), 23.0_degf, Rad);
+    CORRADE_COMPARE_AS(b.rotation().angle(), 23.0_degf, Rad);
 
     CORRADE_COMPARE(a.translation(), translation);
-    CORRADE_COMPARE(b.translation(), Quaternion::rotation(Deg(23.0f), Vector3::xAxis()).transformVector(translation));
+    CORRADE_COMPARE(b.translation(), Quaternion::rotation(23.0_degf, Vector3::xAxis()).transformVector(translation));
 }
 
 void DualQuaternionTest::matrix() {
-    DualQuaternion q = DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis())*DualQuaternion::translation({-1.0f, 2.0f, 3.0f});
-    Matrix4 m = Matrix4::rotationX(Deg(23.0f))*Matrix4::translation({-1.0f, 2.0f, 3.0f});
+    DualQuaternion q = DualQuaternion::rotation(23.0_degf, Vector3::xAxis())*DualQuaternion::translation({-1.0f, 2.0f, 3.0f});
+    Matrix4 m = Matrix4::rotationX(23.0_degf)*Matrix4::translation({-1.0f, 2.0f, 3.0f});
 
     /* Verify that negated dual quaternion gives the same transformation */
     CORRADE_COMPARE(q.toMatrix(), m);
@@ -548,10 +548,10 @@ void DualQuaternionTest::transformVectorNormalizedNotNormalized() {
 }
 
 void DualQuaternionTest::transformPoint() {
-    DualQuaternion a = DualQuaternion::translation({-1.0f, 2.0f, 3.0f})*DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis());
-    DualQuaternion b = DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis())*DualQuaternion::translation({-1.0f, 2.0f, 3.0f});
-    Matrix4 m = Matrix4::translation({-1.0f, 2.0f, 3.0f})*Matrix4::rotationX(Deg(23.0f));
-    Matrix4 n = Matrix4::rotationX(Deg(23.0f))*Matrix4::translation({-1.0f, 2.0f, 3.0f});
+    DualQuaternion a = DualQuaternion::translation({-1.0f, 2.0f, 3.0f})*DualQuaternion::rotation(23.0_degf, Vector3::xAxis());
+    DualQuaternion b = DualQuaternion::rotation(23.0_degf, Vector3::xAxis())*DualQuaternion::translation({-1.0f, 2.0f, 3.0f});
+    Matrix4 m = Matrix4::translation({-1.0f, 2.0f, 3.0f})*Matrix4::rotationX(23.0_degf);
+    Matrix4 n = Matrix4::rotationX(23.0_degf)*Matrix4::translation({-1.0f, 2.0f, 3.0f});
     Vector3 v(0.0f, -3.6f, 0.7f);
 
     Vector3 transformedA = (a*Dual(2)).transformPoint(v);
@@ -564,10 +564,10 @@ void DualQuaternionTest::transformPoint() {
 }
 
 void DualQuaternionTest::transformPointNormalized() {
-    DualQuaternion a = DualQuaternion::translation({-1.0f, 2.0f, 3.0f})*DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis());
-    DualQuaternion b = DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis())*DualQuaternion::translation({-1.0f, 2.0f, 3.0f});
-    Matrix4 m = Matrix4::translation({-1.0f, 2.0f, 3.0f})*Matrix4::rotationX(Deg(23.0f));
-    Matrix4 n = Matrix4::rotationX(Deg(23.0f))*Matrix4::translation({-1.0f, 2.0f, 3.0f});
+    DualQuaternion a = DualQuaternion::translation({-1.0f, 2.0f, 3.0f})*DualQuaternion::rotation(23.0_degf, Vector3::xAxis());
+    DualQuaternion b = DualQuaternion::rotation(23.0_degf, Vector3::xAxis())*DualQuaternion::translation({-1.0f, 2.0f, 3.0f});
+    Matrix4 m = Matrix4::translation({-1.0f, 2.0f, 3.0f})*Matrix4::rotationX(23.0_degf);
+    Matrix4 n = Matrix4::rotationX(23.0_degf)*Matrix4::translation({-1.0f, 2.0f, 3.0f});
     Vector3 v(0.0f, -3.6f, 0.7f);
 
     Vector3 transformedA = a.transformPointNormalized(v);
@@ -587,7 +587,7 @@ void DualQuaternionTest::transformPointNormalizedNotNormalized() {
     std::ostringstream out;
     Error redirectError{&out};
 
-    DualQuaternion a = DualQuaternion::translation({-1.0f, 2.0f, 3.0f})*DualQuaternion::rotation(Deg(23.0f), Vector3::xAxis());
+    DualQuaternion a = DualQuaternion::translation({-1.0f, 2.0f, 3.0f})*DualQuaternion::rotation(23.0_degf, Vector3::xAxis());
     (a*Dual(2)).transformPointNormalized({});
     CORRADE_COMPARE(out.str(), "Math::DualQuaternion::transformPointNormalized(): DualQuaternion({{0.398736, 0, 0}, 1.95985}, {{-0.979925, 2.55795, 2.54104}, 0.199368}) is not normalized\n");
 }


### PR DESCRIPTION
Hi @mosra !

Here's a super small PR to avoid a common pattern when working with dual quaternions:
```cpp
DualQuaternion q = DualQuaternion::translation(v)*DualQuaternion::rotation(rot);
```

Or worse:
```cpp
DualQuaternion q = DualQuaternion::fromMatrix(Matrix4::from(rot.toMatrix(), v));
```

Best,
Jonathan