### PR TITLE
Bye bye std::string in the GL library

### DIFF
--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -1137,6 +1137,12 @@ See also:
 -   As part of the ongoing STL header dependency cleanup, the following
     breaking changes related to @ref std::string and a @ref std::vector are
     done:
+    -   @ref GL::AbstractShaderProgram::validate() now returns a
+        @relativeref{Corrade,Containers::String} instead of a @ref std::string;
+        @ref GL::Shader::sources() now returns a
+        @relativeref{Corrade,Containers::StringIterable} instead of a
+        @ref std::vector of a @ref std::string See also [mosra/magnum#499](https://github.com/mosra/magnum/pull/499)
+        and [mosra/magnum#608](https://github.com/mosra/magnum/pull/608).
     -   @ref GL::Context::vendorString(),
         @relativeref{GL::Context,rendererString()},
         @relativeref{GL::Context,versionString()},

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -1135,11 +1135,12 @@ See also:
     significant positive effect on compile times of code using the @ref GL,
     @ref Audio, @ref Trade and @ref Text libraries
 -   As part of the ongoing STL header dependency cleanup, the following
-    breaking changes related to @ref std::string and a @ref std::vector are
-    done:
+    breaking changes related to @ref std::string, @ref std::vector and
+    @ref std::pair are done:
     -   @ref GL::AbstractShaderProgram::validate() now returns a
-        @relativeref{Corrade,Containers::String} instead of a @ref std::string;
-        @ref GL::Shader::sources() now returns a
+        @relativeref{Corrade,Containers::Pair} with a
+        @relativeref{Corrade,Containers::String} instead of a @ref std::pair
+        with a @ref std::string; @ref GL::Shader::sources() now returns a
         @relativeref{Corrade,Containers::StringIterable} instead of a
         @ref std::vector of a @ref std::string See also [mosra/magnum#499](https://github.com/mosra/magnum/pull/499)
         and [mosra/magnum#608](https://github.com/mosra/magnum/pull/608).

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -863,6 +863,10 @@ See also:
     particular, if `BUILD_DEPRECATED` is set but `MAGNUM_BUILD_DEPRECATED` not,
     the unprefixed options are also recognized. See also
     [mosra/corrade#139](https://github.com/mosra/corrade/issues/139).
+-   @ref GL::DebugOutput::setCallback() taking a @ref std::string in the
+    callback function pointer is deprecated in favor of a version taking a
+    @ref Containers::StringView. See also [mosra/magnum#499](https://github.com/mosra/magnum/pull/499)
+    and [mosra/magnum#596](https://github.com/mosra/magnum/pull/596).
 -   The @cpp Array @ce, @cpp Array1D @ce, @cpp Array2D @ce and
     @cpp Array3D @ce types that were used exclusively for specifying
     @ref SamplerWrapping in various texture APIs are deprecated in favor of

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -1137,6 +1137,10 @@ See also:
 -   As part of the ongoing STL header dependency cleanup, the following
     breaking changes related to @ref std::string, @ref std::vector and
     @ref std::pair are done:
+    -   @ref DebugTools::FrameProfiler::measurementName() and
+        @ref DebugTools::FrameProfiler::statistics() now return a
+        @relativeref{Corrade,Containers::StringView} /
+        @relativeref{Corrade,Containers::String} instead of a @ref std::string
     -   @ref GL::AbstractShaderProgram::validate() now returns a
         @relativeref{Corrade,Containers::Pair} with a
         @relativeref{Corrade,Containers::String} instead of a @ref std::pair

--- a/doc/generated/primitives.cpp
+++ b/doc/generated/primitives.cpp
@@ -26,7 +26,7 @@
 #include <tuple>
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/Optional.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/Utility/Path.h>
 
@@ -93,47 +93,47 @@ struct PrimitiveVisualizer: Platform::WindowlessApplication {
 
     int exec() override;
 
-    std::pair<Trade::MeshData, std::string> axis2D();
-    std::pair<Trade::MeshData, std::string> axis3D();
+    std::pair<Trade::MeshData, Containers::StringView> axis2D();
+    std::pair<Trade::MeshData, Containers::StringView> axis3D();
 
-    std::pair<Trade::MeshData, std::string> capsule2DWireframe();
-    std::pair<Trade::MeshData, std::string> circle2DWireframe();
-    std::pair<Trade::MeshData, std::string> crosshair2D();
-    std::pair<Trade::MeshData, std::string> line2D();
-    std::pair<Trade::MeshData, std::string> squareWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> capsule2DWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> circle2DWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> crosshair2D();
+    std::pair<Trade::MeshData, Containers::StringView> line2D();
+    std::pair<Trade::MeshData, Containers::StringView> squareWireframe();
 
-    std::pair<Trade::MeshData, std::string> capsule3DWireframe();
-    std::pair<Trade::MeshData, std::string> circle3DWireframe();
-    std::pair<Trade::MeshData, std::string> crosshair3D();
-    std::pair<Trade::MeshData, std::string> coneWireframe();
-    std::pair<Trade::MeshData, std::string> cubeWireframe();
-    std::pair<Trade::MeshData, std::string> cylinderWireframe();
-    std::pair<Trade::MeshData, std::string> grid3DWireframe();
-    std::pair<Trade::MeshData, std::string> icosphereWireframe();
-    std::pair<Trade::MeshData, std::string> line3D();
-    std::pair<Trade::MeshData, std::string> planeWireframe();
-    std::pair<Trade::MeshData, std::string> uvSphereWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> capsule3DWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> circle3DWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> crosshair3D();
+    std::pair<Trade::MeshData, Containers::StringView> coneWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> cubeWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> cylinderWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> grid3DWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> icosphereWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> line3D();
+    std::pair<Trade::MeshData, Containers::StringView> planeWireframe();
+    std::pair<Trade::MeshData, Containers::StringView> uvSphereWireframe();
 
-    std::pair<Trade::MeshData, std::string> circle2DSolid();
-    std::pair<Trade::MeshData, std::string> squareSolid();
+    std::pair<Trade::MeshData, Containers::StringView> circle2DSolid();
+    std::pair<Trade::MeshData, Containers::StringView> squareSolid();
 
-    std::pair<Trade::MeshData, std::string> capsule3DSolid();
-    std::pair<Trade::MeshData, std::string> circle3DSolid();
-    std::pair<Trade::MeshData, std::string> coneSolid();
-    std::pair<Trade::MeshData, std::string> cubeSolid();
-    std::pair<Trade::MeshData, std::string> cylinderSolid();
-    std::pair<Trade::MeshData, std::string> grid3DSolid();
-    std::pair<Trade::MeshData, std::string> icosphereSolid();
-    std::pair<Trade::MeshData, std::string> planeSolid();
-    std::pair<Trade::MeshData, std::string> uvSphereSolid();
+    std::pair<Trade::MeshData, Containers::StringView> capsule3DSolid();
+    std::pair<Trade::MeshData, Containers::StringView> circle3DSolid();
+    std::pair<Trade::MeshData, Containers::StringView> coneSolid();
+    std::pair<Trade::MeshData, Containers::StringView> cubeSolid();
+    std::pair<Trade::MeshData, Containers::StringView> cylinderSolid();
+    std::pair<Trade::MeshData, Containers::StringView> grid3DSolid();
+    std::pair<Trade::MeshData, Containers::StringView> icosphereSolid();
+    std::pair<Trade::MeshData, Containers::StringView> planeSolid();
+    std::pair<Trade::MeshData, Containers::StringView> uvSphereSolid();
 
-    std::pair<Trade::MeshData, std::string> gradient2D();
-    std::pair<Trade::MeshData, std::string> gradient2DHorizontal();
-    std::pair<Trade::MeshData, std::string> gradient2DVertical();
+    std::pair<Trade::MeshData, Containers::StringView> gradient2D();
+    std::pair<Trade::MeshData, Containers::StringView> gradient2DHorizontal();
+    std::pair<Trade::MeshData, Containers::StringView> gradient2DVertical();
 
-    std::pair<Trade::MeshData, std::string> gradient3D();
-    std::pair<Trade::MeshData, std::string> gradient3DHorizontal();
-    std::pair<Trade::MeshData, std::string> gradient3DVertical();
+    std::pair<Trade::MeshData, Containers::StringView> gradient3D();
+    std::pair<Trade::MeshData, Containers::StringView> gradient3DHorizontal();
+    std::pair<Trade::MeshData, Containers::StringView> gradient3DVertical();
 };
 
 namespace {
@@ -191,7 +191,7 @@ int PrimitiveVisualizer::exec() {
         for(auto fun: {&PrimitiveVisualizer::axis2D}) {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -210,7 +210,7 @@ int PrimitiveVisualizer::exec() {
         for(auto fun: {&PrimitiveVisualizer::axis3D}) {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -235,7 +235,7 @@ int PrimitiveVisualizer::exec() {
         {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -266,7 +266,7 @@ int PrimitiveVisualizer::exec() {
         {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -296,7 +296,7 @@ int PrimitiveVisualizer::exec() {
         {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -341,7 +341,7 @@ int PrimitiveVisualizer::exec() {
         {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -364,7 +364,7 @@ int PrimitiveVisualizer::exec() {
                        &PrimitiveVisualizer::gradient2DVertical}) {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -387,7 +387,7 @@ int PrimitiveVisualizer::exec() {
                        &PrimitiveVisualizer::gradient3DVertical}) {
             multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-            std::string filename;
+            Containers::StringView filename;
             Containers::Optional<Trade::MeshData> data;
             std::tie(data, filename) = (this->*fun)();
 
@@ -404,11 +404,11 @@ int PrimitiveVisualizer::exec() {
     return 0;
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::axis2D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::axis2D() {
     return {Primitives::axis2D(), "axis2d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::gradient2D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::gradient2D() {
     return {Primitives::gradient2D({1.0f, -2.0f}, 0x2f83cc_srgbf, {-1.0f, 2.0f}, 0x3bd267_srgbf), "gradient2d.png"};
 }
 
@@ -419,151 +419,151 @@ namespace {
     const Color3 Gradient80Percent = Math::lerp(0x2f83cc_srgbf, 0x3bd267_srgbf, 0.8f);
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::gradient2DHorizontal() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::gradient2DHorizontal() {
     return {Primitives::gradient2DHorizontal(Gradient20Percent, Gradient80Percent), "gradient2dhorizontal.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::gradient2DVertical() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::gradient2DVertical() {
     /* End colors are 20%/80% blends of the above to match the range */
     return {Primitives::gradient2DVertical(Gradient20Percent, Gradient80Percent), "gradient2dvertical.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::axis3D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::axis3D() {
     return {Primitives::axis3D(), "axis3d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::gradient3D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::gradient3D() {
     return {Primitives::gradient3D({1.0f, -2.0f, -1.5f}, 0x2f83cc_srgbf, {-1.0f, 2.0f, -1.5f}, 0x3bd267_srgbf), "gradient3d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::gradient3DHorizontal() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::gradient3DHorizontal() {
     return {Primitives::gradient3DHorizontal(Gradient20Percent, Gradient80Percent), "gradient3dhorizontal.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::gradient3DVertical() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::gradient3DVertical() {
     return {Primitives::gradient3DVertical(Gradient20Percent, Gradient80Percent), "gradient3dvertical.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::capsule2DWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::capsule2DWireframe() {
     Trade::MeshData capsule = Primitives::capsule2DWireframe(8, 1, 0.75f);
     MeshTools::transformPointsInPlace(Matrix3::scaling(Vector2{0.75f}),
         capsule.mutableAttribute<Vector2>(Trade::MeshAttribute::Position));
     return {std::move(capsule), "capsule2dwireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::circle2DWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::circle2DWireframe() {
     return {Primitives::circle2DWireframe(32), "circle2dwireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::crosshair2D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::crosshair2D() {
     return {Primitives::crosshair2D(), "crosshair2d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::line2D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::line2D() {
     Trade::MeshData line = Primitives::line2D();
     MeshTools::transformPointsInPlace(Matrix3::translation(Vector2::xAxis(-1.0f))*Matrix3::scaling(Vector2::xScale(2.0f)),
         line.mutableAttribute<Vector2>(Trade::MeshAttribute::Position));
     return {std::move(line), "line2d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::squareWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::squareWireframe() {
     return {Primitives::squareWireframe(), "squarewireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::capsule3DWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::capsule3DWireframe() {
     Trade::MeshData capsule = Primitives::capsule3DWireframe(8, 1, 16, 1.0f);
     MeshTools::transformPointsInPlace(Matrix4::scaling(Vector3{0.75f}),
         capsule.mutableAttribute<Vector3>(Trade::MeshAttribute::Position));
     return {std::move(capsule), "capsule3dwireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::circle3DWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::circle3DWireframe() {
     return {Primitives::circle3DWireframe(32), "circle3dwireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::crosshair3D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::crosshair3D() {
     return {Primitives::crosshair3D(), "crosshair3d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::coneWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::coneWireframe() {
     return {Primitives::coneWireframe(32, 1.25f), "conewireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::cubeWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::cubeWireframe() {
     return {Primitives::cubeWireframe(), "cubewireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::cylinderWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::cylinderWireframe() {
     return {Primitives::cylinderWireframe(1, 32, 1.0f), "cylinderwireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::grid3DWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::grid3DWireframe() {
     return {Primitives::grid3DWireframe({5, 3}), "grid3dwireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::icosphereWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::icosphereWireframe() {
     return {Primitives::icosphereWireframe(), "icospherewireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::line3D() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::line3D() {
     Trade::MeshData line = Primitives::line3D();
     MeshTools::transformPointsInPlace(Matrix4::translation(Vector3::xAxis(-1.0f))*Matrix4::scaling(Vector3::xScale(2.0f)),
         line.mutableAttribute<Vector3>(Trade::MeshAttribute::Position));
     return {std::move(line), "line3d.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::planeWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::planeWireframe() {
     return {Primitives::planeWireframe(), "planewireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::uvSphereWireframe() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::uvSphereWireframe() {
     return {Primitives::uvSphereWireframe(16, 32), "uvspherewireframe.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::circle2DSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::circle2DSolid() {
     return {Primitives::circle2DSolid(16), "circle2dsolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::squareSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::squareSolid() {
     return {Primitives::squareSolid(), "squaresolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::capsule3DSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::capsule3DSolid() {
     Trade::MeshData capsule = Primitives::capsule3DSolid(4, 1, 12, 0.75f);
     MeshTools::transformPointsInPlace(Matrix4::scaling(Vector3{0.75f}),
         capsule.mutableAttribute<Vector3>(Trade::MeshAttribute::Position));
     return {std::move(capsule), "capsule3dsolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::circle3DSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::circle3DSolid() {
     return {Primitives::circle3DSolid(16), "circle3dsolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::coneSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::coneSolid() {
     return {Primitives::coneSolid(1, 12, 1.25f, Primitives::ConeFlag::CapEnd), "conesolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::cubeSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::cubeSolid() {
     return {Primitives::cubeSolid(), "cubesolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::cylinderSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::cylinderSolid() {
     return {Primitives::cylinderSolid(1, 12, 1.0f, Primitives::CylinderFlag::CapEnds), "cylindersolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::grid3DSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::grid3DSolid() {
     return {Primitives::grid3DSolid({5, 3}), "grid3dsolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::icosphereSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::icosphereSolid() {
     return {Primitives::icosphereSolid(1), "icospheresolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::planeSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::planeSolid() {
     return {Primitives::planeSolid(), "planesolid.png"};
 }
 
-std::pair<Trade::MeshData, std::string> PrimitiveVisualizer::uvSphereSolid() {
+std::pair<Trade::MeshData, Containers::StringView> PrimitiveVisualizer::uvSphereSolid() {
     return {Primitives::uvSphereSolid(8, 16), "uvspheresolid.png"};
 }
 

--- a/doc/generated/shaders.cpp
+++ b/doc/generated/shaders.cpp
@@ -25,7 +25,7 @@
 
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/Optional.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/Utility/Path.h>
 
@@ -79,16 +79,16 @@ struct ShaderVisualizer: Platform::WindowlessApplication {
 
     int exec() override;
 
-    std::string phong();
-    std::string meshVisualizer2D();
-    std::string meshVisualizer2DPrimitiveId();
-    std::string meshVisualizer3D();
-    std::string meshVisualizer3DPrimitiveId();
-    std::string flat();
-    std::string vertexColor();
+    Containers::StringView phong();
+    Containers::StringView meshVisualizer2D();
+    Containers::StringView meshVisualizer2DPrimitiveId();
+    Containers::StringView meshVisualizer3D();
+    Containers::StringView meshVisualizer3DPrimitiveId();
+    Containers::StringView flat();
+    Containers::StringView vertexColor();
 
-    std::string vector();
-    std::string distanceFieldVector();
+    Containers::StringView vector();
+    Containers::StringView distanceFieldVector();
 
     Containers::Pointer<Trade::AbstractImporter> _importer;
 };
@@ -142,7 +142,7 @@ int ShaderVisualizer::exec() {
                    &ShaderVisualizer::distanceFieldVector}) {
         multisampleFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth);
 
-        std::string filename = (this->*fun)();
+        Containers::StringView filename = (this->*fun)();
 
         GL::AbstractFramebuffer::blit(multisampleFramebuffer, framebuffer, framebuffer.viewport(), GL::FramebufferBlit::Color);
         Image2D result = framebuffer.read(framebuffer.viewport(), {PixelFormat::RGBA8Unorm});
@@ -161,7 +161,7 @@ namespace {
     const auto OutlineColor = 0xdcdcdc_srgbf;
 }
 
-std::string ShaderVisualizer::phong() {
+Containers::StringView ShaderVisualizer::phong() {
     Shaders::PhongGL{}
         .setAmbientColor(0x22272e_srgbf)
         .setDiffuseColor(BaseColor)
@@ -175,7 +175,7 @@ std::string ShaderVisualizer::phong() {
     return "phong.png";
 }
 
-std::string ShaderVisualizer::meshVisualizer2D() {
+Containers::StringView ShaderVisualizer::meshVisualizer2D() {
     const Matrix3 projection =
         Matrix3::projection(Vector2{3.0f})*
         Matrix3::rotation(13.7_degf);
@@ -193,7 +193,7 @@ std::string ShaderVisualizer::meshVisualizer2D() {
     return "meshvisualizer2d.png";
 }
 
-std::string ShaderVisualizer::meshVisualizer2DPrimitiveId() {
+Containers::StringView ShaderVisualizer::meshVisualizer2DPrimitiveId() {
     const Matrix3 projection =
         Matrix3::projection(Vector2{3.0f})*
         Matrix3::rotation(13.7_degf);
@@ -219,7 +219,7 @@ std::string ShaderVisualizer::meshVisualizer2DPrimitiveId() {
     return "meshvisualizer2d-primitiveid.png";
 }
 
-std::string ShaderVisualizer::meshVisualizer3D() {
+Containers::StringView ShaderVisualizer::meshVisualizer3D() {
     const Matrix4 transformation = Transformation*
         Matrix4::rotationZ(13.7_degf)*
         Matrix4::rotationX(-12.6_degf);
@@ -244,7 +244,7 @@ std::string ShaderVisualizer::meshVisualizer3D() {
     return "meshvisualizer3d.png";
 }
 
-std::string ShaderVisualizer::meshVisualizer3DPrimitiveId() {
+Containers::StringView ShaderVisualizer::meshVisualizer3DPrimitiveId() {
     const Matrix4 transformation = Transformation*
         Matrix4::rotationZ(13.7_degf)*
         Matrix4::rotationX(-12.6_degf);
@@ -271,7 +271,7 @@ std::string ShaderVisualizer::meshVisualizer3DPrimitiveId() {
     return "meshvisualizer3d-primitiveid.png";
 }
 
-std::string ShaderVisualizer::flat() {
+Containers::StringView ShaderVisualizer::flat() {
     Shaders::FlatGL3D{}
         .setColor(BaseColor)
         .setTransformationProjectionMatrix(Projection*Transformation)
@@ -280,7 +280,7 @@ std::string ShaderVisualizer::flat() {
     return "flat.png";
 }
 
-std::string ShaderVisualizer::vertexColor() {
+Containers::StringView ShaderVisualizer::vertexColor() {
     Trade::MeshData sphere = Primitives::uvSphereSolid(32, 64);
 
     /* Add a color attribute */
@@ -303,7 +303,7 @@ std::string ShaderVisualizer::vertexColor() {
     return "vertexcolor.png";
 }
 
-std::string ShaderVisualizer::vector() {
+Containers::StringView ShaderVisualizer::vector() {
     Containers::Optional<Trade::ImageData2D> image;
     if(!_importer->openFile("vector.png") || !(image = _importer->image2D(0))) {
         Error() << "Cannot open vector.png";
@@ -332,7 +332,7 @@ std::string ShaderVisualizer::vector() {
     return "vector.png";
 }
 
-std::string ShaderVisualizer::distanceFieldVector() {
+Containers::StringView ShaderVisualizer::distanceFieldVector() {
     Containers::Optional<Trade::ImageData2D> image;
     if(!_importer->openFile("vector-distancefield.png") || !(image = _importer->image2D(0))) {
         Error() << "Cannot open vector-distancefield.png";

--- a/doc/snippets/MagnumGL.cpp
+++ b/doc/snippets/MagnumGL.cpp
@@ -27,6 +27,8 @@
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/Iterable.h>
 #include <Corrade/Containers/Reference.h>
+#include <Corrade/Containers/StringIterable.h>
+#include <Corrade/Containers/StringView.h>
 #include <Corrade/Containers/Triple.h>
 #include <Corrade/TestSuite/Tester.h>
 

--- a/doc/snippets/MagnumShaders-gl.cpp
+++ b/doc/snippets/MagnumShaders-gl.cpp
@@ -28,7 +28,8 @@
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/Iterable.h>
 #include <Corrade/Containers/Pair.h>
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 
 #include "Magnum/ImageView.h"
 #include "Magnum/PixelFormat.h"
@@ -683,7 +684,7 @@ bindAttributeLocation(Shaders::GenericGL3D::Normal::Location, "normal");
 {
 GL::Shader vert{GL::Version::None, GL::Shader::Type::Vertex};
 /* [GenericGL-custom-preprocessor] */
-vert.addSource(Utility::formatString(
+vert.addSource(Utility::format(
     "#define POSITION_ATTRIBUTE_LOCATION {}\n"
     "#define NORMAL_ATTRIBUTE_LOCATION {}\n",
     Shaders::GenericGL3D::Position::Location,

--- a/doc/snippets/MagnumVk.cpp
+++ b/doc/snippets/MagnumVk.cpp
@@ -23,7 +23,6 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <string>
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/Containers/StringIterable.h>

--- a/doc/snippets/platforms-html5.cpp
+++ b/doc/snippets/platforms-html5.cpp
@@ -23,15 +23,17 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <string>
+#include <Corrade/Containers/String.h>
 #include <emscripten/emscripten.h>
+
+using namespace Corrade;
 
 int main() {
 {
 /* [emasm-dollar] */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
-std::string title;
+Containers::String title;
 EM_ASM_({document.getElementById('title').innerHTML =
     UTF8ToString($0)}, title.data());
 #pragma GCC diagnostic pop

--- a/package/archlinux/PKGBUILD
+++ b/package/archlinux/PKGBUILD
@@ -18,9 +18,12 @@ build() {
     mkdir -p "$_rootdir/build"
     cd "$_rootdir/build"
 
+    # RelWithDebInfo is enabled but not built -- it's meant for profiling from
+    # within the build dir
     cmake .. \
-        -DCMAKE_CONFIGURATION_TYPES="Debug;Release" \
+        -DCMAKE_CONFIGURATION_TYPES="Debug;Release;RelWithDebInfo" \
         -DCMAKE_CROSS_CONFIGS=all \
+        -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g -DNDEBUG -fno-omit-frame-pointer" \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DMAGNUM_WITH_AUDIO=ON \
         -DMAGNUM_WITH_VK=ON \
@@ -57,7 +60,7 @@ build() {
         -DMAGNUM_BUILD_GL_TESTS=ON \
         -DMAGNUM_BUILD_VK_TESTS=ON \
         -G "Ninja Multi-Config"
-    ninja all:all
+    ninja all:Debug all:Release
 }
 
 check() {

--- a/src/Magnum/DebugTools/FrameProfiler.h
+++ b/src/Magnum/DebugTools/FrameProfiler.h
@@ -30,12 +30,19 @@
  * @m_since{2020,06}
  */
 
-#include <string>
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Pointer.h>
+#include <Corrade/Containers/String.h>
 
 #include "Magnum/Magnum.h"
 #include "Magnum/DebugTools/visibility.h"
+
+#ifdef MAGNUM_BUILD_DEPRECATED
+/* Measurement used to take a std::string, measurementName() and statistics()
+   used to be a std::string. Not ideal for the return types, but at least
+   something. */
+#include <Corrade/Containers/StringStl.h>
+#endif
 
 namespace Magnum { namespace DebugTools {
 
@@ -289,9 +296,13 @@ class MAGNUM_DEBUGTOOLS_EXPORT FrameProfiler {
          *
          * The @p id corresponds to the index of the measurement in the list
          * passed to @ref setup(). Expects that @p id is less than
-         * @ref measurementCount().
+         * @ref measurementCount(). The returned view is always
+         * @relativeref{Corrade,Containers::StringViewFlag::NullTerminated};
+         * @relativeref{Corrade,Containers::StringViewFlag::Global} is set if
+         * the corresponding @ref Measurement was created with a global
+         * null-terminated string view.
          */
-        std::string measurementName(UnsignedInt id) const;
+        Containers::StringView measurementName(UnsignedInt id) const;
 
         /**
          * @brief Measurement units
@@ -359,7 +370,7 @@ class MAGNUM_DEBUGTOOLS_EXPORT FrameProfiler {
          * is not available yet, prints placeholder values for these.
          * @see @ref isMeasurementAvailable(), @ref isEnabled()
          */
-        std::string statistics() const;
+        Containers::String statistics() const;
 
         /**
          * @brief Print an overview of all measurements to a console at given rate
@@ -427,8 +438,12 @@ class MAGNUM_DEBUGTOOLS_EXPORT FrameProfiler::Measurement {
          *      the measured value
          * @param state     State pointer passed to both @p begin and @p end
          *      as a first argument
+         *
+         * If @p name is @relativeref{Corrade,Containers::StringViewFlag::NullTerminated}
+         * and @relativeref{Corrade::Containers::StringViewFlag,Global}, no
+         * internal copy of the string is made.
          */
-        explicit Measurement(const std::string& name, Units units, void(*begin)(void*), UnsignedLong(*end)(void*), void* state);
+        explicit Measurement(Containers::StringView name, Units units, void(*begin)(void*), UnsignedLong(*end)(void*), void* state);
 
         /**
          * @brief Construct a delayed measurement
@@ -458,13 +473,17 @@ class MAGNUM_DEBUGTOOLS_EXPORT FrameProfiler::Measurement {
          *      corresponds to current frame.
          * @param state     State pointer passed to both @p begin and @p end
          *      as a first argument
+         *
+         * If @p name is @relativeref{Corrade,Containers::StringViewFlag::NullTerminated}
+         * and @relativeref{Corrade::Containers::StringViewFlag,Global}, no
+         * internal copy of the string is made.
          */
-        explicit Measurement(const std::string& name, Units units, UnsignedInt delay, void(*begin)(void*, UnsignedInt), void(*end)(void*, UnsignedInt), UnsignedLong(*query)(void*, UnsignedInt, UnsignedInt), void* state);
+        explicit Measurement(Containers::StringView name, Units units, UnsignedInt delay, void(*begin)(void*, UnsignedInt), void(*end)(void*, UnsignedInt), UnsignedLong(*query)(void*, UnsignedInt, UnsignedInt), void* state);
 
     private:
         friend FrameProfiler;
 
-        std::string _name;
+        Containers::String _name;
         union {
             void(*immediate)(void*);
             void(*delayed)(void*, UnsignedInt);
@@ -733,16 +752,18 @@ template<> struct MAGNUM_DEBUGTOOLS_EXPORT ConfigurationValue<Magnum::DebugTools
     /**
      * @brief Writes enum value as a string
      *
-     * If the value is invalid, returns an empty string.
+     * If the value is invalid, returns an empty string. The returned view is
+     * always @relativeref{Corrade,Containers::StringViewFlag::NullTerminated}
+     * and @relativeref{Corrade,Containers::StringViewFlag::Global}.
      */
-    static std::string toString(Magnum::DebugTools::FrameProfilerGL::Value value, ConfigurationValueFlags);
+    static Containers::StringView toString(Magnum::DebugTools::FrameProfilerGL::Value value, ConfigurationValueFlags);
 
     /**
      * @brief Reads enum value as a string
      *
      * If the string is invalid, returns a zero (invalid) value.
      */
-    static Magnum::DebugTools::FrameProfilerGL::Value fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::DebugTools::FrameProfilerGL::Value fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 /**
@@ -758,7 +779,7 @@ template<> struct MAGNUM_DEBUGTOOLS_EXPORT ConfigurationValue<Magnum::DebugTools
      * Writes the enum set as a sequence of flag names separated by spaces. If
      * the value is invalid, returns an empty string.
      */
-    static std::string toString(Magnum::DebugTools::FrameProfilerGL::Values value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::DebugTools::FrameProfilerGL::Values value, ConfigurationValueFlags);
 
     /**
      * @brief Reads enum set value as a string
@@ -766,7 +787,7 @@ template<> struct MAGNUM_DEBUGTOOLS_EXPORT ConfigurationValue<Magnum::DebugTools
      * Assumes the string is a sequence of flag names separated by spaces. If
      * the value is invalid, returns an empty set.
      */
-    static Magnum::DebugTools::FrameProfilerGL::Values fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::DebugTools::FrameProfilerGL::Values fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 #endif
 

--- a/src/Magnum/DebugTools/Screenshot.cpp
+++ b/src/Magnum/DebugTools/Screenshot.cpp
@@ -26,9 +26,8 @@
 #include "Screenshot.h"
 
 #include <Corrade/Containers/Optional.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/StringView.h>
 #include <Corrade/PluginManager/Manager.h>
-#include <Corrade/Utility/DebugStl.h>
 
 #include "Magnum/PixelFormat.h"
 #include "Magnum/Image.h"
@@ -39,12 +38,12 @@
 
 namespace Magnum { namespace DebugTools {
 
-bool screenshot(GL::AbstractFramebuffer& framebuffer, const std::string& filename) {
+bool screenshot(GL::AbstractFramebuffer& framebuffer, const Containers::StringView filename) {
     PluginManager::Manager<Trade::AbstractImageConverter> manager;
     return screenshot(manager, framebuffer, filename);
 }
 
-bool screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, const std::string& filename) {
+bool screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, const Containers::StringView filename) {
     /* Get the implementation-specific color read format for given framebuffer */
     const GL::PixelFormat format = framebuffer.implementationColorReadFormat();
     const GL::PixelType type = framebuffer.implementationColorReadType();
@@ -68,12 +67,12 @@ bool screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, 
     return screenshot(manager, framebuffer, *genericFormat, filename);
 }
 
-bool screenshot(GL::AbstractFramebuffer& framebuffer, const PixelFormat format, const std::string& filename) {
+bool screenshot(GL::AbstractFramebuffer& framebuffer, const PixelFormat format, const Containers::StringView filename) {
     PluginManager::Manager<Trade::AbstractImageConverter> manager;
     return screenshot(manager, framebuffer, format, filename);
 }
 
-bool screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, const PixelFormat format, const std::string& filename) {
+bool screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, const PixelFormat format, const Containers::StringView filename) {
     Containers::Pointer<Trade::AbstractImageConverter> converter;
     if(!(converter = manager.loadAndInstantiate("AnyImageConverter")))
         return false;

--- a/src/Magnum/DebugTools/Screenshot.h
+++ b/src/Magnum/DebugTools/Screenshot.h
@@ -29,13 +29,17 @@
  * @brief Function @ref Magnum::DebugTools::screenshot()
  */
 
-#include <string>
 #include <Corrade/PluginManager/PluginManager.h>
 
 #include "Magnum/Magnum.h"
 #include "Magnum/DebugTools/visibility.h"
 #include "Magnum/GL/GL.h"
 #include "Magnum/Trade/Trade.h"
+
+#ifdef MAGNUM_BUILD_DEPRECATED
+/* The filename used to be a std::string */
+#include <Corrade/Containers/StringStl.h>
+#endif
 
 namespace Magnum { namespace DebugTools {
 
@@ -51,7 +55,7 @@ using @ref GL::AbstractFramebuffer::implementationColorReadFormat() and
 @ref GL::AbstractFramebuffer::implementationColorReadType() and then mapped
 back to the generic @ref Magnum::PixelFormat "PixelFormat". If, for some
 reason, the driver-suggested pixel format is not desired, use the
-@ref screenshot(GL::AbstractFramebuffer&, PixelFormat, const std::string&)
+@ref screenshot(GL::AbstractFramebuffer&, PixelFormat, Containers::StringView)
 overload instead.
 
 The read pixel data are saved using the
@@ -66,7 +70,7 @@ map the detected pixel format back to a generic format, if either the
 for given file format could not be loaded, or if the file saving fails (for
 example due to unsupported pixel format). A message is printed in each case.
 */
-bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(GL::AbstractFramebuffer& framebuffer, const std::string& filename);
+bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(GL::AbstractFramebuffer& framebuffer, Containers::StringView filename);
 
 /** @overload
 @m_since{2019,10}
@@ -75,7 +79,7 @@ Useful in case you already have an instance of the converter plugin manager in
 your application or if you intend to save screenshots often, as the operation
 doesn't involve costly dynamic library loading and unloading on every call.
 */
-bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, const std::string& filename);
+bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, Containers::StringView filename);
 
 /**
 @brief Save a screenshot in requested pixel format to a file
@@ -84,12 +88,12 @@ bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(PluginManager::Manager<Trade::AbstractI
 @param filename     File where to save
 @m_since{2019,10}
 
-Similar to @ref screenshot(GL::AbstractFramebuffer&, PixelFormat, const std::string&)
+Similar to @ref screenshot(GL::AbstractFramebuffer&, PixelFormat, Containers::StringView)
 but with an explicit pixel format. Useful in cases where the driver-suggested
 pixel format is not desired, however note that supplying a format that's
 incompatible with the framebuffer may result in GL errors.
 */
-bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(GL::AbstractFramebuffer& framebuffer, PixelFormat format, const std::string& filename);
+bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(GL::AbstractFramebuffer& framebuffer, PixelFormat format, Containers::StringView filename);
 
 /** @overload
 @m_since{2019,10}
@@ -98,7 +102,7 @@ Useful in case you already have an instance of the converter plugin manager in
 your application or if you intend to save screenshots often, as the operation
 doesn't involve costly dynamic library loading and unloading on every call.
 */
-bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, PixelFormat format, const std::string& filename);
+bool MAGNUM_DEBUGTOOLS_EXPORT screenshot(PluginManager::Manager<Trade::AbstractImageConverter>& manager, GL::AbstractFramebuffer& framebuffer, PixelFormat format, Containers::StringView filename);
 
 }}
 

--- a/src/Magnum/DebugTools/Test/FrameProfilerGLTest.cpp
+++ b/src/Magnum/DebugTools/Test/FrameProfilerGLTest.cpp
@@ -124,6 +124,7 @@ void FrameProfilerGLTest::test() {
     CORRADE_COMPARE(profiler.maxFrameCount(), 4);
 
     /* MSVC 2015 needs the {} */
+    UnsignedInt i = 0;
     for(auto value: {FrameProfilerGL::Value::CpuDuration,
                      FrameProfilerGL::Value::GpuDuration,
                      #ifndef MAGNUM_TARGET_GLES
@@ -131,8 +132,11 @@ void FrameProfilerGLTest::test() {
                      FrameProfilerGL::Value::PrimitiveClipRatio
                      #endif
                      }) {
-        if(data.values & value)
-            CORRADE_VERIFY(!profiler.isMeasurementAvailable(value));
+        if(!(data.values & value)) continue;
+
+        CORRADE_VERIFY(!profiler.isMeasurementAvailable(value));
+        /* The names should not be allocated */
+        CORRADE_COMPARE(profiler.measurementName(i++).flags(), Containers::StringViewFlag::NullTerminated|Containers::StringViewFlag::Global);
     }
 
     profiler.beginFrame();

--- a/src/Magnum/DebugTools/Test/ScreenshotGLTest.cpp
+++ b/src/Magnum/DebugTools/Test/ScreenshotGLTest.cpp
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <Corrade/Containers/ScopeGuard.h>
 #include <Corrade/Containers/String.h>
-#include <Corrade/Containers/StringStl.h> /** @todo remove when screenshot() is <string>-free */
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/FormatStl.h>

--- a/src/Magnum/DebugTools/TextureImage.cpp
+++ b/src/Magnum/DebugTools/TextureImage.cpp
@@ -37,7 +37,6 @@
 #if defined(MAGNUM_TARGET_GLES) && !defined(MAGNUM_TARGET_GLES2)
 #include <Corrade/Containers/Iterable.h>
 #include <Corrade/Containers/Reference.h>
-#include <Corrade/Containers/StringStl.h> /** @todo remove once GL::Shader is <string>-free */
 #include <Corrade/Utility/Resource.h>
 
 #include "Magnum/GL/AbstractShaderProgram.h"

--- a/src/Magnum/DebugTools/TextureImage.cpp
+++ b/src/Magnum/DebugTools/TextureImage.cpp
@@ -56,6 +56,8 @@ static void importDebugToolsResources() {
 namespace Magnum { namespace DebugTools {
 
 #if defined(MAGNUM_TARGET_GLES) && !defined(MAGNUM_TARGET_GLES2)
+using namespace Containers::Literals;
+
 namespace {
 
 class FloatReinterpretShader: public GL::AbstractShaderProgram {
@@ -75,7 +77,7 @@ class FloatReinterpretShader: public GL::AbstractShaderProgram {
 FloatReinterpretShader::FloatReinterpretShader() {
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumDebugTools"))
+    if(!Utility::Resource::hasGroup("MagnumDebugTools"_s))
         importDebugToolsResources();
     #endif
     Utility::Resource rs{"MagnumDebugTools"};
@@ -83,21 +85,21 @@ FloatReinterpretShader::FloatReinterpretShader() {
     GL::Shader vert{GL::Version::GLES300, GL::Shader::Type::Vertex};
     GL::Shader frag{GL::Version::GLES300, GL::Shader::Type::Fragment};
     if(!GL::Context::current().isExtensionSupported<GL::Extensions::MAGNUM::shader_vertex_id>())
-        vert.addSource("#define DISABLE_GL_MAGNUM_shader_vertex_id\n");
-    vert.addSource(rs.getString("TextureImage.vert"));
-    frag.addSource(rs.getString("TextureImage.frag"));
+        vert.addSource("#define DISABLE_GL_MAGNUM_shader_vertex_id\n"_s);
+    vert.addSource(rs.getString("TextureImage.vert"_s));
+    frag.addSource(rs.getString("TextureImage.frag"_s));
 
     CORRADE_INTERNAL_ASSERT_OUTPUT(vert.compile() && frag.compile());
     attachShaders({vert, frag});
 
     if(!GL::Context::current().isExtensionSupported<GL::Extensions::MAGNUM::shader_vertex_id>()) {
-        bindAttributeLocation(0, "position");
+        bindAttributeLocation(0, "position"_s);
     }
 
     CORRADE_INTERNAL_ASSERT_OUTPUT(link());
 
-    levelUniform = uniformLocation("level");
-    setUniform(uniformLocation("textureData"), 0);
+    levelUniform = uniformLocation("level"_s);
+    setUniform(uniformLocation("textureData"_s), 0);
 }
 
 }

--- a/src/Magnum/DebugTools/resources.conf
+++ b/src/Magnum/DebugTools/resources.conf
@@ -1,4 +1,5 @@
 group=MagnumDebugTools
+nullTerminated=true
 
 [file]
 filename=TextureImage.vert

--- a/src/Magnum/GL/AbstractShaderProgram.cpp
+++ b/src/Magnum/GL/AbstractShaderProgram.cpp
@@ -34,7 +34,9 @@
 #include <Corrade/Containers/String.h>
 #endif
 #include <Corrade/Containers/StringStl.h> /** @todo remove once <string>-free */
+#ifdef MAGNUM_BUILD_DEPRECATED
 #include <Corrade/Containers/Reference.h>
+#endif
 #include <Corrade/Utility/DebugStl.h>
 
 #include "Magnum/GL/Context.h"

--- a/src/Magnum/GL/AbstractShaderProgram.cpp
+++ b/src/Magnum/GL/AbstractShaderProgram.cpp
@@ -38,6 +38,7 @@
 #include <Corrade/Containers/Reference.h>
 #endif
 #include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/String.h>
 
 #include "Magnum/GL/Context.h"
 #include "Magnum/GL/Extensions.h"
@@ -357,7 +358,11 @@ std::pair<bool, std::string> AbstractShaderProgram::validate() {
         glGetProgramInfoLog(_id, message.size(), nullptr, &message[0]);
     message.resize(Math::max(logLength, 1)-1);
 
-    return {success, std::move(message)};
+    /* On some drivers (such as SwiftShader) the message contains a newline at
+       the end, on some (such as Mesa) it doesn't. Same as with link() or
+       compile() message trimming it doesn't make sense to add driver-specific
+       workarounds for this, so just trim it always. */
+    return {success, Utility::String::trim(std::move(message))};
 }
 
 AbstractShaderProgram& AbstractShaderProgram::draw(Mesh& mesh) {

--- a/src/Magnum/GL/AbstractShaderProgram.cpp
+++ b/src/Magnum/GL/AbstractShaderProgram.cpp
@@ -29,6 +29,7 @@
 
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Iterable.h>
+#include <Corrade/Containers/Pair.h>
 #ifdef MAGNUM_BUILD_DEPRECATED
 #include <Corrade/Containers/Reference.h>
 #endif
@@ -339,7 +340,7 @@ AbstractShaderProgram& AbstractShaderProgram::setLabel(const Containers::StringV
 }
 #endif
 
-std::pair<bool, Containers::String> AbstractShaderProgram::validate() {
+Containers::Pair<bool, Containers::String> AbstractShaderProgram::validate() {
     glValidateProgram(_id);
 
     /* Check validation status */
@@ -361,7 +362,7 @@ std::pair<bool, Containers::String> AbstractShaderProgram::validate() {
     /** @todo this allocates a new string, revisit once String is capable of
         trimming in-place, e.g. `std::move(message).trimmed()` would just
         shift the data around */
-    return {success, message.trimmed()};
+    return {bool(success), message.trimmed()};
 }
 
 AbstractShaderProgram& AbstractShaderProgram::draw(Mesh& mesh) {

--- a/src/Magnum/GL/AbstractShaderProgram.h
+++ b/src/Magnum/GL/AbstractShaderProgram.h
@@ -834,7 +834,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          *      @def_gl{VALIDATE_STATUS}, @def_gl{INFO_LOG_LENGTH},
          *      @fn_gl_keyword{GetProgramInfoLog}
          */
-        std::pair<bool, Containers::String> validate();
+        Containers::Pair<bool, Containers::String> validate();
 
         /**
          * @brief Draw a mesh

--- a/src/Magnum/GL/AbstractShaderProgram.h
+++ b/src/Magnum/GL/AbstractShaderProgram.h
@@ -36,7 +36,6 @@
 
 #include "Magnum/Tags.h"
 #include "Magnum/GL/AbstractObject.h"
-#include "Magnum/GL/Attribute.h"
 #include "Magnum/GL/GL.h"
 
 #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_GLES2)

--- a/src/Magnum/GL/Buffer.cpp
+++ b/src/Magnum/GL/Buffer.cpp
@@ -603,9 +603,7 @@ void Buffer::textureWorkaroundAppleBefore() {
 
         /* Unbind the texture, reset state tracker */
         glBindTexture(GL_TEXTURE_BUFFER, 0);
-        /* libstdc++ since GCC 6.3 can't handle just = {} (ambiguous overload
-           of operator=) */
-        textureState.bindings[textureUnit] = std::pair<GLenum, GLuint>{};
+        textureState.bindings[textureUnit] = {};
         textureState.bufferTextureBound.set(textureUnit, false);
     }
 }

--- a/src/Magnum/GL/CMakeLists.txt
+++ b/src/Magnum/GL/CMakeLists.txt
@@ -150,7 +150,8 @@ if(NOT MAGNUM_TARGET_WEBGL)
     list(APPEND MagnumGL_SRCS
         DebugOutput.cpp
 
-        Implementation/DebugState.cpp)
+        Implementation/DebugState.cpp
+        Implementation/defaultDebugCallback.h)
 
     list(APPEND MagnumGL_HEADERS
         DebugOutput.h)

--- a/src/Magnum/GL/CMakeLists.txt
+++ b/src/Magnum/GL/CMakeLists.txt
@@ -101,10 +101,12 @@ set(MagnumGL_HEADERS
 set(MagnumGL_PRIVATE_HEADERS
     Implementation/BufferState.h
     Implementation/ContextState.h
+    Implementation/compressedPixelFormatMapping.hpp
     Implementation/FramebufferState.h
     Implementation/maxTextureSize.h
     Implementation/MeshState.h
     Implementation/QueryState.h
+    Implementation/pixelFormatMapping.hpp
     Implementation/RendererState.h
     Implementation/ShaderProgramState.h
     Implementation/ShaderState.h

--- a/src/Magnum/GL/Context.cpp
+++ b/src/Magnum/GL/Context.cpp
@@ -994,7 +994,7 @@ bool Context::tryCreate(const Configuration& configuration) {
     if(!_driverWorkarounds.isEmpty()) {
         Debug{output} << "Using driver workarounds:";
         for(const auto& workaround: _driverWorkarounds)
-            if(!workaround.second) Debug(output) << "   " << workaround.first;
+            if(!workaround.second()) Debug(output) << "   " << workaround.first();
     }
 
     /* Fetch default framebuffer size and set up default clear color. If we are

--- a/src/Magnum/GL/Context.cpp
+++ b/src/Magnum/GL/Context.cpp
@@ -28,6 +28,7 @@
 #include <algorithm> /* std::lower_bound() */
 #include <Corrade/Containers/EnumSet.hpp>
 #include <Corrade/Containers/GrowableArray.h>
+#include <Corrade/Containers/Reference.h>
 #include <Corrade/Containers/StringIterable.h>
 #include <Corrade/Utility/Arguments.h>
 #include <Corrade/Utility/Debug.h>
@@ -985,9 +986,9 @@ bool Context::tryCreate(const Configuration& configuration) {
             Debug{output} << "   " << extension.string();
     }
 
-    std::pair<Containers::ArrayTuple, Implementation::State&> state = Implementation::State::allocate(*this, output);
-    _stateData = std::move(state.first);
-    _state = &state.second;
+    Containers::Pair<Containers::ArrayTuple, Containers::Reference<Implementation::State>> state = Implementation::State::allocate(*this, output);
+    _stateData = std::move(state.first());
+    _state = &*state.second();
 
     /* Print a list of used workarounds */
     if(!_driverWorkarounds.isEmpty()) {

--- a/src/Magnum/GL/Context.h
+++ b/src/Magnum/GL/Context.h
@@ -915,7 +915,7 @@ class MAGNUM_GL_EXPORT Context {
             then can be discarded -- what to do? we could avoid including
             Array altogether */
         /* True means known and disabled, false means known */
-        Containers::Array<std::pair<Containers::StringView, bool>> _driverWorkarounds;
+        Containers::Array<Containers::Pair<Containers::StringView, bool>> _driverWorkarounds;
         Containers::Array<Extension> _disabledExtensions;
         Implementation::ContextConfigurationFlags _configurationFlags;
 };

--- a/src/Magnum/GL/DebugOutput.cpp
+++ b/src/Magnum/GL/DebugOutput.cpp
@@ -145,7 +145,8 @@ Int DebugOutput::maxMessageLength() {
 }
 
 void DebugOutput::setCallback(const Callback callback, const void* userParam) {
-    Context::current().state().debug.callbackImplementation(callback, userParam);
+    Context::current().state().debug.messageCallback.userParam = userParam;
+    Context::current().state().debug.callbackImplementation(callback);
 }
 
 void DebugOutput::setDefaultCallback() {
@@ -172,38 +173,38 @@ void DebugOutput::controlImplementationKhrES(const GLenum source, const GLenum t
 }
 #endif
 
-void DebugOutput::callbackImplementationNoOp(Callback, const void*) {}
+void DebugOutput::callbackImplementationNoOp(Callback) {}
 
 #ifndef MAGNUM_TARGET_GLES2
-void DebugOutput::callbackImplementationKhrDesktopES32(const Callback callback, const void* userParam) {
+void DebugOutput::callbackImplementationKhrDesktopES32(const Callback callback) {
     /* Replace the callback */
-    const Callback original = Context::current().state().debug.messageCallback.callback;
+    const bool setPreviously = !!Context::current().state().debug.messageCallback.callback;
+
     Context::current().state().debug.messageCallback.callback = callback;
-    Context::current().state().debug.messageCallback.userParam = userParam;
 
     /* Adding callback */
-    if(!original && callback)
+    if(!setPreviously && callback)
         glDebugMessageCallback(callbackWrapper,  &Context::current().state().debug.messageCallback);
 
     /* Deleting callback */
-    else if(original && !callback)
+    else if(setPreviously && !callback)
         glDebugMessageCallback(nullptr, nullptr);
 }
 #endif
 
 #ifdef MAGNUM_TARGET_GLES
-void DebugOutput::callbackImplementationKhrES(const Callback callback, const void* userParam) {
+void DebugOutput::callbackImplementationKhrES(const Callback callback) {
     /* Replace the callback */
-    const Callback original = Context::current().state().debug.messageCallback.callback;
+    const bool setPreviously = !!Context::current().state().debug.messageCallback.callback;
+
     Context::current().state().debug.messageCallback.callback = callback;
-    Context::current().state().debug.messageCallback.userParam = userParam;
 
     /* Adding callback */
-    if(!original && callback)
+    if(!setPreviously && callback)
         glDebugMessageCallbackKHR(callbackWrapper, &Context::current().state().debug.messageCallback);
 
     /* Deleting callback */
-    else if(original && !callback)
+    else if(setPreviously && !callback)
         glDebugMessageCallbackKHR(nullptr, nullptr);
 }
 #endif

--- a/src/Magnum/GL/DebugOutput.h
+++ b/src/Magnum/GL/DebugOutput.h
@@ -422,12 +422,12 @@ class MAGNUM_GL_EXPORT DebugOutput {
         static MAGNUM_GL_LOCAL void controlImplementationKhrES(GLenum source, GLenum type, GLenum severity, std::initializer_list<UnsignedInt> ids, bool enabled);
         #endif
 
-        static MAGNUM_GL_LOCAL void callbackImplementationNoOp(Callback, const void*);
+        static MAGNUM_GL_LOCAL void callbackImplementationNoOp(Callback callback);
         #ifndef MAGNUM_TARGET_GLES2
-        static MAGNUM_GL_LOCAL void callbackImplementationKhrDesktopES32(Callback callback, const void* userParam);
+        static MAGNUM_GL_LOCAL void callbackImplementationKhrDesktopES32(Callback callback);
         #endif
         #ifdef MAGNUM_TARGET_GLES
-        static MAGNUM_GL_LOCAL void callbackImplementationKhrES(Callback callback, const void* userParam);
+        static MAGNUM_GL_LOCAL void callbackImplementationKhrES(Callback callback);
         #endif
 };
 

--- a/src/Magnum/GL/Implementation/DebugState.h
+++ b/src/Magnum/GL/Implementation/DebugState.h
@@ -42,7 +42,7 @@ struct DebugState {
 
     void(*messageInsertImplementation)(DebugMessage::Source, DebugMessage::Type, UnsignedInt, DebugOutput::Severity, Containers::ArrayView<const char>);
     void(*controlImplementation)(GLenum, GLenum, GLenum, std::initializer_list<UnsignedInt>, bool);
-    void(*callbackImplementation)(DebugOutput::Callback, const void*);
+    void(*callbackImplementation)(DebugOutput::Callback);
     void(*pushGroupImplementation)(DebugGroup::Source, UnsignedInt, Containers::ArrayView<const char>);
     void(*popGroupImplementation)();
 

--- a/src/Magnum/GL/Implementation/DebugState.h
+++ b/src/Magnum/GL/Implementation/DebugState.h
@@ -40,16 +40,20 @@ struct DebugState {
     Containers::String(*getLabelImplementation)(GLenum, GLuint);
     void(*labelImplementation)(GLenum, GLuint, Containers::StringView);
 
-    void(*messageInsertImplementation)(DebugMessage::Source, DebugMessage::Type, UnsignedInt, DebugOutput::Severity, Containers::ArrayView<const char>);
+    void(*messageInsertImplementation)(DebugMessage::Source, DebugMessage::Type, UnsignedInt, DebugOutput::Severity, Containers::StringView);
     void(*controlImplementation)(GLenum, GLenum, GLenum, std::initializer_list<UnsignedInt>, bool);
     void(*callbackImplementation)(DebugOutput::Callback);
-    void(*pushGroupImplementation)(DebugGroup::Source, UnsignedInt, Containers::ArrayView<const char>);
+    void(*pushGroupImplementation)(DebugGroup::Source, UnsignedInt, Containers::StringView);
     void(*popGroupImplementation)();
 
     GLint maxLabelLength, maxLoggedMessages, maxMessageLength, maxStackDepth;
     struct MessageCallback {
         DebugOutput::Callback callback{};
         const void* userParam{};
+        #ifdef MAGNUM_BUILD_DEPRECATED
+        void(*callbackStlString)(DebugOutput::Source, DebugOutput::Type, UnsignedInt, DebugOutput::Severity, const std::string&, const void*);
+        const void* userParamStlString{};
+        #endif
     } messageCallback;
 };
 

--- a/src/Magnum/GL/Implementation/ShaderProgramState.h
+++ b/src/Magnum/GL/Implementation/ShaderProgramState.h
@@ -27,8 +27,6 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <Corrade/Utility/StlForwardString.h>
-
 #include "Magnum/Magnum.h"
 #include "Magnum/GL/GL.h"
 #include "Magnum/GL/OpenGL.h"
@@ -46,9 +44,9 @@ struct ShaderProgramState {
     void reset();
 
     #ifndef MAGNUM_TARGET_GLES2
-    void(AbstractShaderProgram::*transformFeedbackVaryingsImplementation)(Containers::ArrayView<const std::string>, AbstractShaderProgram::TransformFeedbackBufferMode);
+    void(AbstractShaderProgram::*transformFeedbackVaryingsImplementation)(const Containers::StringIterable&, AbstractShaderProgram::TransformFeedbackBufferMode);
     #endif
-    void(*cleanLogImplementation)(std::string&);
+    void(*cleanLogImplementation)(Containers::String&);
     /* This is a direct pointer to a GL function, so needs a __stdcall on
        Windows to compile properly on 32 bits */
     void(APIENTRY *completionStatusImplementation)(GLuint, GLenum, GLint* value);

--- a/src/Magnum/GL/Implementation/ShaderState.h
+++ b/src/Magnum/GL/Implementation/ShaderState.h
@@ -26,8 +26,6 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <Corrade/Utility/StlForwardString.h>
-
 #include "Magnum/Magnum.h"
 #include "Magnum/GL/GL.h"
 #include "Magnum/GL/OpenGL.h"
@@ -52,8 +50,8 @@ struct ShaderState {
         #endif
     };
 
-    void(Shader::*addSourceImplementation)(std::string);
-    void(*cleanLogImplementation)(std::string&);
+    void(Shader::*addSourceImplementation)(Containers::String&&);
+    void(*cleanLogImplementation)(Containers::String&);
     /* This is a direct pointer to a GL function, so needs a __stdcall on
        Windows to compile properly on 32 bits */
     void(APIENTRY *completionStatusImplementation)(GLuint, GLenum, GLint* value);

--- a/src/Magnum/GL/Implementation/State.cpp
+++ b/src/Magnum/GL/Implementation/State.cpp
@@ -27,6 +27,7 @@
 
 #include <Corrade/Containers/ArrayTuple.h>
 #include <Corrade/Containers/Pair.h>
+#include <Corrade/Containers/Reference.h>
 #include <Corrade/Utility/Assert.h>
 
 #include "Magnum/GL/Context.h"
@@ -49,7 +50,7 @@
 
 namespace Magnum { namespace GL { namespace Implementation {
 
-std::pair<Containers::ArrayTuple, State&> State::allocate(Context& context, std::ostream* const out) {
+Containers::Pair<Containers::ArrayTuple, Containers::Reference<State>> State::allocate(Context& context, std::ostream* const out) {
     /* TextureState needs to track state per texture / image binding, fetch
        how many of them is there and allocate here as well so we don't need to
        do another nested allocation */

--- a/src/Magnum/GL/Implementation/State.cpp
+++ b/src/Magnum/GL/Implementation/State.cpp
@@ -26,6 +26,7 @@
 #include "State.h"
 
 #include <Corrade/Containers/ArrayTuple.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Utility/Assert.h>
 
 #include "Magnum/GL/Context.h"
@@ -83,7 +84,7 @@ std::pair<Containers::ArrayTuple, State&> State::allocate(Context& context, std:
     Containers::ArrayView<ShaderState> shaderStateView;
     Containers::ArrayView<ShaderProgramState> shaderProgramStateView;
     Containers::ArrayView<TextureState> textureStateView;
-    Containers::ArrayView<std::pair<GLenum, GLuint>> textureBindings;
+    Containers::ArrayView<Containers::Pair<GLenum, GLuint>> textureBindings;
     #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
     Containers::ArrayView<TextureState::ImageBinding> imageBindings;
     #endif

--- a/src/Magnum/GL/Implementation/State.h
+++ b/src/Magnum/GL/Implementation/State.h
@@ -26,7 +26,6 @@
 */
 
 #include <iosfwd>
-#include <utility>
 #include <Corrade/Containers/Containers.h>
 
 #include "Magnum/Magnum.h"
@@ -53,7 +52,7 @@ struct TransformFeedbackState;
 struct State {
     /* Initializes context-based functionality together with all nested classes
        in a single allocation */
-    static std::pair<Containers::ArrayTuple, State&> allocate(Context& context, std::ostream* out);
+    static Containers::Pair<Containers::ArrayTuple, Containers::Reference<State>> allocate(Context& context, std::ostream* out);
 
     enum: GLuint { DisengagedBinding = ~0u };
 

--- a/src/Magnum/GL/Implementation/TextureState.cpp
+++ b/src/Magnum/GL/Implementation/TextureState.cpp
@@ -43,7 +43,7 @@ namespace Magnum { namespace GL { namespace Implementation {
 using namespace Containers::Literals;
 
 TextureState::TextureState(Context& context,
-    Containers::ArrayView<std::pair<GLenum, GLuint>> bindings,
+    Containers::ArrayView<Containers::Pair<GLenum, GLuint>> bindings,
     #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
     Containers::ArrayView<ImageBinding> imageBindings,
     #endif
@@ -547,7 +547,7 @@ TextureState::TextureState(Context& context,
 }
 
 void TextureState::reset() {
-    for(std::pair<GLenum, GLuint>& i: bindings)
+    for(Containers::Pair<GLenum, GLuint>& i: bindings)
         i = {{}, State::DisengagedBinding};
     #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
     for(ImageBinding& i: imageBindings)

--- a/src/Magnum/GL/Implementation/TextureState.h
+++ b/src/Magnum/GL/Implementation/TextureState.h
@@ -25,7 +25,7 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <utility> /* std::pair */
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/ArrayView.h>
 
 #include "Magnum/Magnum.h"
@@ -74,7 +74,7 @@ struct TextureState {
     #endif
 
     explicit TextureState(Context& context,
-        Containers::ArrayView<std::pair<GLenum, GLuint>> bindings,
+        Containers::ArrayView<Containers::Pair<GLenum, GLuint>> bindings,
         #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
         Containers::ArrayView<ImageBinding> imageBindings,
         #endif
@@ -187,7 +187,7 @@ struct TextureState {
     /* Texture type, texture object ID. While not true, for simplicity this
        assumes that each slot can have just one ID bound, not one ID per
        texture type. */
-    Containers::ArrayView<std::pair<GLenum, GLuint>> bindings;
+    Containers::ArrayView<Containers::Pair<GLenum, GLuint>> bindings;
     #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
     Math::BitVector<80> bufferTextureBound;
     #endif

--- a/src/Magnum/GL/Implementation/defaultDebugCallback.h
+++ b/src/Magnum/GL/Implementation/defaultDebugCallback.h
@@ -1,0 +1,46 @@
+#ifndef Magnum_GL_Implementation_defaultDebugCallback_h
+#define Magnum_GL_Implementation_defaultDebugCallback_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021, 2022 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Magnum/configure.h"
+
+#ifndef MAGNUM_TARGET_WEBGL
+#include <iosfwd>
+
+#include "Magnum/GL/DebugOutput.h"
+
+namespace Magnum { namespace GL { namespace Implementation {
+
+/* Exposed just for testing; not included in DebugOutput.h to avoid having to
+   include <iosfwd> there */
+MAGNUM_GL_EXPORT void defaultDebugCallback(DebugOutput::Source source, DebugOutput::Type type, UnsignedInt id, DebugOutput::Severity severity, Containers::StringView string, std::ostream* output);
+
+}}}
+#else
+#error this header is not available in WebGL build
+#endif
+
+#endif

--- a/src/Magnum/GL/Implementation/driverSpecific.cpp
+++ b/src/Magnum/GL/Implementation/driverSpecific.cpp
@@ -24,6 +24,7 @@
 */
 
 #include <Corrade/Containers/GrowableArray.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/StringView.h>
 #include <Corrade/Containers/StringIterable.h>
 
@@ -612,7 +613,7 @@ bool Context::isDriverWorkaroundDisabled(const Containers::StringView workaround
        compare just data pointers instead of the whole string as we store only
        the views in the KnownWorkarounds list. */
     for(const auto& i: _driverWorkarounds)
-        if(i.first.data() == found.data()) return i.second;
+        if(i.first().data() == found.data()) return i.second();
     arrayAppend(_driverWorkarounds, InPlaceInit, found, false);
     return false;
 }

--- a/src/Magnum/GL/OpenGLTester.cpp
+++ b/src/Magnum/GL/OpenGLTester.cpp
@@ -25,8 +25,6 @@
 
 #include "OpenGLTester.h"
 
-#include <string>
-
 #include "Magnum/GL/Context.h"
 #include "Magnum/GL/Extensions.h"
 #ifndef MAGNUM_TARGET_WEBGL

--- a/src/Magnum/GL/Test/AbstractShaderProgramGLTest.cpp
+++ b/src/Magnum/GL/Test/AbstractShaderProgramGLTest.cpp
@@ -26,6 +26,7 @@
 
 #include <sstream>
 #include <Corrade/Containers/Iterable.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/Reference.h>
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Containers/StringStl.h> /* StringHasPrefix / StringHasSuffix */
@@ -350,7 +351,7 @@ void AbstractShaderProgramGLTest::create() {
 
     program.bindAttributeLocation(0, data.positionName);
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
@@ -425,7 +426,7 @@ void AbstractShaderProgramGLTest::createAsync() {
 
     CORRADE_VERIFY(program.checkLink({vert, frag}));
     CORRADE_VERIFY(program.isLinkFinished());
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     {
@@ -492,7 +493,7 @@ void AbstractShaderProgramGLTest::createMultipleOutputs() {
     program.bindFragmentDataLocation(0, data.firstName);
     program.bindFragmentDataLocation(1, data.secondName);
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
@@ -554,7 +555,7 @@ void AbstractShaderProgramGLTest::createMultipleOutputsIndexed() {
     program.bindFragmentDataLocationIndexed(0, 0, data.firstName);
     program.bindFragmentDataLocationIndexed(0, 1, data.secondName);
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
@@ -782,16 +783,16 @@ void main() {
     program.setUniform(program.uniformLocation("textureData2D"), 0);
     program.setUniform(program.uniformLocation("textureData3D"), 0);
 
-    std::pair<bool, Containers::String> result = program.validate();
+    Containers::Pair<bool, Containers::String> result = program.validate();
     MAGNUM_VERIFY_NO_GL_ERROR();
-    CORRADE_VERIFY(!result.first);
+    CORRADE_VERIFY(!result.first());
     /* The message shouldn't be empty */
-    CORRADE_COMPARE_AS(result.second,
+    CORRADE_COMPARE_AS(result.second(),
         "",
         TestSuite::Compare::NotEqual);
     /* No stray \0 or \n should be anywhere */
-    CORRADE_COMPARE_AS(result.second, "\0"_s, TestSuite::Compare::StringNotContains);
-    CORRADE_COMPARE_AS(result.second, "\n"_s, TestSuite::Compare::StringNotContains);
+    CORRADE_COMPARE_AS(result.second(), "\0"_s, TestSuite::Compare::StringNotContains);
+    CORRADE_COMPARE_AS(result.second(), "\n"_s, TestSuite::Compare::StringNotContains);
     #endif
 }
 
@@ -1084,7 +1085,7 @@ void AbstractShaderProgramGLTest::createUniformBlocks() {
     MAGNUM_VERIFY_NO_GL_ERROR();
 
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);

--- a/src/Magnum/GL/Test/AbstractShaderProgramGLTest.cpp
+++ b/src/Magnum/GL/Test/AbstractShaderProgramGLTest.cpp
@@ -287,7 +287,7 @@ void AbstractShaderProgramGLTest::create() {
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
 
-    // Some drivers need a bit of time to update this result
+    /* Some drivers need a bit of time to update this result */
     Utility::System::sleep(200);
     CORRADE_VERIFY(program.isLinkFinished());
     {

--- a/src/Magnum/GL/Test/ContextGLTest.cpp
+++ b/src/Magnum/GL/Test/ContextGLTest.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <Corrade/Containers/ScopeGuard.h>
 #include <Corrade/Containers/StringIterable.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/StringStl.h> /* contains() on std::string */
 #include <Corrade/Containers/StringView.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 

--- a/src/Magnum/GL/Test/ContextTest.cpp
+++ b/src/Magnum/GL/Test/ContextTest.cpp
@@ -376,7 +376,7 @@ void ContextTest::makeCurrentNoOp() {
 void ContextTest::extensions() {
     const char* used[GL::Implementation::ExtensionCount]{};
 
-    std::set<std::string> unique;
+    std::set<Containers::StringView> unique;
 
     /* Check that all extension indices are unique, are in correct lists, are
        not compiled on versions that shouldn't have them, are listed just once
@@ -404,12 +404,12 @@ void ContextTest::extensions() {
         #endif
         Version::None})
     {
-        std::string previous;
+        Containers::StringView previous;
         for(const Extension& e: Extension::extensions(version)) {
             CORRADE_ITERATION(version);
             CORRADE_ITERATION(e.string());
 
-            CORRADE_FAIL_IF(!previous.empty() && previous >= e.string(),
+            CORRADE_FAIL_IF(previous && previous >= e.string(),
                 "Extension not sorted after" << previous);
 
             CORRADE_FAIL_IF(e.index() >= GL::Implementation::ExtensionCount,

--- a/src/Magnum/GL/Test/PrimitiveQueryGLTest.cpp
+++ b/src/Magnum/GL/Test/PrimitiveQueryGLTest.cpp
@@ -24,6 +24,7 @@
 */
 
 #include <Corrade/Containers/Reference.h>
+#include <Corrade/Containers/StringIterable.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Resource.h>
 

--- a/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
+++ b/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
@@ -74,8 +74,6 @@ struct TransformFeedbackGLTest: OpenGLTester {
 };
 
 #ifndef MAGNUM_TARGET_GLES
-enum: std::size_t { DrawDataCount = 4 };
-
 const struct {
     const char* name;
     UnsignedInt stream;
@@ -83,7 +81,7 @@ const struct {
     UnsignedInt countStream0;
     UnsignedInt countStreamN;
     UnsignedInt countDraw;
-} DrawData[DrawDataCount] = {
+} DrawData[]{
     {"basic", 0, 1, 6, 6, 6},
     {"instanced", 0, 5, 6, 6, 30},
     {"stream", 1, 1, 0, 6, 6},
@@ -111,7 +109,8 @@ TransformFeedbackGLTest::TransformFeedbackGLTest() {
               });
 
     #ifndef MAGNUM_TARGET_GLES
-    addInstancedTests({&TransformFeedbackGLTest::draw}, DrawDataCount);
+    addInstancedTests({&TransformFeedbackGLTest::draw},
+        Containers::arraySize(DrawData));
     #endif
 }
 

--- a/src/Magnum/Platform/WindowlessEglApplication.cpp
+++ b/src/Magnum/Platform/WindowlessEglApplication.cpp
@@ -27,8 +27,7 @@
 
 #include "WindowlessEglApplication.h"
 
-#include <cstring> /** @todo used by extensionSupported(), cleann up */
-#include <string>
+#include <cstring> /** @todo used by extensionSupported(), clean up */
 #include <Corrade/Utility/Arguments.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>

--- a/src/Magnum/Platform/gl-info.cpp
+++ b/src/Magnum/Platform/gl-info.cpp
@@ -397,7 +397,7 @@ MagnumInfo::MagnumInfo(const Arguments& arguments): Platform::WindowlessApplicat
     Debug{} << "";
 
     /* Get first future (not supported) version */
-    std::vector<GL::Version> versions{
+    GL::Version versions[]{
         #ifndef MAGNUM_TARGET_GLES
         GL::Version::GL300,
         GL::Version::GL310,
@@ -431,7 +431,7 @@ MagnumInfo::MagnumInfo(const Arguments& arguments): Platform::WindowlessApplicat
           "        "_s;
 
     /* Display supported OpenGL extensions from unsupported versions */
-    for(std::size_t i = future; i != versions.size(); ++i) {
+    for(std::size_t i = future; i != Containers::arraySize(versions); ++i) {
         if(versions[i] != GL::Version::None)
             Debug{} << versions[i] << "extension support:";
         else Debug{} << "Vendor extension support:";

--- a/src/Magnum/Shaders/DistanceFieldVectorGL.cpp
+++ b/src/Magnum/Shaders/DistanceFieldVectorGL.cpp
@@ -39,7 +39,8 @@
 #include "Magnum/Math/Matrix4.h"
 
 #ifndef MAGNUM_TARGET_GLES2
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 
 #include "Magnum/GL/Buffer.h"
 #endif
@@ -110,7 +111,7 @@ template<UnsignedInt dimensions> typename DistanceFieldVectorGL<dimensions>::Com
         .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n");
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
@@ -121,7 +122,7 @@ template<UnsignedInt dimensions> typename DistanceFieldVectorGL<dimensions>::Com
         .addSource(rs.getString("Vector.vert"));
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        frag.addSource(Utility::formatString(
+        frag.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define MATERIAL_COUNT {}\n"
             "#define DRAW_COUNT {}\n",

--- a/src/Magnum/Shaders/DistanceFieldVectorGL.cpp
+++ b/src/Magnum/Shaders/DistanceFieldVectorGL.cpp
@@ -49,6 +49,8 @@
 
 namespace Magnum { namespace Shaders {
 
+using namespace Containers::Literals;
+
 namespace {
     enum: Int { TextureUnit = 6 };
 
@@ -91,10 +93,10 @@ template<UnsignedInt dimensions> typename DistanceFieldVectorGL<dimensions>::Com
 
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumShadersGL"))
+    if(!Utility::Resource::hasGroup("MagnumShadersGL"_s))
         importShaderResources();
     #endif
-    Utility::Resource rs("MagnumShadersGL");
+    Utility::Resource rs("MagnumShadersGL"_s);
 
     const GL::Context& context = GL::Context::current();
 
@@ -107,19 +109,19 @@ template<UnsignedInt dimensions> typename DistanceFieldVectorGL<dimensions>::Com
     GL::Shader vert = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Vertex);
     GL::Shader frag = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Fragment);
 
-    vert.addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n" : "")
-        .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n");
+    vert.addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n"_s : ""_s)
+        .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n"_s : "#define THREE_DIMENSIONS\n"_s);
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
         vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
-        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    vert.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Vector.vert"));
+    vert.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Vector.vert"_s));
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
         frag.addSource(Utility::format(
@@ -128,11 +130,11 @@ template<UnsignedInt dimensions> typename DistanceFieldVectorGL<dimensions>::Com
             "#define DRAW_COUNT {}\n",
             configuration.materialCount(),
             configuration.drawCount()));
-        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("DistanceFieldVector.frag"));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("DistanceFieldVector.frag"_s));
 
     vert.submitCompile();
     frag.submitCompile();
@@ -152,8 +154,8 @@ template<UnsignedInt dimensions> typename DistanceFieldVectorGL<dimensions>::Com
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
-        out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates");
+        out.bindAttributeLocation(Position::Location, "position"_s);
+        out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates"_s);
     }
     #endif
 
@@ -201,17 +203,17 @@ template<UnsignedInt dimensions> DistanceFieldVectorGL<dimensions>::DistanceFiel
     {
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
+            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix"_s);
             if(_flags & Flag::TextureTransformation)
-                _textureMatrixUniform = uniformLocation("textureMatrix");
-            _colorUniform = uniformLocation("color");
-            _outlineColorUniform = uniformLocation("outlineColor");
-            _outlineRangeUniform = uniformLocation("outlineRange");
-            _smoothnessUniform = uniformLocation("smoothness");
+                _textureMatrixUniform = uniformLocation("textureMatrix"_s);
+            _colorUniform = uniformLocation("color"_s);
+            _outlineColorUniform = uniformLocation("outlineColor"_s);
+            _outlineRangeUniform = uniformLocation("outlineRange"_s);
+            _smoothnessUniform = uniformLocation("smoothness"_s);
         }
     }
 
@@ -219,14 +221,14 @@ template<UnsignedInt dimensions> DistanceFieldVectorGL<dimensions>::DistanceFiel
     if(!context.isExtensionSupported<GL::Extensions::ARB::shading_language_420pack>(state._version))
     #endif
     {
-        setUniform(uniformLocation("vectorTexture"), TextureUnit);
+        setUniform(uniformLocation("vectorTexture"_s), TextureUnit);
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::UniformBuffers) {
-            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"), TransformationProjectionBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Draw"), DrawBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Material"), MaterialBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"_s), TransformationProjectionBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Draw"_s), DrawBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Material"_s), MaterialBufferBinding);
             if(_flags & Flag::TextureTransformation)
-                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"), TextureTransformationBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"_s), TextureTransformationBufferBinding);
         }
         #endif
     }

--- a/src/Magnum/Shaders/DistanceFieldVectorGL.h
+++ b/src/Magnum/Shaders/DistanceFieldVectorGL.h
@@ -31,6 +31,8 @@
  * @m_since_latest
  */
 
+#include <Corrade/Utility/Move.h>
+
 #include "Magnum/DimensionTraits.h"
 #include "Magnum/GL/AbstractShaderProgram.h"
 #include "Magnum/Shaders/GenericGL.h"
@@ -752,7 +754,7 @@ template<UnsignedInt dimensions> class DistanceFieldVectorGL<dimensions>::Compil
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): DistanceFieldVectorGL<dimensions>{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): DistanceFieldVectorGL<dimensions>{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif

--- a/src/Magnum/Shaders/FlatGL.cpp
+++ b/src/Magnum/Shaders/FlatGL.cpp
@@ -132,10 +132,10 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
 
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumShadersGL"))
+    if(!Utility::Resource::hasGroup("MagnumShadersGL"_s))
         importShaderResources();
     #endif
-    Utility::Resource rs("MagnumShadersGL");
+    Utility::Resource rs("MagnumShadersGL"_s);
 
     const GL::Context& context = GL::Context::current();
 
@@ -165,18 +165,18 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
             #ifndef MAGNUM_TARGET_GLES2
             || configuration.flags() >= Flag::ObjectIdTexture
             #endif
-            ) ? "#define TEXTURED\n" : "")
-        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
-        .addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n" : "")
+            ) ? "#define TEXTURED\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
+        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
         #endif
-        .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n")
+        .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n"_s : "#define THREE_DIMENSIONS\n"_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
+        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
         #endif
-        .addSource(configuration.flags() & Flag::InstancedTransformation ? "#define INSTANCED_TRANSFORMATION\n" : "")
-        .addSource(configuration.flags() >= Flag::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n" : "");
+        .addSource(configuration.flags() & Flag::InstancedTransformation ? "#define INSTANCED_TRANSFORMATION\n"_s : ""_s)
+        .addSource(configuration.flags() >= Flag::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n"_s : ""_s);
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.jointCount()) {
         vert.addSource(Utility::format(
@@ -208,21 +208,21 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
-        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    vert.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Flat.vert"));
-    frag.addSource(configuration.flags() & Flag::Textured ? "#define TEXTURED\n" : "")
+    vert.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Flat.vert"_s));
+    frag.addSource(configuration.flags() & Flag::Textured ? "#define TEXTURED\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
+        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
         #endif
-        .addSource(configuration.flags() & Flag::AlphaMask ? "#define ALPHA_MASK\n" : "")
-        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
+        .addSource(configuration.flags() & Flag::AlphaMask ? "#define ALPHA_MASK\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() & Flag::ObjectId ? "#define OBJECT_ID\n" : "")
-        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
-        .addSource(configuration.flags() >= Flag::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n" : "")
+        .addSource(configuration.flags() & Flag::ObjectId ? "#define OBJECT_ID\n"_s : ""_s)
+        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
+        .addSource(configuration.flags() >= Flag::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n"_s : ""_s)
         #endif
         ;
     #ifndef MAGNUM_TARGET_GLES2
@@ -233,11 +233,11 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
             "#define MATERIAL_COUNT {}\n",
             configuration.drawCount(),
             configuration.materialCount()));
-        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Flat.frag"));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Flat.frag"_s));
 
     vert.submitCompile();
     frag.submitCompile();
@@ -251,38 +251,38 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
+        out.bindAttributeLocation(Position::Location, "position"_s);
         if(configuration.flags() & Flag::Textured
             #ifndef MAGNUM_TARGET_GLES2
             || configuration.flags() >= Flag::ObjectIdTexture
             #endif
         )
-            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates");
+            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates"_s);
         if(configuration.flags() & Flag::VertexColor)
-            out.bindAttributeLocation(Color3::Location, "vertexColor"); /* Color4 is the same */
+            out.bindAttributeLocation(Color3::Location, "vertexColor"_s); /* Color4 is the same */
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() & Flag::ObjectId) {
-            out.bindFragmentDataLocation(ColorOutput, "color");
-            out.bindFragmentDataLocation(ObjectIdOutput, "objectId");
+            out.bindFragmentDataLocation(ColorOutput, "color"_s);
+            out.bindFragmentDataLocation(ObjectIdOutput, "objectId"_s);
         }
         if(configuration.flags() >= Flag::InstancedObjectId)
-            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId");
+            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId"_s);
         #endif
         if(configuration.flags() & Flag::InstancedTransformation)
-            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix");
+            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix"_s);
         if(configuration.flags() >= Flag::InstancedTextureOffset)
-            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset");
+            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset"_s);
         #ifndef MAGNUM_TARGET_GLES2
         /* Configuration::setJointCount() checks that jointCount and
            perVertexJointCount / secondaryPerVertexJointCount are either all
            zero or non-zero so we don't need to check for jointCount() here */
         if(configuration.perVertexJointCount()) {
-            out.bindAttributeLocation(Weights::Location, "weights");
-            out.bindAttributeLocation(JointIds::Location, "jointIds");
+            out.bindAttributeLocation(Weights::Location, "weights"_s);
+            out.bindAttributeLocation(JointIds::Location, "jointIds"_s);
         }
         if(configuration.secondaryPerVertexJointCount()) {
-            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights");
-            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds");
+            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights"_s);
+            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds"_s);
         }
         #endif
     }
@@ -333,28 +333,28 @@ template<UnsignedInt dimensions> FlatGL<dimensions>::FlatGL(CompileState&& state
     {
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::DynamicPerVertexJointCount)
-            _perVertexJointCountUniform = uniformLocation("perVertexJointCount");
+            _perVertexJointCountUniform = uniformLocation("perVertexJointCount"_s);
         if(_flags >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
+            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix"_s);
             if(_flags & Flag::TextureTransformation)
-                _textureMatrixUniform = uniformLocation("textureMatrix");
+                _textureMatrixUniform = uniformLocation("textureMatrix"_s);
             #ifndef MAGNUM_TARGET_GLES2
             if(_flags & Flag::TextureArrays)
-                _textureLayerUniform = uniformLocation("textureLayer");
+                _textureLayerUniform = uniformLocation("textureLayer"_s);
             #endif
-            _colorUniform = uniformLocation("color");
-            if(_flags & Flag::AlphaMask) _alphaMaskUniform = uniformLocation("alphaMask");
+            _colorUniform = uniformLocation("color"_s);
+            if(_flags & Flag::AlphaMask) _alphaMaskUniform = uniformLocation("alphaMask"_s);
             #ifndef MAGNUM_TARGET_GLES2
-            if(_flags & Flag::ObjectId) _objectIdUniform = uniformLocation("objectId");
+            if(_flags & Flag::ObjectId) _objectIdUniform = uniformLocation("objectId"_s);
             #endif
             #ifndef MAGNUM_TARGET_GLES2
             if(_jointCount) {
-                _jointMatricesUniform = uniformLocation("jointMatrices");
-                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount");
+                _jointMatricesUniform = uniformLocation("jointMatrices"_s);
+                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount"_s);
             }
             #endif
         }
@@ -364,17 +364,17 @@ template<UnsignedInt dimensions> FlatGL<dimensions>::FlatGL(CompileState&& state
     if(!context.isExtensionSupported<GL::Extensions::ARB::shading_language_420pack>(state._version))
     #endif
     {
-        if(_flags & Flag::Textured) setUniform(uniformLocation("textureData"), TextureUnit);
+        if(_flags & Flag::Textured) setUniform(uniformLocation("textureData"_s), TextureUnit);
         #ifndef MAGNUM_TARGET_GLES2
-        if(_flags >= Flag::ObjectIdTexture) setUniform(uniformLocation("objectIdTextureData"), ObjectIdTextureUnit);
+        if(_flags >= Flag::ObjectIdTexture) setUniform(uniformLocation("objectIdTextureData"_s), ObjectIdTextureUnit);
         if(_flags >= Flag::UniformBuffers) {
-            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"), TransformationProjectionBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Draw"), DrawBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"_s), TransformationProjectionBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Draw"_s), DrawBufferBinding);
             if(_flags & Flag::TextureTransformation)
-                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"), TextureTransformationBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Material"), MaterialBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"_s), TextureTransformationBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Material"_s), MaterialBufferBinding);
             if(_jointCount)
-                setUniformBlockBinding(uniformBlockIndex("Joint"), JointBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("Joint"_s), JointBufferBinding);
         }
         #endif
     }

--- a/src/Magnum/Shaders/FlatGL.cpp
+++ b/src/Magnum/Shaders/FlatGL.cpp
@@ -41,7 +41,8 @@
 #include "Magnum/Shaders/Implementation/CreateCompatibilityShader.h"
 
 #ifndef MAGNUM_TARGET_GLES2
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 
 #include "Magnum/GL/Buffer.h"
 #include "Magnum/GL/TextureArray.h"
@@ -178,7 +179,7 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
         .addSource(configuration.flags() >= Flag::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n" : "");
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.jointCount()) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define JOINT_COUNT {}\n"
             "#define PER_VERTEX_JOINT_COUNT {}u\n"
             "#define SECONDARY_PER_VERTEX_JOINT_COUNT {}u\n"
@@ -195,7 +196,7 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
             out._perInstanceJointCountUniform));
     }
     if(configuration.flags() >= Flag::DynamicPerVertexJointCount) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define DYNAMIC_PER_VERTEX_JOINT_COUNT\n"
             "#define PER_VERTEX_JOINT_COUNT_LOCATION {}\n",
             out._perVertexJointCountUniform));
@@ -203,7 +204,7 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
     #endif
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
@@ -226,7 +227,7 @@ template<UnsignedInt dimensions> typename FlatGL<dimensions>::CompileState FlatG
         ;
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        frag.addSource(Utility::formatString(
+        frag.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n"
             "#define MATERIAL_COUNT {}\n",

--- a/src/Magnum/Shaders/FlatGL.h
+++ b/src/Magnum/Shaders/FlatGL.h
@@ -31,11 +31,17 @@
  * @m_since_latest
  */
 
+#include <Corrade/Utility/Move.h>
+
 #include "Magnum/DimensionTraits.h"
 #include "Magnum/GL/AbstractShaderProgram.h"
 #include "Magnum/Shaders/GenericGL.h"
 #include "Magnum/Shaders/glShaderWrapper.h"
 #include "Magnum/Shaders/visibility.h"
+
+#ifndef MAGNUM_TARGET_GLES2
+#include <initializer_list>
+#endif
 
 namespace Magnum { namespace Shaders {
 
@@ -1520,7 +1526,7 @@ template<UnsignedInt dimensions> class FlatGL<dimensions>::CompileState: public 
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): FlatGL<dimensions>{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): FlatGL<dimensions>{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif

--- a/src/Magnum/Shaders/Implementation/CreateCompatibilityShader.h
+++ b/src/Magnum/Shaders/Implementation/CreateCompatibilityShader.h
@@ -43,30 +43,32 @@ static void importShaderResources() {
 namespace Magnum { namespace Shaders { namespace Implementation {
 
 inline GL::Shader createCompatibilityShader(const Utility::Resource& rs, GL::Version version, GL::Shader::Type type) {
+    using namespace Containers::Literals;
+
     GL::Shader shader(version, type);
 
     #ifndef MAGNUM_TARGET_GLES
     if(GL::Context::current().isExtensionDisabled<GL::Extensions::ARB::explicit_attrib_location>(version))
-        shader.addSource("#define DISABLE_GL_ARB_explicit_attrib_location\n");
+        shader.addSource("#define DISABLE_GL_ARB_explicit_attrib_location\n"_s);
     if(GL::Context::current().isExtensionDisabled<GL::Extensions::ARB::shading_language_420pack>(version))
-        shader.addSource("#define DISABLE_GL_ARB_shading_language_420pack\n");
+        shader.addSource("#define DISABLE_GL_ARB_shading_language_420pack\n"_s);
     if(GL::Context::current().isExtensionDisabled<GL::Extensions::ARB::explicit_uniform_location>(version))
-        shader.addSource("#define DISABLE_GL_ARB_explicit_uniform_location\n");
+        shader.addSource("#define DISABLE_GL_ARB_explicit_uniform_location\n"_s);
     #endif
 
     #ifndef MAGNUM_TARGET_GLES2
     if(type == GL::Shader::Type::Vertex && GL::Context::current().isExtensionDisabled<GL::Extensions::MAGNUM::shader_vertex_id>(version))
-        shader.addSource("#define DISABLE_GL_MAGNUM_shader_vertex_id\n");
+        shader.addSource("#define DISABLE_GL_MAGNUM_shader_vertex_id\n"_s);
     #endif
 
     /* My Android emulator (running on NVidia) doesn't define GL_ES
        preprocessor macro, thus *all* the stock shaders fail to compile */
     /** @todo remove this when Android emulator is sane */
     #ifdef CORRADE_TARGET_ANDROID
-    shader.addSource("#ifndef GL_ES\n#define GL_ES 1\n#endif\n");
+    shader.addSource("#ifndef GL_ES\n#define GL_ES 1\n#endif\n"_s);
     #endif
 
-    shader.addSource(rs.getString("compatibility.glsl"));
+    shader.addSource(rs.getString("compatibility.glsl"_s));
     return shader;
 }
 

--- a/src/Magnum/Shaders/Implementation/CreateCompatibilityShader.h
+++ b/src/Magnum/Shaders/Implementation/CreateCompatibilityShader.h
@@ -25,7 +25,6 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <Corrade/Containers/StringStl.h> /** @todo remove when Shader is <string>-free */
 #include <Corrade/Containers/StringView.h>
 #include <Corrade/Utility/Resource.h>
 

--- a/src/Magnum/Shaders/MeshVisualizerGL.cpp
+++ b/src/Magnum/Shaders/MeshVisualizerGL.cpp
@@ -28,7 +28,6 @@
 
 #include <Corrade/Containers/EnumSet.hpp>
 #include <Corrade/Containers/Iterable.h>
-#include <Corrade/Utility/FormatStl.h>
 #include <Corrade/Utility/Resource.h>
 
 #include "Magnum/Math/Color.h"
@@ -40,6 +39,9 @@
 #include "Magnum/GL/Texture.h"
 
 #ifndef MAGNUM_TARGET_GLES2
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
+
 #include "Magnum/GL/Buffer.h"
 #include "Magnum/GL/TextureArray.h"
 #endif
@@ -196,7 +198,7 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
         ;
     #ifndef MAGNUM_TARGET_GLES2
     if(jointCount) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define JOINT_COUNT {}\n"
             "#define PER_VERTEX_JOINT_COUNT {}u\n"
             "#define SECONDARY_PER_VERTEX_JOINT_COUNT {}u\n"
@@ -213,7 +215,7 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
             perInstanceJointCountUniform));
     }
     if(flags >= FlagBase::DynamicPerVertexJointCount) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define DYNAMIC_PER_VERTEX_JOINT_COUNT\n"
             "#define PER_VERTEX_JOINT_COUNT_LOCATION {}\n",
             perVertexJointCountUniform));
@@ -221,7 +223,7 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
     #endif
     #ifndef MAGNUM_TARGET_GLES2
     if(flags >= FlagBase::UniformBuffers) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n"
             "#define MATERIAL_COUNT {}\n",
@@ -245,7 +247,7 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
         ;
     #ifndef MAGNUM_TARGET_GLES2
     if(flags >= FlagBase::UniformBuffers) {
-        frag.addSource(Utility::formatString(
+        frag.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n"
             "#define MATERIAL_COUNT {}\n",
@@ -539,7 +541,7 @@ MeshVisualizerGL2D::CompileState MeshVisualizerGL2D::compile(const Configuration
                     "#define PRIMITIVE_ID\n") : "");
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::UniformBuffers) {
-            geom->addSource(Utility::formatString(
+            geom->addSource(Utility::format(
                 "#define TWO_DIMENSIONS\n"
                 "#define UNIFORM_BUFFERS\n"
                 "#define DRAW_COUNT {}\n"
@@ -1002,7 +1004,7 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
 
         geom = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Geometry);
         (*geom)
-            .addSource(Utility::formatString("#define MAX_VERTICES {}\n", maxVertices))
+            .addSource(Utility::format("#define MAX_VERTICES {}\n", maxVertices))
             .addSource(configuration.flags() & Flag::Wireframe ? "#define WIREFRAME_RENDERING\n" : "")
             .addSource(baseFlags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n" : "")
             .addSource(baseFlags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
@@ -1018,7 +1020,7 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
             .addSource(configuration.flags() & Flag::NormalDirection ? "#define NORMAL_DIRECTION\n" : "");
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::UniformBuffers) {
-            geom->addSource(Utility::formatString(
+            geom->addSource(Utility::format(
                 "#define THREE_DIMENSIONS\n"
                 "#define UNIFORM_BUFFERS\n"
                 "#define DRAW_COUNT {}\n"

--- a/src/Magnum/Shaders/MeshVisualizerGL.cpp
+++ b/src/Magnum/Shaders/MeshVisualizerGL.cpp
@@ -144,7 +144,7 @@ void MeshVisualizerGLBase::assertExtensions(const FlagsBase flags) {
 
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumShadersGL"))
+    if(!Utility::Resource::hasGroup("MagnumShadersGL"_s))
         importShaderResources();
     #endif
 }
@@ -176,24 +176,24 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
     vert = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Vertex);
     frag = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Fragment);
 
-    vert.addSource(flags & FlagBase::Wireframe ? "#define WIREFRAME_RENDERING\n" : "")
+    vert.addSource(flags & FlagBase::Wireframe ? "#define WIREFRAME_RENDERING\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(flags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n" : "")
-        .addSource(flags & FlagBase::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n" : "")
-        .addSource(flags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
-        .addSource(flags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
+        .addSource(flags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n"_s : ""_s)
+        .addSource(flags & FlagBase::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n"_s : ""_s)
+        .addSource(flags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
+        .addSource(flags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
         #endif
-        .addSource(flags & FlagBase::InstancedTransformation ? "#define INSTANCED_TRANSFORMATION\n" : "")
+        .addSource(flags & FlagBase::InstancedTransformation ? "#define INSTANCED_TRANSFORMATION\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(flags >= FlagBase::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n" : "")
-        .addSource(flags & FlagBase::VertexId ? "#define VERTEX_ID\n" : "")
-        .addSource(flags >= FlagBase::PrimitiveIdFromVertexId ? "#define PRIMITIVE_ID_FROM_VERTEX_ID\n" : "")
+        .addSource(flags >= FlagBase::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n"_s : ""_s)
+        .addSource(flags & FlagBase::VertexId ? "#define VERTEX_ID\n"_s : ""_s)
+        .addSource(flags >= FlagBase::PrimitiveIdFromVertexId ? "#define PRIMITIVE_ID_FROM_VERTEX_ID\n"_s : ""_s)
         #endif
         #ifdef MAGNUM_TARGET_WEBGL
-        .addSource("#define SUBSCRIPTING_WORKAROUND\n")
+        .addSource("#define SUBSCRIPTING_WORKAROUND\n"_s)
         #elif defined(MAGNUM_TARGET_GLES2)
         .addSource(context.detectedDriver() & GL::Context::DetectedDriver::Angle ?
-            "#define SUBSCRIPTING_WORKAROUND\n" : "")
+            "#define SUBSCRIPTING_WORKAROUND\n"_s : ""_s)
         #endif
         ;
     #ifndef MAGNUM_TARGET_GLES2
@@ -229,20 +229,20 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
             "#define MATERIAL_COUNT {}\n",
             drawCount,
             materialCount));
-        vert.addSource(flags >= FlagBase::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        vert.addSource(flags >= FlagBase::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    frag.addSource(flags & FlagBase::Wireframe ? "#define WIREFRAME_RENDERING\n" : "")
+    frag.addSource(flags & FlagBase::Wireframe ? "#define WIREFRAME_RENDERING\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(flags & FlagBase::ObjectId ? "#define OBJECT_ID\n" : "")
-        .addSource(flags >= FlagBase::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n" : "")
-        .addSource(flags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
-        .addSource(flags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
-        .addSource(flags & FlagBase::VertexId ? "#define VERTEX_ID\n" : "")
+        .addSource(flags & FlagBase::ObjectId ? "#define OBJECT_ID\n"_s : ""_s)
+        .addSource(flags >= FlagBase::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n"_s : ""_s)
+        .addSource(flags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
+        .addSource(flags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
+        .addSource(flags & FlagBase::VertexId ? "#define VERTEX_ID\n"_s : ""_s)
         .addSource(flags & FlagBase::PrimitiveId ?
             (flags >= FlagBase::PrimitiveIdFromVertexId ?
-                "#define PRIMITIVE_ID_FROM_VERTEX_ID\n" :
-                "#define PRIMITIVE_ID\n") : "")
+                "#define PRIMITIVE_ID_FROM_VERTEX_ID\n"_s :
+                "#define PRIMITIVE_ID\n"_s) : ""_s)
         #endif
         ;
     #ifndef MAGNUM_TARGET_GLES2
@@ -253,7 +253,7 @@ GL::Version MeshVisualizerGLBase::setupShaders(GL::Shader& vert, GL::Shader& fra
             "#define MATERIAL_COUNT {}\n",
             drawCount,
             materialCount));
-        frag.addSource(flags >= FlagBase::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        frag.addSource(flags >= FlagBase::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
 
@@ -503,42 +503,42 @@ MeshVisualizerGL2D::CompileState MeshVisualizerGL2D::compile(const Configuration
     );
     Containers::Optional<GL::Shader> geom;
 
-    vert.addSource("#define TWO_DIMENSIONS\n")
+    vert.addSource("#define TWO_DIMENSIONS\n"_s)
         /* Pass NO_GEOMETRY_SHADER not only when NoGeometryShader but also when
            nothing actually needs it, as that makes checks much simpler in
            the shader code */
         .addSource((configuration.flags() & Flag::NoGeometryShader) || !(configuration.flags() & Flag::Wireframe) ?
-            "#define NO_GEOMETRY_SHADER\n" : "")
-        .addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("MeshVisualizer.vert"));
+            "#define NO_GEOMETRY_SHADER\n"_s : ""_s)
+        .addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("MeshVisualizer.vert"_s));
     frag
         /* Pass NO_GEOMETRY_SHADER not only when NoGeometryShader but also when
            nothing actually needs it, as that makes checks much simpler in
            the shader code */
         .addSource((configuration.flags() & Flag::NoGeometryShader) || !(configuration.flags() & Flag::Wireframe) ?
-            "#define NO_GEOMETRY_SHADER\n" : "");
+            "#define NO_GEOMETRY_SHADER\n"_s : ""_s);
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers)
-        frag.addSource("#define TWO_DIMENSIONS\n");
+        frag.addSource("#define TWO_DIMENSIONS\n"_s);
     #endif
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("MeshVisualizer.frag"));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("MeshVisualizer.frag"_s));
 
 
     #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
     if(configuration.flags() & Flag::Wireframe && !(configuration.flags() & Flag::NoGeometryShader)) {
         geom = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Geometry);
         (*geom)
-            .addSource("#define WIREFRAME_RENDERING\n#define MAX_VERTICES 3\n")
-            .addSource(baseFlags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n" : "")
-            .addSource(baseFlags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
-            .addSource(baseFlags & FlagBase::ObjectId ? "#define OBJECT_ID\n" : "")
-            .addSource(baseFlags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
-            .addSource(baseFlags & FlagBase::VertexId ? "#define VERTEX_ID\n" : "")
+            .addSource("#define WIREFRAME_RENDERING\n#define MAX_VERTICES 3\n"_s)
+            .addSource(baseFlags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n"_s : ""_s)
+            .addSource(baseFlags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
+            .addSource(baseFlags & FlagBase::ObjectId ? "#define OBJECT_ID\n"_s : ""_s)
+            .addSource(baseFlags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
+            .addSource(baseFlags & FlagBase::VertexId ? "#define VERTEX_ID\n"_s : ""_s)
             .addSource(baseFlags & FlagBase::PrimitiveId ?
                 (baseFlags >= FlagBase::PrimitiveIdFromVertexId ?
-                    "#define PRIMITIVE_ID_FROM_VERTEX_ID\n" :
-                    "#define PRIMITIVE_ID\n") : "");
+                    "#define PRIMITIVE_ID_FROM_VERTEX_ID\n"_s :
+                    "#define PRIMITIVE_ID\n"_s) : ""_s);
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::UniformBuffers) {
             geom->addSource(Utility::format(
@@ -548,10 +548,10 @@ MeshVisualizerGL2D::CompileState MeshVisualizerGL2D::compile(const Configuration
                 "#define MATERIAL_COUNT {}\n",
                 configuration.drawCount(),
                 configuration.materialCount()));
-            geom->addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+            geom->addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
         }
         #endif
-        geom->addSource(rs.getString("MeshVisualizer.geom"));
+        geom->addSource(rs.getString("MeshVisualizer.geom"_s));
     }
     #else
     static_cast<void>(version);
@@ -571,25 +571,25 @@ MeshVisualizerGL2D::CompileState MeshVisualizerGL2D::compile(const Configuration
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
+        out.bindAttributeLocation(Position::Location, "position"_s);
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::ObjectIdTexture)
-            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates");
+            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates"_s);
         if(configuration.flags() >= Flag::InstancedObjectId)
-            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId");
+            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId"_s);
         #endif
         if(configuration.flags() & Flag::InstancedTransformation)
-            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix");
+            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix"_s);
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::InstancedTextureOffset)
-            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset");
+            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset"_s);
         #endif
         #if !defined(MAGNUM_TARGET_GLES) || defined(MAGNUM_TARGET_GLES2)
         #ifndef MAGNUM_TARGET_GLES
         if(!context.isVersionSupported(GL::Version::GL310))
         #endif
         {
-            out.bindAttributeLocation(VertexIndex::Location, "vertexIndex");
+            out.bindAttributeLocation(VertexIndex::Location, "vertexIndex"_s);
         }
         #endif
         #ifndef MAGNUM_TARGET_GLES2
@@ -597,12 +597,12 @@ MeshVisualizerGL2D::CompileState MeshVisualizerGL2D::compile(const Configuration
            perVertexJointCount / secondaryPerVertexJointCount are either all
            zero or non-zero so we don't need to check for jointCount() here */
         if(configuration.perVertexJointCount()) {
-            out.bindAttributeLocation(Weights::Location, "weights");
-            out.bindAttributeLocation(JointIds::Location, "jointIds");
+            out.bindAttributeLocation(Weights::Location, "weights"_s);
+            out.bindAttributeLocation(JointIds::Location, "jointIds"_s);
         }
         if(configuration.secondaryPerVertexJointCount()) {
-            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights");
-            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds");
+            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights"_s);
+            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds"_s);
         }
         #endif
     }
@@ -660,45 +660,45 @@ MeshVisualizerGL2D::MeshVisualizerGL2D(CompileState&& state): MeshVisualizerGL2D
         /* This one is used also in the UBO case as it's usually a global
            setting */
         if((flags() & Flag::Wireframe) && !(flags() & Flag::NoGeometryShader))
-            _viewportSizeUniform = uniformLocation("viewportSize");
+            _viewportSizeUniform = uniformLocation("viewportSize"_s);
 
         #ifndef MAGNUM_TARGET_GLES2
         if(flags() >= Flag::DynamicPerVertexJointCount)
-            _perVertexJointCountUniform = uniformLocation("perVertexJointCount");
+            _perVertexJointCountUniform = uniformLocation("perVertexJointCount"_s);
         if(flags() >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
+            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix"_s);
             #ifndef MAGNUM_TARGET_GLES2
             if(flags() & Flag::TextureTransformation)
-                _textureMatrixUniform = uniformLocation("textureMatrix");
+                _textureMatrixUniform = uniformLocation("textureMatrix"_s);
             if(flags() & Flag::TextureArrays)
-                _textureLayerUniform = uniformLocation("textureLayer");
+                _textureLayerUniform = uniformLocation("textureLayer"_s);
             #endif
             if(flags() & (Flag::Wireframe
                 #ifndef MAGNUM_TARGET_GLES2
                 |Flag::ObjectId|Flag::VertexId|Flag::PrimitiveIdFromVertexId
                 #endif
             ))
-                _colorUniform = uniformLocation("color");
+                _colorUniform = uniformLocation("color"_s);
             if(flags() & Flag::Wireframe) {
-                _wireframeColorUniform = uniformLocation("wireframeColor");
-                _wireframeWidthUniform = uniformLocation("wireframeWidth");
-                _smoothnessUniform = uniformLocation("smoothness");
+                _wireframeColorUniform = uniformLocation("wireframeColor"_s);
+                _wireframeWidthUniform = uniformLocation("wireframeWidth"_s);
+                _smoothnessUniform = uniformLocation("smoothness"_s);
             }
             #ifndef MAGNUM_TARGET_GLES2
             if(flags() & (Flag::ObjectId|Flag::VertexId|Flag::PrimitiveIdFromVertexId)) {
-                _colorMapOffsetScaleUniform = uniformLocation("colorMapOffsetScale");
+                _colorMapOffsetScaleUniform = uniformLocation("colorMapOffsetScale"_s);
             }
             if(flags() & Flag::ObjectId)
-                _objectIdUniform = uniformLocation("objectId");
+                _objectIdUniform = uniformLocation("objectId"_s);
             #endif
             #ifndef MAGNUM_TARGET_GLES2
             if(_jointCount) {
-                _jointMatricesUniform = uniformLocation("jointMatrices");
-                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount");
+                _jointMatricesUniform = uniformLocation("jointMatrices"_s);
+                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount"_s);
             }
             #endif
         }
@@ -710,19 +710,19 @@ MeshVisualizerGL2D::MeshVisualizerGL2D(CompileState&& state): MeshVisualizerGL2D
     #endif
     {
         if(flags() & (Flag::ObjectId|Flag::VertexId|Flag::PrimitiveIdFromVertexId)) {
-            setUniform(uniformLocation("colorMapTexture"), ColorMapTextureUnit);
+            setUniform(uniformLocation("colorMapTexture"_s), ColorMapTextureUnit);
         }
         #ifndef MAGNUM_TARGET_GLES2
         if(flags() >= Flag::ObjectIdTexture)
-            setUniform(uniformLocation("objectIdTextureData"), ObjectIdTextureUnit);
+            setUniform(uniformLocation("objectIdTextureData"_s), ObjectIdTextureUnit);
         if(flags() >= Flag::UniformBuffers) {
-            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"), TransformationProjectionBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Draw"), DrawBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Material"), MaterialBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"_s), TransformationProjectionBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Draw"_s), DrawBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Material"_s), MaterialBufferBinding);
             if(flags() & Flag::TextureTransformation)
-                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"), TextureTransformationBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"_s), TextureTransformationBufferBinding);
             if(_jointCount)
-                setUniformBlockBinding(uniformBlockIndex("Joint"), JointBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("Joint"_s), JointBufferBinding);
         }
         #endif
     }
@@ -955,7 +955,7 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
     CORRADE_INTERNAL_ASSERT(!(configuration.flags() & (Flag::NormalDirection|Flag::TangentDirection|Flag::BitangentDirection|Flag::BitangentFromTangentDirection)) || version >= GL::Version::GLES310);
     #endif
 
-    vert.addSource("#define THREE_DIMENSIONS\n")
+    vert.addSource("#define THREE_DIMENSIONS\n"_s)
         /* Pass NO_GEOMETRY_SHADER not only when NoGeometryShader but also when
            nothing actually needs it, as that makes checks much simpler in
            the vertex shader code */
@@ -963,16 +963,16 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
             #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
             |Flag::TangentDirection|Flag::BitangentDirection|Flag::BitangentFromTangentDirection|Flag::NormalDirection
             #endif
-            )) ? "#define NO_GEOMETRY_SHADER\n" : "")
+            )) ? "#define NO_GEOMETRY_SHADER\n"_s : ""_s)
         #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
-        .addSource(configuration.flags() & Flag::TangentDirection ? "#define TANGENT_DIRECTION\n" : "")
-        .addSource(configuration.flags() & Flag::BitangentFromTangentDirection ? "#define BITANGENT_FROM_TANGENT_DIRECTION\n" : "")
-        .addSource(configuration.flags() & Flag::BitangentDirection ? "#define BITANGENT_DIRECTION\n" : "")
-        .addSource(configuration.flags() & Flag::NormalDirection ? "#define NORMAL_DIRECTION\n" : "")
+        .addSource(configuration.flags() & Flag::TangentDirection ? "#define TANGENT_DIRECTION\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::BitangentFromTangentDirection ? "#define BITANGENT_FROM_TANGENT_DIRECTION\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::BitangentDirection ? "#define BITANGENT_DIRECTION\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::NormalDirection ? "#define NORMAL_DIRECTION\n"_s : ""_s)
         #endif
         ;
-    vert.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("MeshVisualizer.vert"));
+    vert.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("MeshVisualizer.vert"_s));
     frag
         /* Pass NO_GEOMETRY_SHADER not only when NoGeometryShader but also when
            nothing actually needs it, as that makes checks much simpler in
@@ -981,17 +981,17 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
             #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
             |Flag::TangentDirection|Flag::BitangentDirection|Flag::BitangentFromTangentDirection|Flag::NormalDirection
             #endif
-            )) ? "#define NO_GEOMETRY_SHADER\n" : "")
+            )) ? "#define NO_GEOMETRY_SHADER\n"_s : ""_s)
         #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
-        .addSource(configuration.flags() & (Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection) ? "#define TBN_DIRECTION\n" : "")
+        .addSource(configuration.flags() & (Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection) ? "#define TBN_DIRECTION\n"_s : ""_s)
         #endif
         ;
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers)
-        frag.addSource("#define THREE_DIMENSIONS\n");
+        frag.addSource("#define THREE_DIMENSIONS\n"_s);
     #endif
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("MeshVisualizer.frag"));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("MeshVisualizer.frag"_s));
 
     #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
     if(configuration.flags() & (Flag::Wireframe|Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection) && !(configuration.flags() & Flag::NoGeometryShader)) {
@@ -1005,19 +1005,19 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
         geom = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Geometry);
         (*geom)
             .addSource(Utility::format("#define MAX_VERTICES {}\n", maxVertices))
-            .addSource(configuration.flags() & Flag::Wireframe ? "#define WIREFRAME_RENDERING\n" : "")
-            .addSource(baseFlags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n" : "")
-            .addSource(baseFlags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
-            .addSource(baseFlags & FlagBase::ObjectId ? "#define OBJECT_ID\n" : "")
-            .addSource(baseFlags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
-            .addSource(baseFlags & FlagBase::VertexId ? "#define VERTEX_ID\n" : "")
+            .addSource(configuration.flags() & Flag::Wireframe ? "#define WIREFRAME_RENDERING\n"_s : ""_s)
+            .addSource(baseFlags >= FlagBase::ObjectIdTexture ? "#define TEXTURED\n"_s : ""_s)
+            .addSource(baseFlags & FlagBase::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
+            .addSource(baseFlags & FlagBase::ObjectId ? "#define OBJECT_ID\n"_s : ""_s)
+            .addSource(baseFlags >= FlagBase::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
+            .addSource(baseFlags & FlagBase::VertexId ? "#define VERTEX_ID\n"_s : ""_s)
             .addSource(baseFlags & FlagBase::PrimitiveId ?
                 (baseFlags >= FlagBase::PrimitiveIdFromVertexId ?
-                    "#define PRIMITIVE_ID_FROM_VERTEX_ID\n" :
-                    "#define PRIMITIVE_ID\n") : "")
-            .addSource(configuration.flags() & Flag::TangentDirection ? "#define TANGENT_DIRECTION\n" : "")
-            .addSource(configuration.flags() & (Flag::BitangentDirection|Flag::BitangentFromTangentDirection) ? "#define BITANGENT_DIRECTION\n" : "")
-            .addSource(configuration.flags() & Flag::NormalDirection ? "#define NORMAL_DIRECTION\n" : "");
+                    "#define PRIMITIVE_ID_FROM_VERTEX_ID\n"_s :
+                    "#define PRIMITIVE_ID\n"_s) : ""_s)
+            .addSource(configuration.flags() & Flag::TangentDirection ? "#define TANGENT_DIRECTION\n"_s : ""_s)
+            .addSource(configuration.flags() & (Flag::BitangentDirection|Flag::BitangentFromTangentDirection) ? "#define BITANGENT_DIRECTION\n"_s : ""_s)
+            .addSource(configuration.flags() & Flag::NormalDirection ? "#define NORMAL_DIRECTION\n"_s : ""_s);
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::UniformBuffers) {
             geom->addSource(Utility::format(
@@ -1027,10 +1027,10 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
                 "#define MATERIAL_COUNT {}\n",
                 configuration.drawCount(),
                 configuration.materialCount()));
-            geom->addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+            geom->addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
         }
         #endif
-        geom->addSource(rs.getString("MeshVisualizer.geom"));
+        geom->addSource(rs.getString("MeshVisualizer.geom"_s));
     }
     #else
     static_cast<void>(version);
@@ -1050,40 +1050,40 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
+        out.bindAttributeLocation(Position::Location, "position"_s);
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::ObjectIdTexture)
-            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates");
+            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates"_s);
         if(configuration.flags() >= Flag::InstancedObjectId)
-            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId");
+            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId"_s);
         #endif
         if(configuration.flags() & Flag::InstancedTransformation) {
-            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix");
+            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix"_s);
             #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
             if(configuration.flags() & (Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection))
-                out.bindAttributeLocation(NormalMatrix::Location, "instancedNormalMatrix");
+                out.bindAttributeLocation(NormalMatrix::Location, "instancedNormalMatrix"_s);
             #endif
         }
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() >= Flag::InstancedTextureOffset)
-            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset");
+            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset"_s);
         #endif
         #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
         if(configuration.flags() & Flag::TangentDirection ||
            configuration.flags() & Flag::BitangentFromTangentDirection)
-            out.bindAttributeLocation(Tangent4::Location, "tangent");
+            out.bindAttributeLocation(Tangent4::Location, "tangent"_s);
         if(configuration.flags() & Flag::BitangentDirection)
-            out.bindAttributeLocation(Bitangent::Location, "bitangent");
+            out.bindAttributeLocation(Bitangent::Location, "bitangent"_s);
         if(configuration.flags() & Flag::NormalDirection ||
            configuration.flags() & Flag::BitangentFromTangentDirection)
-            out.bindAttributeLocation(Normal::Location, "normal");
+            out.bindAttributeLocation(Normal::Location, "normal"_s);
         #endif
         #if !defined(MAGNUM_TARGET_GLES) || defined(MAGNUM_TARGET_GLES2)
         #ifndef MAGNUM_TARGET_GLES
         if(!context.isVersionSupported(GL::Version::GL310))
         #endif
         {
-            out.bindAttributeLocation(VertexIndex::Location, "vertexIndex");
+            out.bindAttributeLocation(VertexIndex::Location, "vertexIndex"_s);
         }
         #endif
         #ifndef MAGNUM_TARGET_GLES2
@@ -1091,12 +1091,12 @@ MeshVisualizerGL3D::CompileState MeshVisualizerGL3D::compile(const Configuration
            perVertexJointCount / secondaryPerVertexJointCount are either all
            zero or non-zero so we don't need to check for jointCount() here */
         if(configuration.perVertexJointCount()) {
-            out.bindAttributeLocation(Weights::Location, "weights");
-            out.bindAttributeLocation(JointIds::Location, "jointIds");
+            out.bindAttributeLocation(Weights::Location, "weights"_s);
+            out.bindAttributeLocation(JointIds::Location, "jointIds"_s);
         }
         if(configuration.secondaryPerVertexJointCount()) {
-            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights");
-            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds");
+            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights"_s);
+            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds"_s);
         }
         #endif
     }
@@ -1158,59 +1158,59 @@ MeshVisualizerGL3D::MeshVisualizerGL3D(CompileState&& state): MeshVisualizerGL3D
             || (flags() & (Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection))
             #endif
         )
-            _viewportSizeUniform = uniformLocation("viewportSize");
+            _viewportSizeUniform = uniformLocation("viewportSize"_s);
 
         #ifndef MAGNUM_TARGET_GLES2
         if(flags() >= Flag::DynamicPerVertexJointCount)
-            _perVertexJointCountUniform = uniformLocation("perVertexJointCount");
+            _perVertexJointCountUniform = uniformLocation("perVertexJointCount"_s);
         if(flags() >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationMatrixUniform = uniformLocation("transformationMatrix");
-            _projectionMatrixUniform = uniformLocation("projectionMatrix");
+            _transformationMatrixUniform = uniformLocation("transformationMatrix"_s);
+            _projectionMatrixUniform = uniformLocation("projectionMatrix"_s);
             #ifndef MAGNUM_TARGET_GLES2
             if(flags() & Flag::TextureTransformation)
-                _textureMatrixUniform = uniformLocation("textureMatrix");
+                _textureMatrixUniform = uniformLocation("textureMatrix"_s);
             if(flags() & Flag::TextureArrays)
-                _textureLayerUniform = uniformLocation("textureLayer");
+                _textureLayerUniform = uniformLocation("textureLayer"_s);
             #endif
             if(flags() & (Flag::Wireframe
                 #ifndef MAGNUM_TARGET_GLES2
                 |Flag::ObjectId|Flag::VertexId|Flag::PrimitiveIdFromVertexId
                 #endif
             ))
-                _colorUniform = uniformLocation("color");
+                _colorUniform = uniformLocation("color"_s);
             if(flags() & Flag::Wireframe) {
-                _wireframeColorUniform = uniformLocation("wireframeColor");
-                _wireframeWidthUniform = uniformLocation("wireframeWidth");
+                _wireframeColorUniform = uniformLocation("wireframeColor"_s);
+                _wireframeWidthUniform = uniformLocation("wireframeWidth"_s);
             }
             if(flags() & (Flag::Wireframe
                 #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
                 |Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection
                 #endif
             )) {
-                _smoothnessUniform = uniformLocation("smoothness");
+                _smoothnessUniform = uniformLocation("smoothness"_s);
             }
             #ifndef MAGNUM_TARGET_GLES2
             if(flags() & (Flag::ObjectId|Flag::VertexId|Flag::PrimitiveIdFromVertexId)) {
-                _colorMapOffsetScaleUniform = uniformLocation("colorMapOffsetScale");
+                _colorMapOffsetScaleUniform = uniformLocation("colorMapOffsetScale"_s);
             }
             if(flags() & Flag::ObjectId)
-                _objectIdUniform = uniformLocation("objectId");
+                _objectIdUniform = uniformLocation("objectId"_s);
             #endif
             #if !defined(MAGNUM_TARGET_GLES2) && !defined(MAGNUM_TARGET_WEBGL)
             if(flags() & (Flag::TangentDirection|Flag::BitangentFromTangentDirection|Flag::BitangentDirection|Flag::NormalDirection)) {
-                _normalMatrixUniform = uniformLocation("normalMatrix");
-                _lineWidthUniform = uniformLocation("lineWidth");
-                _lineLengthUniform = uniformLocation("lineLength");
+                _normalMatrixUniform = uniformLocation("normalMatrix"_s);
+                _lineWidthUniform = uniformLocation("lineWidth"_s);
+                _lineLengthUniform = uniformLocation("lineLength"_s);
             }
             #endif
             #ifndef MAGNUM_TARGET_GLES2
             if(_jointCount) {
-                _jointMatricesUniform = uniformLocation("jointMatrices");
-                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount");
+                _jointMatricesUniform = uniformLocation("jointMatrices"_s);
+                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount"_s);
             }
             #endif
         }
@@ -1222,20 +1222,20 @@ MeshVisualizerGL3D::MeshVisualizerGL3D(CompileState&& state): MeshVisualizerGL3D
     #endif
     {
         if(flags() & (Flag::ObjectId|Flag::VertexId|Flag::PrimitiveIdFromVertexId)) {
-            setUniform(uniformLocation("colorMapTexture"), ColorMapTextureUnit);
+            setUniform(uniformLocation("colorMapTexture"_s), ColorMapTextureUnit);
         }
         #ifndef MAGNUM_TARGET_GLES2
         if(flags() >= Flag::ObjectIdTexture)
-            setUniform(uniformLocation("objectIdTextureData"), ObjectIdTextureUnit);
+            setUniform(uniformLocation("objectIdTextureData"_s), ObjectIdTextureUnit);
         if(flags() >= Flag::UniformBuffers) {
-            setUniformBlockBinding(uniformBlockIndex("Projection"), ProjectionBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Transformation"), TransformationBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Draw"), DrawBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Material"), MaterialBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Projection"_s), ProjectionBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Transformation"_s), TransformationBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Draw"_s), DrawBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Material"_s), MaterialBufferBinding);
             if(flags() & Flag::TextureTransformation)
-                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"), TextureTransformationBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"_s), TextureTransformationBufferBinding);
             if(_jointCount)
-                setUniformBlockBinding(uniformBlockIndex("Joint"), JointBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("Joint"_s), JointBufferBinding);
         }
         #endif
     }

--- a/src/Magnum/Shaders/MeshVisualizerGL.h
+++ b/src/Magnum/Shaders/MeshVisualizerGL.h
@@ -31,6 +31,7 @@
  * @m_since_latest
  */
 
+#include <Corrade/Utility/Move.h>
 #include <Corrade/Utility/Utility.h>
 
 #include "Magnum/DimensionTraits.h"
@@ -38,6 +39,10 @@
 #include "Magnum/Shaders/GenericGL.h"
 #include "Magnum/Shaders/glShaderWrapper.h"
 #include "Magnum/Shaders/visibility.h"
+
+#ifndef MAGNUM_TARGET_GLES2
+#include <initializer_list>
+#endif
 
 namespace Magnum { namespace Shaders {
 
@@ -1320,13 +1325,13 @@ class MeshVisualizerGL2D::CompileState: public MeshVisualizerGL2D {
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): MeshVisualizerGL2D{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): MeshVisualizerGL2D{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif
     {
         #if !defined(MAGNUM_TARGET_WEBGL) && !defined(MAGNUM_TARGET_GLES2)
-        if(geom) _geom = Implementation::GLShaderWrapper{std::move(*geom)};
+        if(geom) _geom = Implementation::GLShaderWrapper{Utility::move(*geom)};
         #endif
     }
 
@@ -3288,13 +3293,13 @@ class MeshVisualizerGL3D::CompileState: public MeshVisualizerGL3D {
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): MeshVisualizerGL3D{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): MeshVisualizerGL3D{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif
     {
         #if !defined(MAGNUM_TARGET_WEBGL) && !defined(MAGNUM_TARGET_GLES2)
-        if(geom) _geom = Implementation::GLShaderWrapper{std::move(*geom)};
+        if(geom) _geom = Implementation::GLShaderWrapper{Utility::move(*geom)};
         #endif
     }
 

--- a/src/Magnum/Shaders/PhongGL.cpp
+++ b/src/Magnum/Shaders/PhongGL.cpp
@@ -32,8 +32,8 @@
 #endif
 #include <Corrade/Containers/EnumSet.hpp>
 #include <Corrade/Containers/Iterable.h>
-#include <Corrade/Containers/StringView.h>
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 #include <Corrade/Utility/Resource.h>
 
 #include "Magnum/GL/Context.h"
@@ -192,9 +192,9 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
     /* Initializer for the light color / position / range arrays -- we need a
        list of initializers joined by commas. For GLES we'll simply upload the
        values directly. */
-    std::string lightInitializer;
+    Containers::String lightInitializer;
     if(!(configuration.flags() >= Flag::UniformBuffers) && configuration.lightCount())
-        lightInitializer = Utility::formatString(
+        lightInitializer = Utility::format(
             "#define LIGHT_POSITION_INITIALIZER {}\n"
             "#define LIGHT_COLOR_INITIALIZER {}\n"
             "#define LIGHT_RANGE_INITIALIZER {}\n",
@@ -223,7 +223,7 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
         .addSource(configuration.flags() >= Flag::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n" : "");
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.jointCount()) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define JOINT_COUNT {}\n"
             "#define PER_VERTEX_JOINT_COUNT {}u\n"
             "#define SECONDARY_PER_VERTEX_JOINT_COUNT {}u\n"
@@ -242,7 +242,7 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
             out._perInstanceJointCountUniform));
     }
     if(configuration.flags() >= Flag::DynamicPerVertexJointCount) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define DYNAMIC_PER_VERTEX_JOINT_COUNT\n"
             "#define PER_VERTEX_JOINT_COUNT_LOCATION {}\n",
             out._perVertexJointCountUniform));
@@ -250,7 +250,7 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
     #endif
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount(),
@@ -279,7 +279,7 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
         ;
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        frag.addSource(Utility::formatString(
+        frag.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n"
             "#define MATERIAL_COUNT {}\n"
@@ -292,7 +292,7 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
     } else
     #endif
     {
-        frag.addSource(Utility::formatString(
+        frag.addSource(Utility::format(
             "#define LIGHT_COUNT {}\n"
             "#define LIGHT_COLORS_LOCATION {}\n"
             "#define LIGHT_SPECULAR_COLORS_LOCATION {}\n"

--- a/src/Magnum/Shaders/PhongGL.cpp
+++ b/src/Magnum/Shaders/PhongGL.cpp
@@ -147,10 +147,10 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
 
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumShadersGL"))
+    if(!Utility::Resource::hasGroup("MagnumShadersGL"_s))
         importShaderResources();
     #endif
-    Utility::Resource rs("MagnumShadersGL");
+    Utility::Resource rs("MagnumShadersGL"_s);
 
     const GL::Context& context = GL::Context::current();
 
@@ -207,20 +207,20 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
             #ifndef MAGNUM_TARGET_GLES2
             || configuration.flags() >= Flag::ObjectIdTexture
             #endif
-            ) ? "#define TEXTURED\n" : "")
-        .addSource(configuration.flags() & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n" : "")
-        .addSource(configuration.flags() & Flag::Bitangent ? "#define BITANGENT\n" : "")
-        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
-        .addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n" : "")
+            ) ? "#define TEXTURED\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::Bitangent ? "#define BITANGENT\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
+        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
         #endif
-        .addSource(configuration.lightCount() ? "#define HAS_LIGHTS\n" : "")
+        .addSource(configuration.lightCount() ? "#define HAS_LIGHTS\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
+        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
         #endif
-        .addSource(configuration.flags() & Flag::InstancedTransformation ? "#define INSTANCED_TRANSFORMATION\n" : "")
-        .addSource(configuration.flags() >= Flag::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n" : "");
+        .addSource(configuration.flags() & Flag::InstancedTransformation ? "#define INSTANCED_TRANSFORMATION\n"_s : ""_s)
+        .addSource(configuration.flags() >= Flag::InstancedTextureOffset ? "#define INSTANCED_TEXTURE_OFFSET\n"_s : ""_s);
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.jointCount()) {
         vert.addSource(Utility::format(
@@ -255,27 +255,27 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
             "#define DRAW_COUNT {}\n",
             configuration.drawCount(),
             configuration.lightCount()));
-        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    vert.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Phong.vert"));
-    frag.addSource(configuration.flags() & Flag::AmbientTexture ? "#define AMBIENT_TEXTURE\n" : "")
-        .addSource(configuration.flags() & Flag::DiffuseTexture ? "#define DIFFUSE_TEXTURE\n" : "")
-        .addSource(configuration.flags() & Flag::SpecularTexture ? "#define SPECULAR_TEXTURE\n" : "")
-        .addSource(configuration.flags() & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n" : "")
+    vert.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Phong.vert"_s));
+    frag.addSource(configuration.flags() & Flag::AmbientTexture ? "#define AMBIENT_TEXTURE\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::DiffuseTexture ? "#define DIFFUSE_TEXTURE\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::SpecularTexture ? "#define SPECULAR_TEXTURE\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n" : "")
+        .addSource(configuration.flags() & Flag::TextureArrays ? "#define TEXTURE_ARRAYS\n"_s : ""_s)
         #endif
-        .addSource(configuration.flags() & Flag::Bitangent ? "#define BITANGENT\n" : "")
-        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
-        .addSource(configuration.flags() & Flag::AlphaMask ? "#define ALPHA_MASK\n" : "")
+        .addSource(configuration.flags() & Flag::Bitangent ? "#define BITANGENT\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::VertexColor ? "#define VERTEX_COLOR\n"_s : ""_s)
+        .addSource(configuration.flags() & Flag::AlphaMask ? "#define ALPHA_MASK\n"_s : ""_s)
         #ifndef MAGNUM_TARGET_GLES2
-        .addSource(configuration.flags() & Flag::ObjectId ? "#define OBJECT_ID\n" : "")
-        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n" : "")
-        .addSource(configuration.flags() >= Flag::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n" : "")
+        .addSource(configuration.flags() & Flag::ObjectId ? "#define OBJECT_ID\n"_s : ""_s)
+        .addSource(configuration.flags() >= Flag::InstancedObjectId ? "#define INSTANCED_OBJECT_ID\n"_s : ""_s)
+        .addSource(configuration.flags() >= Flag::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n"_s : ""_s)
         #endif
-        .addSource(configuration.flags() & Flag::NoSpecular ? "#define NO_SPECULAR\n" : "")
+        .addSource(configuration.flags() & Flag::NoSpecular ? "#define NO_SPECULAR\n"_s : ""_s)
         ;
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
@@ -287,8 +287,8 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
             configuration.drawCount(),
             configuration.materialCount(),
             configuration.lightCount()));
-        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "")
-            .addSource(configuration.flags() >= Flag::LightCulling ? "#define LIGHT_CULLING\n" : "");
+        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s)
+            .addSource(configuration.flags() >= Flag::LightCulling ? "#define LIGHT_CULLING\n"_s : ""_s);
     } else
     #endif
     {
@@ -306,8 +306,8 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
     if(!(configuration.flags() >= Flag::UniformBuffers) && configuration.lightCount())
         frag.addSource(std::move(lightInitializer));
     #endif
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Phong.frag"));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Phong.frag"_s));
 
     vert.submitCompile();
     frag.submitCompile();
@@ -321,48 +321,48 @@ PhongGL::CompileState PhongGL::compile(const Configuration& configuration) {
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
+        out.bindAttributeLocation(Position::Location, "position"_s);
         if(configuration.lightCount())
-            out.bindAttributeLocation(Normal::Location, "normal");
+            out.bindAttributeLocation(Normal::Location, "normal"_s);
         if((configuration.flags() & Flag::NormalTexture) && configuration.lightCount()) {
-            out.bindAttributeLocation(Tangent::Location, "tangent");
+            out.bindAttributeLocation(Tangent::Location, "tangent"_s);
             if(configuration.flags() & Flag::Bitangent)
-                out.bindAttributeLocation(Bitangent::Location, "bitangent");
+                out.bindAttributeLocation(Bitangent::Location, "bitangent"_s);
         }
         if(configuration.flags() & Flag::VertexColor)
-            out.bindAttributeLocation(Color3::Location, "vertexColor"); /* Color4 is the same */
+            out.bindAttributeLocation(Color3::Location, "vertexColor"_s); /* Color4 is the same */
         if(configuration.flags() & (Flag::AmbientTexture|Flag::DiffuseTexture|Flag::SpecularTexture)
             #ifndef MAGNUM_TARGET_GLES2
             || configuration.flags() >= Flag::ObjectIdTexture
             #endif
         )
-            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates");
+            out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates"_s);
         #ifndef MAGNUM_TARGET_GLES2
         if(configuration.flags() & Flag::ObjectId) {
-            out.bindFragmentDataLocation(ColorOutput, "color");
-            out.bindFragmentDataLocation(ObjectIdOutput, "objectId");
+            out.bindFragmentDataLocation(ColorOutput, "color"_s);
+            out.bindFragmentDataLocation(ObjectIdOutput, "objectId"_s);
         }
         if(configuration.flags() >= Flag::InstancedObjectId)
-            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId");
+            out.bindAttributeLocation(ObjectId::Location, "instanceObjectId"_s);
         #endif
         if(configuration.flags() & Flag::InstancedTransformation) {
-            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix");
+            out.bindAttributeLocation(TransformationMatrix::Location, "instancedTransformationMatrix"_s);
             if(configuration.lightCount())
-                out.bindAttributeLocation(NormalMatrix::Location, "instancedNormalMatrix");
+                out.bindAttributeLocation(NormalMatrix::Location, "instancedNormalMatrix"_s);
         }
         if(configuration.flags() >= Flag::InstancedTextureOffset)
-            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset");
+            out.bindAttributeLocation(TextureOffset::Location, "instancedTextureOffset"_s);
         #ifndef MAGNUM_TARGET_GLES2
         /* Configuration::setJointCount() checks that jointCount and
            perVertexJointCount / secondaryPerVertexJointCount are either all
            zero or non-zero so we don't need to check for jointCount() here */
         if(configuration.perVertexJointCount()) {
-            out.bindAttributeLocation(Weights::Location, "weights");
-            out.bindAttributeLocation(JointIds::Location, "jointIds");
+            out.bindAttributeLocation(Weights::Location, "weights"_s);
+            out.bindAttributeLocation(JointIds::Location, "jointIds"_s);
         }
         if(configuration.secondaryPerVertexJointCount()) {
-            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights");
-            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds");
+            out.bindAttributeLocation(SecondaryWeights::Location, "secondaryWeights"_s);
+            out.bindAttributeLocation(SecondaryJointIds::Location, "secondaryJointIds"_s);
         }
         #endif
     }
@@ -415,44 +415,44 @@ PhongGL::PhongGL(CompileState&& state): PhongGL{static_cast<PhongGL&&>(std::move
     {
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::DynamicPerVertexJointCount)
-            _perVertexJointCountUniform = uniformLocation("perVertexJointCount");
+            _perVertexJointCountUniform = uniformLocation("perVertexJointCount"_s);
         if(_flags >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationMatrixUniform = uniformLocation("transformationMatrix");
+            _transformationMatrixUniform = uniformLocation("transformationMatrix"_s);
             if(_flags & Flag::TextureTransformation)
-                _textureMatrixUniform = uniformLocation("textureMatrix");
+                _textureMatrixUniform = uniformLocation("textureMatrix"_s);
             #ifndef MAGNUM_TARGET_GLES2
             if(_flags & Flag::TextureArrays)
-                _textureLayerUniform = uniformLocation("textureLayer");
+                _textureLayerUniform = uniformLocation("textureLayer"_s);
             #endif
-            _projectionMatrixUniform = uniformLocation("projectionMatrix");
-            _ambientColorUniform = uniformLocation("ambientColor");
+            _projectionMatrixUniform = uniformLocation("projectionMatrix"_s);
+            _ambientColorUniform = uniformLocation("ambientColor"_s);
             if(_lightCount) {
-                _normalMatrixUniform = uniformLocation("normalMatrix");
-                _diffuseColorUniform = uniformLocation("diffuseColor");
+                _normalMatrixUniform = uniformLocation("normalMatrix"_s);
+                _diffuseColorUniform = uniformLocation("diffuseColor"_s);
                 if(!(_flags & Flag::NoSpecular)) {
-                    _specularColorUniform = uniformLocation("specularColor");
-                    _shininessUniform = uniformLocation("shininess");
+                    _specularColorUniform = uniformLocation("specularColor"_s);
+                    _shininessUniform = uniformLocation("shininess"_s);
                 }
                 if(_flags & Flag::NormalTexture)
-                    _normalTextureScaleUniform = uniformLocation("normalTextureScale");
-                _lightPositionsUniform = uniformLocation("lightPositions");
-                _lightColorsUniform = uniformLocation("lightColors");
+                    _normalTextureScaleUniform = uniformLocation("normalTextureScale"_s);
+                _lightPositionsUniform = uniformLocation("lightPositions"_s);
+                _lightColorsUniform = uniformLocation("lightColors"_s);
                 if(!(_flags & Flag::NoSpecular))
-                    _lightSpecularColorsUniform = uniformLocation("lightSpecularColors");
-                _lightRangesUniform = uniformLocation("lightRanges");
+                    _lightSpecularColorsUniform = uniformLocation("lightSpecularColors"_s);
+                _lightRangesUniform = uniformLocation("lightRanges"_s);
             }
-            if(_flags & Flag::AlphaMask) _alphaMaskUniform = uniformLocation("alphaMask");
+            if(_flags & Flag::AlphaMask) _alphaMaskUniform = uniformLocation("alphaMask"_s);
             #ifndef MAGNUM_TARGET_GLES2
-            if(_flags & Flag::ObjectId) _objectIdUniform = uniformLocation("objectId");
+            if(_flags & Flag::ObjectId) _objectIdUniform = uniformLocation("objectId"_s);
             #endif
             #ifndef MAGNUM_TARGET_GLES2
             if(_jointCount) {
-                _jointMatricesUniform = uniformLocation("jointMatrices");
-                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount");
+                _jointMatricesUniform = uniformLocation("jointMatrices"_s);
+                _perInstanceJointCountUniform = uniformLocation("perInstanceJointCount"_s);
             }
             #endif
         }
@@ -462,25 +462,25 @@ PhongGL::PhongGL(CompileState&& state): PhongGL{static_cast<PhongGL&&>(std::move
     if(_flags && !context.isExtensionSupported<GL::Extensions::ARB::shading_language_420pack>(state._version))
     #endif
     {
-        if(_flags & Flag::AmbientTexture) setUniform(uniformLocation("ambientTexture"), AmbientTextureUnit);
+        if(_flags & Flag::AmbientTexture) setUniform(uniformLocation("ambientTexture"_s), AmbientTextureUnit);
         if(_lightCount) {
-            if(_flags & Flag::DiffuseTexture) setUniform(uniformLocation("diffuseTexture"), DiffuseTextureUnit);
-            if(_flags & Flag::SpecularTexture) setUniform(uniformLocation("specularTexture"), SpecularTextureUnit);
-            if(_flags & Flag::NormalTexture) setUniform(uniformLocation("normalTexture"), NormalTextureUnit);
+            if(_flags & Flag::DiffuseTexture) setUniform(uniformLocation("diffuseTexture"_s), DiffuseTextureUnit);
+            if(_flags & Flag::SpecularTexture) setUniform(uniformLocation("specularTexture"_s), SpecularTextureUnit);
+            if(_flags & Flag::NormalTexture) setUniform(uniformLocation("normalTexture"_s), NormalTextureUnit);
         }
         #ifndef MAGNUM_TARGET_GLES2
-        if(_flags >= Flag::ObjectIdTexture) setUniform(uniformLocation("objectIdTextureData"), ObjectIdTextureUnit);
+        if(_flags >= Flag::ObjectIdTexture) setUniform(uniformLocation("objectIdTextureData"_s), ObjectIdTextureUnit);
         if(_flags >= Flag::UniformBuffers) {
-            setUniformBlockBinding(uniformBlockIndex("Projection"), ProjectionBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Transformation"), TransformationBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Draw"), DrawBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Material"), MaterialBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Projection"_s), ProjectionBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Transformation"_s), TransformationBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Draw"_s), DrawBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Material"_s), MaterialBufferBinding);
             if(_flags & Flag::TextureTransformation)
-                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"), TextureTransformationBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"_s), TextureTransformationBufferBinding);
             if(_lightCount)
-                setUniformBlockBinding(uniformBlockIndex("Light"), LightBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("Light"_s), LightBufferBinding);
             if(_jointCount)
-                setUniformBlockBinding(uniformBlockIndex("Joint"), JointBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("Joint"_s), JointBufferBinding);
         }
         #endif
     }

--- a/src/Magnum/Shaders/PhongGL.h
+++ b/src/Magnum/Shaders/PhongGL.h
@@ -32,10 +32,16 @@
  * @m_since_latest
  */
 
+#include <Corrade/Utility/Move.h>
+
 #include "Magnum/GL/AbstractShaderProgram.h"
 #include "Magnum/Shaders/GenericGL.h"
 #include "Magnum/Shaders/glShaderWrapper.h"
 #include "Magnum/Shaders/visibility.h"
+
+#ifndef MAGNUM_TARGET_GLES2
+#include <initializer_list>
+#endif
 
 namespace Magnum { namespace Shaders {
 
@@ -2301,7 +2307,7 @@ class PhongGL::CompileState: public PhongGL {
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): PhongGL{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): PhongGL{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif

--- a/src/Magnum/Shaders/Test/DistanceFieldVectorGLTest.cpp
+++ b/src/Magnum/Shaders/Test/DistanceFieldVectorGLTest.cpp
@@ -26,6 +26,7 @@
 
 #include <sstream>
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Containers/String.h>
 #include <Corrade/Containers/StringIterable.h>
@@ -381,7 +382,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -405,7 +406,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::constructAsync(
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -448,7 +449,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::constructUnifor
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -483,7 +484,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::constructUnifor
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/FlatGLTest.cpp
+++ b/src/Magnum/Shaders/Test/FlatGLTest.cpp
@@ -1068,7 +1068,7 @@ template<UnsignedInt dimensions> void FlatGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1096,7 +1096,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructSkinning() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1124,7 +1124,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1175,7 +1175,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructUniformBuffers() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1218,7 +1218,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructUniformBuffersAsync()
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/MeshVisualizerGLTest.cpp
+++ b/src/Magnum/Shaders/Test/MeshVisualizerGLTest.cpp
@@ -1676,7 +1676,7 @@ void MeshVisualizerGLTest::construct2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1736,7 +1736,7 @@ void MeshVisualizerGLTest::construct3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1766,7 +1766,7 @@ void MeshVisualizerGLTest::constructSkinning2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1795,7 +1795,7 @@ void MeshVisualizerGLTest::constructSkinning3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1821,7 +1821,7 @@ void MeshVisualizerGLTest::constructAsync2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1846,7 +1846,7 @@ void MeshVisualizerGLTest::constructAsync3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1933,7 +1933,7 @@ void MeshVisualizerGLTest::constructUniformBuffers2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -2019,7 +2019,7 @@ void MeshVisualizerGLTest::constructUniformBuffers3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -2060,7 +2060,7 @@ void MeshVisualizerGLTest::constructUniformBuffersAsync2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -2099,7 +2099,7 @@ void MeshVisualizerGLTest::constructUniformBuffersAsync3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/PhongGLTest.cpp
+++ b/src/Magnum/Shaders/Test/PhongGLTest.cpp
@@ -1408,7 +1408,7 @@ void PhongGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1437,7 +1437,7 @@ void PhongGLTest::constructSkinning() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1466,7 +1466,7 @@ void PhongGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1517,7 +1517,7 @@ void PhongGLTest::constructUniformBuffers() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1563,7 +1563,7 @@ void PhongGLTest::constructUniformBuffersAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/VectorGLTest.cpp
+++ b/src/Magnum/Shaders/Test/VectorGLTest.cpp
@@ -26,6 +26,7 @@
 
 #include <sstream>
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Containers/String.h>
 #include <Corrade/Containers/StringIterable.h>
@@ -377,7 +378,7 @@ template<UnsignedInt dimensions> void VectorGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -401,7 +402,7 @@ template<UnsignedInt dimensions> void VectorGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -444,7 +445,7 @@ template<UnsignedInt dimensions> void VectorGLTest::constructUniformBuffers() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -479,7 +480,7 @@ template<UnsignedInt dimensions> void VectorGLTest::constructUniformBuffersAsync
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/VertexColorGLTest.cpp
+++ b/src/Magnum/Shaders/Test/VertexColorGLTest.cpp
@@ -25,6 +25,7 @@
 */
 
 #include <sstream>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Containers/String.h>
 #include <Corrade/Containers/StringIterable.h>
@@ -314,7 +315,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -335,7 +336,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -377,7 +378,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::constructUniformBuffers
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -409,7 +410,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::constructUniformBuffers
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/VectorGL.cpp
+++ b/src/Magnum/Shaders/VectorGL.cpp
@@ -49,6 +49,8 @@
 
 namespace Magnum { namespace Shaders {
 
+using namespace Containers::Literals;
+
 namespace {
     enum: Int { TextureUnit = 6 };
 
@@ -91,10 +93,10 @@ template<UnsignedInt dimensions> typename VectorGL<dimensions>::CompileState Vec
 
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumShadersGL"))
+    if(!Utility::Resource::hasGroup("MagnumShadersGL"_s))
         importShaderResources();
     #endif
-    Utility::Resource rs("MagnumShadersGL");
+    Utility::Resource rs("MagnumShadersGL"_s);
 
     const GL::Context& context = GL::Context::current();
 
@@ -107,19 +109,19 @@ template<UnsignedInt dimensions> typename VectorGL<dimensions>::CompileState Vec
     GL::Shader vert = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Vertex);
     GL::Shader frag = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Fragment);
 
-    vert.addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n" : "")
-        .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n");
+    vert.addSource(configuration.flags() & Flag::TextureTransformation ? "#define TEXTURE_TRANSFORMATION\n"_s : ""_s)
+        .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n"_s : "#define THREE_DIMENSIONS\n"_s);
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
         vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
-        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    vert.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Vector.vert"));
+    vert.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Vector.vert"_s));
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
         frag.addSource(Utility::format(
@@ -128,11 +130,11 @@ template<UnsignedInt dimensions> typename VectorGL<dimensions>::CompileState Vec
             "#define MATERIAL_COUNT {}\n",
             configuration.drawCount(),
             configuration.materialCount()));
-        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        frag.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("Vector.frag"));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("Vector.frag"_s));
 
     vert.submitCompile();
     frag.submitCompile();
@@ -152,8 +154,8 @@ template<UnsignedInt dimensions> typename VectorGL<dimensions>::CompileState Vec
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
-        out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates");
+        out.bindAttributeLocation(Position::Location, "position"_s);
+        out.bindAttributeLocation(TextureCoordinates::Location, "textureCoordinates"_s);
     }
     #endif
 
@@ -202,15 +204,15 @@ template<UnsignedInt dimensions> VectorGL<dimensions>::VectorGL(CompileState&& s
     {
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
+            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix"_s);
             if(_flags & Flag::TextureTransformation)
-                _textureMatrixUniform = uniformLocation("textureMatrix");
-            _backgroundColorUniform = uniformLocation("backgroundColor");
-            _colorUniform = uniformLocation("color");
+                _textureMatrixUniform = uniformLocation("textureMatrix"_s);
+            _backgroundColorUniform = uniformLocation("backgroundColor"_s);
+            _colorUniform = uniformLocation("color"_s);
         }
     }
 
@@ -218,14 +220,14 @@ template<UnsignedInt dimensions> VectorGL<dimensions>::VectorGL(CompileState&& s
     if(!context.isExtensionSupported<GL::Extensions::ARB::shading_language_420pack>(state._version))
     #endif
     {
-        setUniform(uniformLocation("vectorTexture"), TextureUnit);
+        setUniform(uniformLocation("vectorTexture"_s), TextureUnit);
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::UniformBuffers) {
-            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"), TransformationProjectionBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Draw"), DrawBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("TransformationProjection"_s), TransformationProjectionBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Draw"_s), DrawBufferBinding);
             if(_flags & Flag::TextureTransformation)
-                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"), TextureTransformationBufferBinding);
-            setUniformBlockBinding(uniformBlockIndex("Material"), MaterialBufferBinding);
+                setUniformBlockBinding(uniformBlockIndex("TextureTransformation"_s), TextureTransformationBufferBinding);
+            setUniformBlockBinding(uniformBlockIndex("Material"_s), MaterialBufferBinding);
         }
         #endif
     }

--- a/src/Magnum/Shaders/VectorGL.cpp
+++ b/src/Magnum/Shaders/VectorGL.cpp
@@ -39,7 +39,8 @@
 #include "Magnum/Math/Matrix4.h"
 
 #ifndef MAGNUM_TARGET_GLES2
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 
 #include "Magnum/GL/Buffer.h"
 #endif
@@ -110,7 +111,7 @@ template<UnsignedInt dimensions> typename VectorGL<dimensions>::CompileState Vec
         .addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n");
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
@@ -121,7 +122,7 @@ template<UnsignedInt dimensions> typename VectorGL<dimensions>::CompileState Vec
         .addSource(rs.getString("Vector.vert"));
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        frag.addSource(Utility::formatString(
+        frag.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n"
             "#define MATERIAL_COUNT {}\n",

--- a/src/Magnum/Shaders/VectorGL.h
+++ b/src/Magnum/Shaders/VectorGL.h
@@ -31,6 +31,8 @@
  * @m_since_latest
  */
 
+#include <Corrade/Utility/Move.h>
+
 #include "Magnum/DimensionTraits.h"
 #include "Magnum/GL/AbstractShaderProgram.h"
 #include "Magnum/Shaders/GenericGL.h"
@@ -702,7 +704,7 @@ template<UnsignedInt dimensions> class VectorGL<dimensions>::CompileState: publi
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): VectorGL<dimensions>{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): VectorGL<dimensions>{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif

--- a/src/Magnum/Shaders/VertexColorGL.cpp
+++ b/src/Magnum/Shaders/VertexColorGL.cpp
@@ -47,6 +47,8 @@
 
 namespace Magnum { namespace Shaders {
 
+using namespace Containers::Literals;
+
 namespace {
     #ifndef MAGNUM_TARGET_GLES2
     enum: Int {
@@ -82,10 +84,10 @@ template<UnsignedInt dimensions> typename VertexColorGL<dimensions>::CompileStat
 
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumShadersGL"))
+    if(!Utility::Resource::hasGroup("MagnumShadersGL"_s))
         importShaderResources();
     #endif
-    Utility::Resource rs("MagnumShadersGL");
+    Utility::Resource rs("MagnumShadersGL"_s);
 
     const GL::Context& context = GL::Context::current();
 
@@ -98,20 +100,20 @@ template<UnsignedInt dimensions> typename VertexColorGL<dimensions>::CompileStat
     GL::Shader vert = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Vertex);
     GL::Shader frag = Implementation::createCompatibilityShader(rs, version, GL::Shader::Type::Fragment);
 
-    vert.addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n");
+    vert.addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n"_s : "#define THREE_DIMENSIONS\n"_s);
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
         vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));
-        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n" : "");
+        vert.addSource(configuration.flags() >= Flag::MultiDraw ? "#define MULTI_DRAW\n"_s : ""_s);
     }
     #endif
-    vert.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("VertexColor.vert"));
-    frag.addSource(rs.getString("generic.glsl"))
-        .addSource(rs.getString("VertexColor.frag"));
+    vert.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("VertexColor.vert"_s));
+    frag.addSource(rs.getString("generic.glsl"_s))
+        .addSource(rs.getString("VertexColor.frag"_s));
 
     vert.submitCompile();
     frag.submitCompile();
@@ -130,8 +132,8 @@ template<UnsignedInt dimensions> typename VertexColorGL<dimensions>::CompileStat
     if(!context.isExtensionSupported<GL::Extensions::ARB::explicit_attrib_location>(version))
     #endif
     {
-        out.bindAttributeLocation(Position::Location, "position");
-        out.bindAttributeLocation(Color3::Location, "color"); /* Color4 is the same */
+        out.bindAttributeLocation(Position::Location, "position"_s);
+        out.bindAttributeLocation(Color3::Location, "color"_s); /* Color4 is the same */
     }
     #endif
 
@@ -179,11 +181,11 @@ template<UnsignedInt dimensions> VertexColorGL<dimensions>::VertexColorGL(Compil
     {
         #ifndef MAGNUM_TARGET_GLES2
         if(_flags >= Flag::UniformBuffers) {
-            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset");
+            if(_drawCount > 1) _drawOffsetUniform = uniformLocation("drawOffset"_s);
         } else
         #endif
         {
-            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix");
+            _transformationProjectionMatrixUniform = uniformLocation("transformationProjectionMatrix"_s);
         }
     }
 
@@ -193,7 +195,7 @@ template<UnsignedInt dimensions> VertexColorGL<dimensions>::VertexColorGL(Compil
         && !context.isExtensionSupported<GL::Extensions::ARB::shading_language_420pack>(state._version)
         #endif
     ) {
-        setUniformBlockBinding(uniformBlockIndex("TransformationProjection"), TransformationProjectionBufferBinding);
+        setUniformBlockBinding(uniformBlockIndex("TransformationProjection"_s), TransformationProjectionBufferBinding);
     }
     #endif
 

--- a/src/Magnum/Shaders/VertexColorGL.cpp
+++ b/src/Magnum/Shaders/VertexColorGL.cpp
@@ -37,7 +37,8 @@
 #include "Magnum/Math/Matrix4.h"
 
 #ifndef MAGNUM_TARGET_GLES2
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 
 #include "Magnum/GL/Buffer.h"
 #endif
@@ -100,7 +101,7 @@ template<UnsignedInt dimensions> typename VertexColorGL<dimensions>::CompileStat
     vert.addSource(dimensions == 2 ? "#define TWO_DIMENSIONS\n" : "#define THREE_DIMENSIONS\n");
     #ifndef MAGNUM_TARGET_GLES2
     if(configuration.flags() >= Flag::UniformBuffers) {
-        vert.addSource(Utility::formatString(
+        vert.addSource(Utility::format(
             "#define UNIFORM_BUFFERS\n"
             "#define DRAW_COUNT {}\n",
             configuration.drawCount()));

--- a/src/Magnum/Shaders/VertexColorGL.h
+++ b/src/Magnum/Shaders/VertexColorGL.h
@@ -31,6 +31,8 @@
  * @m_since_latest
  */
 
+#include <Corrade/Utility/Move.h>
+
 #include "Magnum/DimensionTraits.h"
 #include "Magnum/GL/AbstractShaderProgram.h"
 #include "Magnum/Shaders/GenericGL.h"
@@ -519,7 +521,7 @@ template<UnsignedInt dimensions> class VertexColorGL<dimensions>::CompileState: 
         #ifndef MAGNUM_TARGET_GLES
         , GL::Version version
         #endif
-    ): VertexColorGL<dimensions>{std::move(shader)}, _vert{std::move(vert)}, _frag{std::move(frag)}
+    ): VertexColorGL<dimensions>{Utility::move(shader)}, _vert{Utility::move(vert)}, _frag{Utility::move(frag)}
         #ifndef MAGNUM_TARGET_GLES
         , _version{version}
         #endif

--- a/src/Magnum/Shaders/resources-gl.conf
+++ b/src/Magnum/Shaders/resources-gl.conf
@@ -1,4 +1,5 @@
 group=MagnumShadersGL
+nullTerminated=true
 
 [file]
 filename=Flat.vert

--- a/src/Magnum/TextureTools/DistanceField.cpp
+++ b/src/Magnum/TextureTools/DistanceField.cpp
@@ -26,7 +26,8 @@
 #include "DistanceField.h"
 
 #include <Corrade/Containers/Iterable.h>
-#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
 #include <Corrade/Utility/Resource.h>
 
 #include "Magnum/Math/Range.h"
@@ -101,7 +102,7 @@ DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
 
     vert.addSource(rs.getString("FullScreenTriangle.glsl"))
         .addSource(rs.getString("DistanceFieldShader.vert"));
-    frag.addSource(Utility::formatString("#define RADIUS {}\n", radius))
+    frag.addSource(Utility::format("#define RADIUS {}\n", radius))
         .addSource(rs.getString("DistanceFieldShader.frag"));
 
     CORRADE_INTERNAL_ASSERT_OUTPUT(vert.compile() && frag.compile());

--- a/src/Magnum/TextureTools/DistanceField.cpp
+++ b/src/Magnum/TextureTools/DistanceField.cpp
@@ -49,6 +49,8 @@ static void importTextureToolResources() {
 
 namespace Magnum { namespace TextureTools {
 
+using namespace Containers::Literals;
+
 namespace {
 
 class DistanceFieldShader: public GL::AbstractShaderProgram {
@@ -86,10 +88,10 @@ class DistanceFieldShader: public GL::AbstractShaderProgram {
 DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
     #ifdef MAGNUM_BUILD_STATIC
     /* Import resources on static build, if not already */
-    if(!Utility::Resource::hasGroup("MagnumTextureTools"))
+    if(!Utility::Resource::hasGroup("MagnumTextureTools"_s))
         importTextureToolResources();
     #endif
-    Utility::Resource rs("MagnumTextureTools");
+    Utility::Resource rs("MagnumTextureTools"_s);
 
     #ifndef MAGNUM_TARGET_GLES
     const GL::Version v = GL::Context::current().supportedVersion({GL::Version::GL320, GL::Version::GL300, GL::Version::GL210});
@@ -100,10 +102,10 @@ DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
     GL::Shader vert = Shaders::Implementation::createCompatibilityShader(rs, v, GL::Shader::Type::Vertex);
     GL::Shader frag = Shaders::Implementation::createCompatibilityShader(rs, v, GL::Shader::Type::Fragment);
 
-    vert.addSource(rs.getString("FullScreenTriangle.glsl"))
-        .addSource(rs.getString("DistanceFieldShader.vert"));
+    vert.addSource(rs.getString("FullScreenTriangle.glsl"_s))
+        .addSource(rs.getString("DistanceFieldShader.vert"_s));
     frag.addSource(Utility::format("#define RADIUS {}\n", radius))
-        .addSource(rs.getString("DistanceFieldShader.frag"));
+        .addSource(rs.getString("DistanceFieldShader.frag"_s));
 
     CORRADE_INTERNAL_ASSERT_OUTPUT(vert.compile() && frag.compile());
 
@@ -113,7 +115,7 @@ DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
     if(!GL::Context::current().isExtensionSupported<GL::Extensions::MAGNUM::shader_vertex_id>())
     #endif
     {
-        bindAttributeLocation(Position::Location, "position");
+        bindAttributeLocation(Position::Location, "position"_s);
     }
 
     CORRADE_INTERNAL_ASSERT_OUTPUT(link());
@@ -122,7 +124,7 @@ DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
     if(!GL::Context::current().isExtensionSupported<GL::Extensions::ARB::explicit_uniform_location>())
     #endif
     {
-        scalingUniform = uniformLocation("scaling");
+        scalingUniform = uniformLocation("scaling"_s);
 
         #ifndef MAGNUM_TARGET_GLES
         if(!GL::Context::current().isVersionSupported(GL::Version::GL320))
@@ -130,7 +132,7 @@ DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
         if(!GL::Context::current().isVersionSupported(GL::Version::GLES300))
         #endif
         {
-            imageSizeInvertedUniform = uniformLocation("imageSizeInverted");
+            imageSizeInvertedUniform = uniformLocation("imageSizeInverted"_s);
         }
     }
 
@@ -138,7 +140,7 @@ DistanceFieldShader::DistanceFieldShader(const UnsignedInt radius) {
     if(!GL::Context::current().isExtensionSupported<GL::Extensions::ARB::shading_language_420pack>())
     #endif
     {
-        setUniform(uniformLocation("textureData"), TextureUnit);
+        setUniform(uniformLocation("textureData"_s), TextureUnit);
     }
 }
 

--- a/src/Magnum/TextureTools/Test/DistanceFieldGLTest.cpp
+++ b/src/Magnum/TextureTools/Test/DistanceFieldGLTest.cpp
@@ -24,7 +24,6 @@
 */
 
 #include <Corrade/Containers/String.h>
-#include <Corrade/Containers/StringStl.h> /** @todo remove when AbstractImporter is <string>-free */
 #include <Corrade/PluginManager/AbstractManager.h>
 #include <Corrade/Utility/Path.h>
 

--- a/src/Magnum/TextureTools/resources.conf
+++ b/src/Magnum/TextureTools/resources.conf
@@ -1,4 +1,5 @@
 group=MagnumTextureTools
+nullTerminated=true
 
 [file]
 filename=../Shaders/FullScreenTriangle.glsl

--- a/src/Magnum/Trade/AbstractImageConverter.cpp
+++ b/src/Magnum/Trade/AbstractImageConverter.cpp
@@ -29,7 +29,6 @@
 #include <Corrade/Containers/EnumSet.hpp>
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/Containers/StringView.h>
-#include <Corrade/Containers/StringStl.h> /** @todo remove once PluginManager is <string>-free */
 #include <Corrade/PluginManager/Manager.hpp>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Path.h>

--- a/src/Magnum/Trade/Test/MaterialDataTest.cpp
+++ b/src/Magnum/Trade/Test/MaterialDataTest.cpp
@@ -26,7 +26,7 @@
 #include <algorithm> /* std::next_permutation() */
 #include <sstream>
 #include <Corrade/Containers/StaticArray.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/StringStl.h> /* partition() on a std::string */
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/TestSuite/Compare/Container.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>

--- a/src/Magnum/Trade/Test/PbrClearCoatMaterialDataTest.cpp
+++ b/src/Magnum/Trade/Test/PbrClearCoatMaterialDataTest.cpp
@@ -24,7 +24,7 @@
 */
 
 #include <sstream>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
 

--- a/src/Magnum/Trade/Test/PbrMetallicRoughnessMaterialDataTest.cpp
+++ b/src/Magnum/Trade/Test/PbrMetallicRoughnessMaterialDataTest.cpp
@@ -24,7 +24,7 @@
 */
 
 #include <sstream>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
 

--- a/src/Magnum/Trade/Test/PbrSpecularGlossinessMaterialDataTest.cpp
+++ b/src/Magnum/Trade/Test/PbrSpecularGlossinessMaterialDataTest.cpp
@@ -24,7 +24,7 @@
 */
 
 #include <sstream>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
 

--- a/src/Magnum/Trade/Test/PhongMaterialDataTest.cpp
+++ b/src/Magnum/Trade/Test/PhongMaterialDataTest.cpp
@@ -24,7 +24,7 @@
 */
 
 #include <sstream>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
 

--- a/src/Magnum/Vk/Test/DevicePropertiesVkTest.cpp
+++ b/src/Magnum/Vk/Test/DevicePropertiesVkTest.cpp
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Optional.h>
-#include <Corrade/Containers/StringStl.h>
 #include <Corrade/Containers/StringIterable.h>
 #include <Corrade/Containers/StringView.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>

--- a/src/Magnum/Vk/Test/DeviceVkTest.cpp
+++ b/src/Magnum/Vk/Test/DeviceVkTest.cpp
@@ -27,8 +27,9 @@
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/Containers/StringIterable.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/StringStl.h> /* StringHasPrefix */
 #include <Corrade/TestSuite/Compare/Numeric.h>
+#include <Corrade/TestSuite/Compare/String.h>
 #include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/FormatStl.h>
 
@@ -785,11 +786,14 @@ void DeviceVkTest::constructExtensionsCommandLineDisable() {
     UnsignedInt major = versionMajor(deviceProperties.version());
     UnsignedInt minor = versionMinor(deviceProperties.version());
     UnsignedInt patch = versionPatch(deviceProperties.version());
-    /* SwiftShader reports just 1.1 with no patch version, special-case that */
-    std::string expected = Utility::formatString(data.log, deviceProperties.name(), major, minor, patch ? Utility::formatString(".{}", patch) : "", deviceProperties.driverName(), deviceProperties.driverInfo());
     /* The output might contain a device workaround list, cut that away.
        That's tested thoroughly in constructWorkaroundsCommandLineDisable(). */
-    CORRADE_COMPARE(out.str().substr(0, expected.size()), expected);
+    CORRADE_COMPARE_AS(out.str(),
+        Utility::format(data.log, deviceProperties.name(), major, minor,
+        /* SwiftShader reports just 1.1 with no patch version, special-case
+           that */
+        patch ? Utility::format(".{}", patch) : "", deviceProperties.driverName(), deviceProperties.driverInfo()),
+        TestSuite::Compare::StringHasPrefix);
 
     /* Verify that the entrypoint is actually (not) loaded as expected, to
        avoid all the above reporting being just smoke & mirrors */
@@ -842,11 +846,14 @@ void DeviceVkTest::constructExtensionsCommandLineEnable() {
     UnsignedInt major = versionMajor(deviceProperties.version());
     UnsignedInt minor = versionMinor(deviceProperties.version());
     UnsignedInt patch = versionPatch(deviceProperties.version());
-    /* SwiftShader reports just 1.1 with no patch version, special-case that */
-    std::string expected = Utility::formatString(data.log, deviceProperties.name(), major, minor, patch ? Utility::formatString(".{}", patch) : "", deviceProperties.driverName(), deviceProperties.driverInfo());
     /* The output might contain a device workaround list, cut that away.
        That's tested thoroughly in constructWorkaroundsCommandLineDisable(). */
-    CORRADE_COMPARE(out.str().substr(0, expected.size()), expected);
+    CORRADE_COMPARE_AS(out.str(),
+        Utility::format(data.log, deviceProperties.name(), major, minor,
+        /* SwiftShader reports just 1.1 with no patch version, special-case
+           that */
+        patch ? Utility::format(".{}", patch) : "", deviceProperties.driverName(), deviceProperties.driverInfo()),
+        TestSuite::Compare::StringHasPrefix);
 
     /* Verify that the entrypoint is actually (not) loaded as expected, to
        avoid all the above reporting being just smoke & mirrors */

--- a/src/Magnum/Vk/Test/ExtensionPropertiesVkTest.cpp
+++ b/src/Magnum/Vk/Test/ExtensionPropertiesVkTest.cpp
@@ -24,8 +24,8 @@
 */
 
 #include <sstream>
+#include <Corrade/Containers/String.h>
 #include <Corrade/Containers/StringIterable.h>
-#include <Corrade/Containers/StringStl.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/Utility/DebugStl.h>
@@ -169,8 +169,7 @@ void ExtensionPropertiesVkTest::instanceExtensionIsSupported() {
     CORRADE_VERIFY(!properties.isSupported("ZZZZZ"));
 
     /* Verify that we're not just comparing a prefix */
-    const std::string extension = std::string(properties.name(0)) + "_hello";
-    CORRADE_VERIFY(!properties.isSupported(extension));
+    CORRADE_VERIFY(!properties.isSupported(properties.name(0) + "_hello"_s));
 
     /* This extension should be available almost always */
     if(!properties.isSupported("VK_KHR_get_physical_device_properties2"))

--- a/src/Magnum/Vk/Test/InstanceVkTest.cpp
+++ b/src/Magnum/Vk/Test/InstanceVkTest.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/StringIterable.h>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/Utility/DebugStl.h>
@@ -432,7 +432,7 @@ void InstanceVkTest::constructCommandLineEnable() {
     UnsignedInt minor = versionMinor(enumerateInstanceVersion());
     UnsignedInt patch = versionPatch(enumerateInstanceVersion());
     /* Vulkan 1.0 instances report no patch version, special-case that */
-    CORRADE_COMPARE(out.str(), Utility::formatString(data.log, major, minor, patch ? Utility::formatString(".{}", patch) : ""));
+    CORRADE_COMPARE(out.str(), Utility::formatString(data.log, major, minor, patch ? Utility::format(".{}", patch) : ""));
 
     /* Verify that the entrypoint is actually (not) loaded as expected, to
        avoid all the above reporting being just smoke & mirrors */

--- a/src/Magnum/Vk/Test/LayerPropertiesVkTest.cpp
+++ b/src/Magnum/Vk/Test/LayerPropertiesVkTest.cpp
@@ -24,7 +24,7 @@
 */
 
 #include <sstream>
-#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/Utility/DebugStl.h>
@@ -136,8 +136,7 @@ void LayerPropertiesVkTest::isSupported() {
     }
 
     /* Verify that we're not just comparing a prefix */
-    const std::string layer = std::string(properties.name(0)) + "_hello";
-    CORRADE_VERIFY(!properties.isSupported(layer));
+    CORRADE_VERIFY(!properties.isSupported(properties.name(0) + "_hello"_s));
 }
 
 }}}}

--- a/src/Magnum/Vk/VulkanTester.cpp
+++ b/src/Magnum/Vk/VulkanTester.cpp
@@ -25,7 +25,6 @@
 
 #include "VulkanTester.h"
 
-#include <string> /* sigh, for setSkippedArgumentPrefixes() */
 #include <Corrade/Containers/StringView.h>
 
 #include "Magnum/Vk/DeviceCreateInfo.h"


### PR DESCRIPTION
As usual, a Saturday afternoon task that turned out to cut much deeper than anticipated. Things to do:

- [x] port `label()` / `setLabel()` away from `std::string` -- bc884428f8c1d8f66ee0216c9a6a338eff31fca4
  - [x] all label tests need to be updated to explicitly check that we handle non-null-terminated strings properly (the GL label APIs have an explicit size, so it *should*, but just in case)
  - [x] duplicate `setLabel()/label()` tests for all Query and Texture subclasses in order to verify these are correctly implemented and exported (since those are all deinlined in new files now)
  - [x] changelog entries, mention all the breaking changes
- [x] port `DebugOutput`, `DebugGroup` away from `std::string`
  - [x] test for non-null-terminated strings
  - [x] explicit test for the deprecated debug output callback
  - [x] changelog entries, mention all the breaking changes
- [x] port `Shader` and `AbstractShaderProgram` away from `std::string`
  - [x] test for non-null-terminated strings
  - [x] `#line` statements added to shader sources need `Utility::format()` to return a `String` -- mosra/corrade@ea9f21790ff88e47a4e0d830165315ecf15644e9
  - [x] `Shader::addFile()` needs `Utility::Path::readString()` to return a `String` -- mosra/corrade@a211a75aa0de82e5d1984ecdb2ef220c209afdd4
  - [x] Shader tests need expanding quite a lot to verify we're correctly copying (or not) if and only if the input view isn't global
    - [x] needs propagating the `Global` flag from `String::nullTerminatedGlobalView()` -- mosra/corrade@f65c6521d5735db44671facf4227d21b7c7a7979
  - [x] changelog entries, mention all the breaking changes
- [x] port the nasty workaround for xfb outputs for NV on Windows
  - [x] test for non-null-terminated strings
  - [x] needs explicit testing from someone with a NV card *and* Windows
- [x] ~~various `<string>` includes may need to be added to various places~~ not anymore, 65a935cedc059bab49172b9a198e3ccc6b346bdc
  - [x] ideally I should first fix `CORRADE_SKIP()` to not need them, because that's the major reason for these -- mosra/corrade@8d077cc24f7fd93bafe3050fcbc72e87deb87b5a
- [x] Drop the `std::pair` from `AbstractShaderProgram::validate()` as it's a breaking change already anyway
  - [x] Take that as a chance to remove it from all internal places in GL as well
- [x] Update `Shader::compile()` to use an ArrayTuple for the output instead of two allocations
- [x] Update builtin shaders to use string view literals, avoiding temporary allocations
  - [x] The actual improvement will happen once `Utility::Resource` starts supporting null-terminated views -- mosra/corrade@9ef4b4aa89c1883529161724cb07bd0788541317
  - [x] Look at the improvements with Heaptrack to be actually sure about the improvement

Related to: #293 