### PR TITLE
GL::Context: pass InternalFlags as parameter

### DIFF
--- a/src/Magnum/GL/Context.cpp
+++ b/src/Magnum/GL/Context.cpp
@@ -912,7 +912,9 @@ bool Context::tryCreate() {
 
     /* Initialize functionality based on current OpenGL version and extensions */
     /** @todo Get rid of these */
-    DefaultFramebuffer::initializeContextBasedFunctionality(*this);
+    if(!(_internalFlags & InternalFlag::NoFramebuffer))
+        DefaultFramebuffer::initializeContextBasedFunctionality(*this);
+
     Renderer::initializeContextBasedFunctionality();
 
     /* Enable GPU validation, if requested */

--- a/src/Magnum/GL/Context.h
+++ b/src/Magnum/GL/Context.h
@@ -747,6 +747,8 @@ class MAGNUM_GL_EXPORT Context {
             DisplayVerboseInitializationLog = DisplayInitializationLog|(1 << 1),
             GpuValidation = 1 << 2,
 
+            NoFramebuffer = 1 << 3,
+
             Default = DisplayInitializationLog
         };
         typedef Containers::EnumSet<InternalFlag> InternalFlags;

--- a/src/Magnum/GL/Context.h
+++ b/src/Magnum/GL/Context.h
@@ -745,7 +745,9 @@ class MAGNUM_GL_EXPORT Context {
         enum class InternalFlag: UnsignedByte {
             DisplayInitializationLog = 1 << 0,
             DisplayVerboseInitializationLog = DisplayInitializationLog|(1 << 1),
-            GpuValidation = 1 << 2
+            GpuValidation = 1 << 2,
+
+            Default = DisplayInitializationLog
         };
         typedef Containers::EnumSet<InternalFlag> InternalFlags;
         CORRADE_ENUMSET_FRIEND_OPERATORS(InternalFlags)
@@ -766,9 +768,10 @@ class MAGNUM_GL_EXPORT Context {
     #endif
         /* Made protected so it's possible to test the NoCreate constructor and
            also not needed to friend Platform::GLContext. */
-        explicit Context(NoCreateT, Int argc, const char** argv, void functionLoader(Context&));
-        explicit Context(NoCreateT, Utility::Arguments&& args, Int argc, const char** argv, void functionLoader(Context&)): Context{NoCreate, args, argc, argv, functionLoader} {}
-        explicit Context(NoCreateT, Utility::Arguments& args, Int argc, const char** argv, void functionLoader(Context&));
+        explicit Context(NoCreateT, Int argc, const char** argv, void functionLoader(Context&), InternalFlags flags = InternalFlag::Default);
+        explicit Context(NoCreateT, Utility::Arguments&& args, Int argc, const char** argv, void functionLoader(Context&), InternalFlags flags = InternalFlag::Default): Context{NoCreate, args, argc, argv, functionLoader, flags} {}
+        explicit Context(NoCreateT, Utility::Arguments& args, Int argc, const char** argv, void functionLoader(Context&), InternalFlags flags = InternalFlag::Default);
+        explicit Context(NoCreateT, void functionLoader(Context&), InternalFlags flags = InternalFlag::Default);
 
         bool tryCreate();
         void create();

--- a/src/Magnum/Platform/GLContext.h
+++ b/src/Magnum/Platform/GLContext.h
@@ -60,13 +60,13 @@ class GLContext: public GL::Context {
          * Equivalent to calling @ref GLContext(NoCreateT, Int, const char**)
          * followed by @ref create().
          */
-        explicit GLContext(Int argc, const char** argv): GLContext{NoCreate, argc, argv} { create(); }
+        explicit GLContext(Int argc, const char** argv, InternalFlags flags = InternalFlag::Default): GLContext{NoCreate, argc, argv, flags} { create(); }
 
         /** @overload */
-        explicit GLContext(Int argc, char** argv): GLContext{argc, const_cast<const char**>(argv)} {}
+        explicit GLContext(Int argc, char** argv, InternalFlags flags = InternalFlag::Default): GLContext{argc, const_cast<const char**>(argv), flags} {}
 
         /** @overload */
-        explicit GLContext(Int argc, std::nullptr_t argv): GLContext{argc, static_cast<const char**>(argv)} {}
+        explicit GLContext(Int argc, std::nullptr_t argv, InternalFlags flags = InternalFlag::Default): GLContext{argc, static_cast<const char**>(argv), flags} {}
 
         /**
          * @brief Default constructor
@@ -77,7 +77,7 @@ class GLContext: public GL::Context {
          * behavior from the environment. See @ref GL-Context-command-line for
          * more information.
          */
-        explicit GLContext(): GLContext{0, nullptr} {}
+        explicit GLContext(InternalFlags flags = InternalFlag::Default): GLContext{0, nullptr, flags} {}
 
         /**
          * @brief Construct without creating the context
@@ -87,28 +87,28 @@ class GLContext: public GL::Context {
          * Use @ref create() or @ref tryCreate() to create the context.
          * @see @ref GLContext(Int, const char**)
          */
-        explicit GLContext(NoCreateT, Int argc, const char** argv):
+        explicit GLContext(NoCreateT, Int argc, const char** argv, InternalFlags flags = InternalFlag::Default):
             #ifndef CORRADE_TARGET_EMSCRIPTEN
-            GL::Context{NoCreate, argc, argv, flextGLInit} {}
+            GL::Context{NoCreate, argc, argv, flextGLInit, flags} {}
             #else
-            GL::Context{NoCreate, argc, argv, nullptr} {}
+            GL::Context{NoCreate, argc, argv, nullptr, flags} {}
             #endif
 
         /** @overload */
-        explicit GLContext(NoCreateT, Int argc, char** argv): GLContext{NoCreate, argc, const_cast<const char**>(argv)} {}
+        explicit GLContext(NoCreateT, Int argc, char** argv, InternalFlags flags = InternalFlag::Default): GLContext{NoCreate, argc, const_cast<const char**>(argv), flags} {}
 
         /** @overload */
-        explicit GLContext(NoCreateT, Int argc, std::nullptr_t argv): GLContext{NoCreate, argc, static_cast<const char**>(argv)} {}
+        explicit GLContext(NoCreateT, Int argc, std::nullptr_t argv, InternalFlags flags = InternalFlag::Default): GLContext{NoCreate, argc, static_cast<const char**>(argv), flags} {}
 
         #ifndef DOXYGEN_GENERATING_OUTPUT
         /* Used privately to inject additional command-line arguments */
-        explicit GLContext(NoCreateT, Utility::Arguments& args, Int argc, char** argv): GLContext{NoCreate, args, argc, const_cast<const char**>(argv)} {}
-        explicit GLContext(NoCreateT, Utility::Arguments& args, Int argc, std::nullptr_t argv): GLContext{NoCreate, args, argc, static_cast<const char**>(argv)} {}
-        explicit GLContext(NoCreateT, Utility::Arguments& args, Int argc, const char** argv):
+        explicit GLContext(NoCreateT, Utility::Arguments& args, Int argc, char** argv, InternalFlags flags = InternalFlag::Default): GLContext{NoCreate, args, argc, const_cast<const char**>(argv), flags} {}
+        explicit GLContext(NoCreateT, Utility::Arguments& args, Int argc, std::nullptr_t argv, InternalFlags flags = InternalFlag::Default): GLContext{NoCreate, args, argc, static_cast<const char**>(argv), flags} {}
+        explicit GLContext(NoCreateT, Utility::Arguments& args, Int argc, const char** argv, InternalFlags flags = InternalFlag::Default):
             #ifndef CORRADE_TARGET_EMSCRIPTEN
-            GL::Context{NoCreate, args, argc, argv, flextGLInit} {}
+            GL::Context{NoCreate, args, argc, argv, flextGLInit, flags} {}
             #else
-            GL::Context{NoCreate, args, argc, argv, nullptr} {}
+            GL::Context{NoCreate, args, argc, argv, nullptr, flags} {}
             #endif
         #endif
 
@@ -121,7 +121,7 @@ class GLContext: public GL::Context {
          * affect the renderer behavior from the environment. See
          * @ref GL-Context-command-line for more information.
          */
-        explicit GLContext(NoCreateT): GLContext{NoCreate, 0, nullptr} {}
+        explicit GLContext(NoCreateT, InternalFlags flags = InternalFlag::Default): GLContext{NoCreate, 0, nullptr, flags} {}
 
         /**
          * @brief Create the context


### PR DESCRIPTION
Here's a possible way to resolve #493 (GL::defaultFramebuffer gets clobbered when you create a second context).

I'm using the already existent InternalFlags enum set, adding a new `NoFramebuffer` flag, which skips initialization of `defaultFramebuffer`. Additionally, the flags are exposed as additional parameters of the `GL::Context` and `Platform::GLContext` constructors, allowing users to pass in the new flag.

Coincidentally, this also allows to control the other flags without creating dummy argc/argv for `Platform::GLContext`, which feels much cleaner to me.

In detail, the passed `flags` are applied before parsing the command line arguments.

@mosra do you feel this is a good solution? Exposing a parameter called `InternalFlags` feels a bit daring, but I guess the Application classes already use that type ;)