### PR TITLE
[WindowLessApps]: add release option to contexts [egl,cgl,glx for linux]

### DIFF
--- a/src/Magnum/Platform/WindowlessCglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessCglApplication.cpp
@@ -97,6 +97,14 @@ bool WindowlessCglContext::makeCurrent() {
     return false;
 }
 
+bool WindowlessCglContext::release() {
+    if(CGLSetCurrentContext(0) == kCGLNoError)
+        return true;
+
+    Error() << "Platform::WindowlessCglContext::release(): cannot release current context";
+    return false;
+}
+
 #ifndef DOXYGEN_GENERATING_OUTPUT
 WindowlessCglApplication::WindowlessCglApplication(const Arguments& arguments): WindowlessCglApplication{arguments, Configuration{}} {}
 #endif

--- a/src/Magnum/Platform/WindowlessCglApplication.h
+++ b/src/Magnum/Platform/WindowlessCglApplication.h
@@ -127,6 +127,14 @@ class WindowlessCglContext {
         bool makeCurrent();
 
         /**
+         * @brief Release current context
+         *
+         * Prints error message and returns @cpp false @ce on failure,
+         * otherwise returns @cpp true @ce.
+         */
+        bool release();
+
+        /**
          * @brief Underlying OpenGL context
          * @m_since{2020,06}
          *

--- a/src/Magnum/Platform/WindowlessEglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessEglApplication.cpp
@@ -503,7 +503,15 @@ bool WindowlessEglContext::makeCurrent() {
         return true;
     #endif
 
-    Error() << "Platform::WindowlessEglApplication::tryCreateContext(): cannot make context current:" << Implementation::eglErrorString(eglGetError());
+    Error() << "Platform::WindowlessEglApplication::makeCurrent(): cannot make context current:" << Implementation::eglErrorString(eglGetError());
+    return false;
+}
+
+bool WindowlessEglContext::release() {
+    if(eglMakeCurrent(_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT))
+        return true;
+
+    Error() << "Platform::WindowlessEglApplication::release(): cannot release current context:" << Implementation::eglErrorString(eglGetError());
     return false;
 }
 

--- a/src/Magnum/Platform/WindowlessEglApplication.h
+++ b/src/Magnum/Platform/WindowlessEglApplication.h
@@ -128,6 +128,14 @@ class WindowlessEglContext {
         bool makeCurrent();
 
         /**
+         * @brief Release current context
+         *
+         * Prints error message and returns @cpp false @ce on failure,
+         * otherwise returns @cpp true @ce.
+         */
+        bool release();
+
+        /**
          * @brief Underlying OpenGL context
          * @m_since{2020,06}
          *

--- a/src/Magnum/Platform/WindowlessGlxApplication.cpp
+++ b/src/Magnum/Platform/WindowlessGlxApplication.cpp
@@ -255,6 +255,14 @@ bool WindowlessGlxContext::makeCurrent() {
     return false;
 }
 
+bool WindowlessGlxContext::release() {
+    if(glXMakeContextCurrent(_display, 0, 0, nullptr))
+        return true;
+
+    Error() << "Platform::WindowlessGlxContext::release(): cannot release current context";
+    return false;
+}
+
 WindowlessGlxContext::Configuration::Configuration():
     #ifndef MAGNUM_TARGET_GLES
     _flags{Flag::ForwardCompatible}

--- a/src/Magnum/Platform/WindowlessGlxApplication.h
+++ b/src/Magnum/Platform/WindowlessGlxApplication.h
@@ -147,6 +147,14 @@ class WindowlessGlxContext {
         bool makeCurrent();
 
         /**
+         * @brief Release current context
+         *
+         * Prints error message and returns @cpp false @ce on failure,
+         * otherwise returns @cpp true @ce.
+         */
+        bool release();
+
+        /**
          * @brief Underlying OpenGL context
          * @m_since{2020,06}
          *


### PR DESCRIPTION
This PR adds the possibility to release a windowless context inside the following apps:

- `EglWindowlessApplication`
- `CglWindowlessApplication`
- `GlxWindowlessApplication`

I have tested `Glx` and it compiles/works like a charm. I will soon test `Egl`. I have no way of testing `Cgl`. Also I have no way of testing it in other windowless apps.

Let me know of your comments..