### PR TITLE
EmscriptenApplication: use _malloc instead of internal allocate

### DIFF
--- a/src/Magnum/Platform/EmscriptenApplication.cpp
+++ b/src/Magnum/Platform/EmscriptenApplication.cpp
@@ -186,7 +186,11 @@ namespace {
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
         char* id = reinterpret_cast<char*>(EM_ASM_INT({
-            return allocate(intArrayFromString(Module['canvas'].id), 'i8', ALLOC_NORMAL);
+            const id = Module['canvas'].id;
+            const bytes = lengthBytesUTF8(id) + 1;
+            const memory = _malloc(bytes);
+            stringToUTF8(id, memory, bytes);
+            return memory;
         }));
         #pragma GCC diagnostic pop
         std::string str = id;
@@ -562,8 +566,12 @@ void EmscriptenApplication::setupCallbacks(bool resizable) {
 
         if(element === document) return 1; /* EMSCRIPTEN_EVENT_TARGET_DOCUMENT */
         if(element === window) return 2; /* EMSCRIPTEN_EVENT_TARGET_WINDOW */
-        if('id' in element)
-            return allocate(intArrayFromString(element.id), 'i8', ALLOC_NORMAL);
+        if('id' in element) {
+            const bytes = lengthBytesUTF8(element.id) + 1;
+            const memory = _malloc(bytes);
+            stringToUTF8(element.id, memory, bytes);
+            return memory;
+        }
 
         return 0;
     }));

--- a/src/Magnum/Platform/Test/CMakeLists.txt
+++ b/src/Magnum/Platform/Test/CMakeLists.txt
@@ -47,7 +47,9 @@ if(WITH_EMSCRIPTENAPPLICATION)
         # Test that the canvas and keylistener can be found with both the old
         # and the new Emscripten target behaviors
         # TODO: use target_link_options() once we can require CMake 3.13
-        "-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0")
+        "-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0"
+        # Enable memory runtime checks
+        "-s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(PlatformEmscriptenApplicationTest PROPERTIES FOLDER "Magnum/Platform/Test")
     add_custom_command(TARGET PlatformEmscriptenApplicationTest POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -63,7 +65,8 @@ if(WITH_EMSCRIPTENAPPLICATION)
         MagnumEmscriptenApplication MagnumGL
         # TODO: use target_link_options() once we can require CMake 3.13
         "-s MODULARIZE -s EXPORT_NAME=createModule"
-        "-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1")
+        "-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1"
+        "-s ASSERTIONS=2 -s SAFE_HEAP=1")
     target_compile_definitions(PlatformMultipleEmscriptenApplicationTest PRIVATE CUSTOM_CLEAR_COLOR=0x3bd267_rgbf)
     set_target_properties(PlatformMultipleEmscriptenApplicationTest PROPERTIES FOLDER "Magnum/Platform/Test")
     add_custom_command(TARGET PlatformMultipleEmscriptenApplicationTest POST_BUILD


### PR DESCRIPTION
Fix for `allocate` having a [different function signature starting with Emscripten 2.0.5](https://github.com/emscripten-core/emscripten/commit/fc67fbf94b6b815c619e75dfe59c84f3c81bf698).

I think this is cleaner than `#ifdef`-ing around `__EMSCRIPTEN_major/minor/tiny__` as that internal function could change again in the future, and duplicating `EM_ASM` blocks means even more code and maintenance.

I added `ASSERTIONS` and `SAFE_HEAP` to the test application compile flags so similar issues get caught in the future.

cc: @Squareys 