### PR TITLE
Add a workaround for eglQueryDeviceAttribEXT segfaulting

### DIFF
--- a/src/Magnum/GL/Implementation/driverSpecific.cpp
+++ b/src/Magnum/GL/Implementation/driverSpecific.cpp
@@ -161,6 +161,13 @@ const char* KnownWorkarounds[]{
    possible to get driver version through EGL, so enabling this unconditionally
    on all EGL NV contexts. */
 "nv-egl-incorrect-gl11-function-pointers",
+
+/* On nv driver 450.80.02, eglQueryDeviceAttribEXT segfaults when query GPUs that 
+   the user does not have access to (i.e. via cgroup).  Instead, always call 
+   eglQueryDeviceStringEXT as that doesn't segfault and sets an error that can be 
+   retrieved via eglGetError to see if the user has access to that device. On well 
+   behaved driver versions, eglQueryDeviceAttribEXT returns false instead of segfaulting. */
+"nv-egl-crashy-query-device-attrib",
 #endif
 
 #ifndef MAGNUM_TARGET_GLES


### PR DESCRIPTION
On nv driver 450.80.02, `eglQueryDeviceAttribEXT` segfaults when query GPUs that the user does not have access to (i.e. via cgroup).  Instead, always call `eglQueryDeviceStringEXT` as that doesn't segfault and sets an error that can be retrieved via eglGetError to see if the user has access to that device. On well behaved driver versions, `eglQueryDeviceAttribEXT` returns false instead of segfaulting.

There is of course the chance that `eglQueryDeviceStringEXT` will be the call with a problem in the future :)