### PR TITLE
SceneData rework

### DIFF
--- a/doc/artwork/scenedata-dod.svg
+++ b/doc/artwork/scenedata-dod.svg
@@ -1,0 +1,1610 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="530"
+   height="240.00002"
+   viewBox="0 0 140.22916 63.500004"
+   version="1.1"
+   id="svg1701"
+   sodipodi:docname="scenedata-dod.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     id="namedview12294"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="1.3009434"
+     inkscape:cx="290.17404"
+     inkscape:cy="51.116751"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer9"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid12857"
+       originx="-18.520834"
+       originy="-15.875007" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1695" />
+  <metadata
+     id="metadata1698">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer3"
+     style="display:none"
+     transform="translate(-25.135421,-55.562503)">
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 44.979165,64.822918 c -0.04047,7.883497 32.952175,0.947985 33.07292,9.128124"
+       id="path2871" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 44.979165,64.822918 c -0.04047,7.883497 14.431342,11.66361 14.552087,19.843749"
+       id="path2936" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 44.979165,64.822918 C 44.938695,72.706415 23.691757,80.322987 23.812502,88.503126"
+       id="path2869" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 23.812502,54.239583 C 23.772032,62.12308 17.077174,67.226111 17.197919,75.40625"
+       id="path2865" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 46.55523,43.65625 c -0.04047,7.883497 19.469856,6.239654 19.590601,14.419793"
+       id="path2861" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 46.55523,43.65625 C 46.51476,51.539747 23.691757,46.059444 23.812502,54.239583"
+       id="path2858" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 46.55523,43.65625 c -0.04047,7.883497 -1.69681,12.986529 -1.576065,21.166668"
+       id="path2863" />
+  </g>
+  <g
+     id="layer1"
+     transform="translate(-25.135421,-55.562503)"
+     style="display:none">
+    <g
+       id="g2510"
+       transform="translate(-1.2715659e-6,5.2916692)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2440"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="41.234787"
+         y="65.563751"
+         id="text2467"><tspan
+           id="tspan2465"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">material</tspan></text>
+    </g>
+    <g
+       id="g2515"
+       transform="translate(-1.2715659e-6,5.2916692)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2459"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text2471"><tspan
+           id="tspan2469"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">mesh</tspan></text>
+    </g>
+    <g
+       id="g2597"
+       transform="translate(-1.2715659e-6,7.9374999)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2591"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.926247"
+         y="68.158577"
+         id="text2595"><tspan
+           id="tspan2593"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">physics</tspan></text>
+    </g>
+    <g
+       id="g2622"
+       transform="translate(-1.2715659e-6,10.583333)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2616"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text2620"><tspan
+           id="tspan2618"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">texture</tspan></text>
+    </g>
+    <g
+       id="g2647"
+       transform="translate(33.072919,14.552086)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2641"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="41.234787"
+         y="65.563751"
+         id="text2645"><tspan
+           id="tspan2643"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">material</tspan></text>
+    </g>
+    <g
+       id="g2655"
+       transform="translate(33.072919,14.552086)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2649"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text2653"><tspan
+           id="tspan2651"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">mesh</tspan></text>
+    </g>
+    <g
+       id="g2663"
+       transform="translate(21.166665,-3.9687525)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2657"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.926247"
+         y="68.158577"
+         id="text2661"><tspan
+           id="tspan2659"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">physics</tspan></text>
+    </g>
+    <g
+       id="g2671"
+       transform="translate(14.552082,25.135422)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2665"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="41.234787"
+         y="65.563751"
+         id="text2669"><tspan
+           id="tspan2667"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">material</tspan></text>
+    </g>
+    <g
+       id="g2679"
+       transform="translate(14.552082,25.135422)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2673"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text2677"><tspan
+           id="tspan2675"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">mesh</tspan></text>
+    </g>
+    <g
+       id="g2687"
+       transform="translate(14.552082,27.781247)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2681"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text2685"><tspan
+           id="tspan2683"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">texture</tspan></text>
+    </g>
+    <g
+       id="g2695"
+       transform="translate(-21.166668,26.458336)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2689"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.926247"
+         y="68.158577"
+         id="text2693"><tspan
+           id="tspan2691"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">physics</tspan></text>
+    </g>
+    <g
+       id="g2703"
+       transform="translate(-21.166668,-7.9374975)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#747474;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2697"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text2701"><tspan
+           id="tspan2699"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">camera</tspan></text>
+    </g>
+    <g
+       id="g2731"
+       transform="translate(-21.166672,-5.2916599)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2725"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.926247"
+         y="68.158577"
+         id="text2729"><tspan
+           id="tspan2727"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">physics</tspan></text>
+    </g>
+    <g
+       id="g2742">
+      <g
+         id="g2589"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2583"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2587"><tspan
+             id="tspan2585"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="circle2581"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2723"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2733"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2758"
+       transform="translate(11.906254,15.874999)">
+      <g
+         id="g2750"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2744"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2748"><tspan
+             id="tspan2746"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="path2752"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2754"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2756"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2774"
+       transform="translate(-6.6145791,26.458332)">
+      <g
+         id="g2766"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2760"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2764"><tspan
+             id="tspan2762"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="path2768"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2770"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2772"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2790"
+       transform="translate(-21.166666,6.6145833)">
+      <g
+         id="g2782"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2776"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2780"><tspan
+             id="tspan2778"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="path2784"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2786"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2788"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2806"
+       transform="translate(-42.333329,-3.9687513)">
+      <g
+         id="g2798"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2792"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2796"><tspan
+             id="tspan2794"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="path2800"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2802"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2804"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2822"
+       transform="translate(-19.590601,-14.419793)">
+      <path
+         id="path2816"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2818"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2820"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2838"
+       transform="translate(-48.947912,17.197915)">
+      <g
+         id="g2830"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2824"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2828"><tspan
+             id="tspan2826"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="path2832"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2834"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2836"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g2854"
+       transform="translate(-42.333329,30.427083)">
+      <g
+         id="g2846"
+         transform="translate(21.166665,-2.6458333)">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2840"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="45.033138"
+           y="62.930618"
+           id="text2844"><tspan
+             id="tspan2842"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+      </g>
+      <path
+         id="path2848"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2850"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+      <path
+         id="path2852"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 67.721894,58.076043 h -3.152126 c 0,-0.870436 0.705627,-1.576063 1.576063,-1.576063 0.870436,0 1.576063,0.705627 1.576063,1.576063 z" />
+    </g>
+    <g
+       id="g3360"
+       transform="translate(1.3229154,-17.197917)">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3354"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="45.033138"
+         y="62.930618"
+         id="text3358"><tspan
+           id="tspan3356"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transform</tspan></text>
+    </g>
+  </g>
+  <g
+     id="layer4"
+     style="display:none"
+     transform="translate(-25.135421,-55.562503)">
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.75,93.927085 c 8.487737,0.106272 -3.046329,-18.646669 5.291664,-18.520836"
+       id="path2947" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.916667,75.40625 c 8.487737,0.106272 -3.046331,-12.032085 5.291662,-11.906253"
+       id="path2949" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.749996,62.17709 c 8.487737,0.106272 18.12034,1.197075 26.458333,1.322907"
+       id="path2951" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.749996,62.17709 c 8.487737,0.106272 -3.046326,13.103328 5.291667,13.22916"
+       id="path2953" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 15.874992,62.17709 c -10.0622813,0.0058 -8.3379889,31.624164 4e-6,31.749996"
+       id="path2955" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 74.083333,63.499997 C 86.425886,63.523406 47.10833,93.997762 31.75,93.927086"
+       id="path2957" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 7.018763,-6.565536 0,-6.614585"
+       id="path2959" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 7.783875,-2.66637 0,-2.645836"
+       id="path2961" />
+    <path
+       style="fill:none;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 7.018763,5.340713 0,5.291664"
+       id="path2963" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 37.041663,72.760419 C 25.982495,72.801216 38.768763,59.580302 31.75,59.531252"
+       id="path2988" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 51.593746,92.604172 C 40.534578,92.644969 38.768763,59.580302 31.75,59.531252"
+       id="path2990" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 70.114583,82.020836 C 59.055415,82.061633 38.768763,59.580302 31.75,59.531252"
+       id="path2992" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 8.594828,-27.599912 1.576065,-27.648961"
+       id="path2994" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 85.989587,82.020836 C 94.477324,82.127108 61.511495,45.160507 54.492732,45.111458"
+       id="path2996" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 85.989587,82.020836 C 94.477324,82.127108 59.93543,66.194883 52.916667,66.145834"
+       id="path2998" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 85.989587,82.020836 c 8.487737,0.106272 7.018763,-2.596787 0,-2.645836"
+       id="path3000" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 85.989587,82.020836 c 8.487737,0.106272 7.018763,-6.565537 0,-6.614586"
+       id="path3002" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 67.46875,92.604172 c 8.487737,0.106272 7.018767,-6.56554 4e-6,-6.614589"
+       id="path3004" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 67.46875,92.604172 c 8.487737,0.106272 7.018763,-2.596787 0,-2.645836"
+       id="path3006" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 67.46875,92.604172 C 75.956487,92.710444 59.93543,66.194883 52.916667,66.145834"
+       id="path3008" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 67.46875,92.604172 c 8.487737,0.106272 7.018763,2.694874 0,2.645825"
+       id="path3010" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 67.46875,92.604172 C 75.956487,92.710444 61.511495,45.160507 54.492732,45.111458"
+       id="path3012" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 31.75,59.531252 C 40.237737,59.637524 61.511495,45.160507 54.492732,45.111458"
+       id="path3014" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 31.75,59.531252 c 8.487737,0.106272 7.018767,-3.919704 4e-6,-3.968753"
+       id="path3016" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 70.114583,82.020836 C 59.055415,82.061633 38.768763,59.580302 31.75,59.531252"
+       id="path3018" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 31.750004,55.562499 c 8.487737,0.106272 7.018755,6.66364 -8e-6,6.614591"
+       id="path3043" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 31.750004,89.958334 c 8.487737,0.106272 7.018759,4.0178 -4e-6,3.968751"
+       id="path3062" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,66.145834 c 8.487737,0.106272 7.018763,9.309465 0,9.260416"
+       id="path3064" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 74.083333,59.531251 c 8.487737,0.106272 7.018763,4.017796 0,3.968746"
+       id="path3066" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 37.041667,66.145832 C 21.166663,66.145833 38.768763,93.976134 31.75,93.927085"
+       id="path3070" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 38.617728,45.111458 C 20.461208,45.284993 38.768763,93.976134 31.75,93.927085"
+       id="path3072" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 54.492732,45.111458 c 8.487737,0.106272 -6.30794,17.800407 3.715597,18.388539"
+       id="path3074" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 38.617728,45.111458 C 22.442776,45.221347 59.93543,75.455299 52.916667,75.40625"
+       id="path3076" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="bg"
+     transform="translate(-1.3229207,-1.3229231)"
+     style="display:inline">
+    <g
+       id="layer2"
+       transform="matrix(1.6060605,0,0,1.0434783,-9.3005006,-40.090118)"
+       style="stroke-width:0.772461">
+      <rect
+         style="vector-effect:none;fill:#2f363f;fill-opacity:1;stroke:none;stroke-width:0.408763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         id="rect1404"
+         width="87.3125"
+         height="60.854168"
+         x="6.6145835"
+         y="39.687496" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer8"
+     inkscape:label="fg"
+     transform="translate(-1.3229207,-1.3229231)">
+    <g
+       id="g3084"
+       transform="matrix(2,0,0,2,-67.468751,-96.572918)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3078"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="40.784985"
+         y="65.563751"
+         id="text3082"><tspan
+           id="tspan3080"
+           x="40.784985"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.132291">materials</tspan></text>
+    </g>
+    <g
+       id="g3108"
+       transform="matrix(2,0,0,2,-67.468751,-78.052091)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3102"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text3106"><tspan
+           id="tspan3104"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">skins</tspan></text>
+    </g>
+    <g
+       id="g3124"
+       transform="matrix(2,0,0,2,-67.468751,-109.80209)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3118"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text3122"><tspan
+           id="tspan3120"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">meshes</tspan></text>
+    </g>
+    <g
+       id="g3164"
+       transform="matrix(2,0,0,2,-67.468751,-107.15625)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3158"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text3162"><tspan
+           id="tspan3160"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transforms</tspan></text>
+    </g>
+    <g
+       id="g3225"
+       transform="matrix(2,0,0,2,-67.468751,-125.67709)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3219"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text3223"><tspan
+           id="tspan3221"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">parents</tspan></text>
+    </g>
+    <g
+       id="g3265"
+       transform="matrix(2,0,0,2,-67.468751,-93.92709)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3259"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.926247"
+         y="68.158577"
+         id="text3263"><tspan
+           sodipodi:role="line"
+           id="tspan30770"
+           x="44.926247"
+           y="68.158577"
+           style="stroke-width:0.132291"><tspan
+             id="tspan3261"
+             x="44.926247"
+             y="68.158577"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">lights</tspan></tspan></text>
+    </g>
+    <g
+       id="g3350"
+       transform="matrix(2,0,0,2,-67.468749,-85.989588)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="rect3344"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#747474;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="m 37.041664,66.145836 h 15.875003 v 2.645832 H 37.041664 Z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text3348"><tspan
+           id="tspan3346"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">cameras</tspan></text>
+    </g>
+    <g
+       id="g132534"
+       transform="matrix(2,0,0,2,-34.395837,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect132528"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text132532"><tspan
+           id="tspan132530"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">7</tspan></text>
+    </g>
+    <g
+       id="g134506"
+       transform="matrix(2,0,0,2,-23.812504,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134500"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134504"><tspan
+           id="tspan134502"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">1</tspan></text>
+    </g>
+    <g
+       id="g134514"
+       transform="matrix(2,0,0,2,-13.229171,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134508"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134512"><tspan
+           id="tspan134510"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">0</tspan></text>
+    </g>
+    <g
+       id="g134522"
+       transform="matrix(2,0,0,2,-2.6458347,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134516"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134520"><tspan
+           id="tspan134518"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">5</tspan></text>
+    </g>
+    <g
+       id="g134530"
+       transform="matrix(2,0,0,2,7.9374983,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134524"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134528"><tspan
+           id="tspan134526"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">3</tspan></text>
+    </g>
+    <g
+       id="g134538"
+       transform="matrix(2,0,0,2,18.520831,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134532"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134536"><tspan
+           id="tspan134534"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">6</tspan></text>
+    </g>
+    <g
+       id="g134546"
+       transform="matrix(2,0,0,2,29.104164,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134540"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134544"><tspan
+           id="tspan134542"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">2</tspan></text>
+    </g>
+    <g
+       id="g134554"
+       transform="matrix(2,0,0,2,39.687498,-125.67708)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.0661459;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134548"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text134552"><tspan
+           id="tspan134550"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">4</tspan></text>
+    </g>
+    <g
+       id="g134642"
+       transform="matrix(2,0,0,2,-30.427085,-107.15625)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect134636"
+         width="9.2604198"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.68034"
+         y="62.930618"
+         id="text134640"><tspan
+           id="tspan134638"
+           x="41.68034"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">1</tspan></text>
+    </g>
+    <g
+       id="g138916"
+       transform="matrix(2,0,0,2,-11.906254,-107.15625)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect138910"
+         width="9.2604198"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.68034"
+         y="62.930618"
+         id="text138914"><tspan
+           id="tspan138912"
+           x="41.68034"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">0</tspan></text>
+    </g>
+    <g
+       id="g138924"
+       transform="matrix(2,0,0,2,6.6145788,-107.15625)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect138918"
+         width="9.2604198"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.68034"
+         y="62.930618"
+         id="text138922"><tspan
+           id="tspan138920"
+           x="41.68034"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">5</tspan></text>
+    </g>
+    <g
+       id="g138932"
+       transform="matrix(2,0,0,2,25.135412,-107.15625)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect138926"
+         width="9.2604198"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.68034"
+         y="62.930618"
+         id="text138930"><tspan
+           id="tspan138928"
+           x="41.68034"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">6</tspan></text>
+    </g>
+    <g
+       id="g138940"
+       transform="matrix(2,0,0,2,43.656255,-107.15625)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect138934"
+         width="9.2604198"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.68034"
+         y="62.930618"
+         id="text138938"><tspan
+           id="tspan138936"
+           x="41.68034"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">2</tspan></text>
+    </g>
+    <g
+       id="g139268"
+       transform="matrix(2,0,0,2,-30.427076,-85.989591)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="path139262"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#747474;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="m 37.041664,66.145836 h 2.645834 v 2.645832 h -2.645834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="38.349766"
+         y="68.209587"
+         id="text139266"><tspan
+           id="tspan139264"
+           x="38.349766"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">1</tspan></text>
+    </g>
+    <g
+       id="g154316"
+       transform="matrix(2,0,0,2,-30.427076,-93.927091)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="path154310"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1;-inkscape-stroke:none"
+         d="m 37.041664,66.145836 h 2.645834 v 2.645832 h -2.645834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="38.349766"
+         y="68.209587"
+         id="text154314"><tspan
+           id="tspan154312"
+           x="38.349766"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">1</tspan></text>
+    </g>
+    <g
+       id="g154376"
+       transform="matrix(2,0,0,2,-30.427078,-78.052088)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="path154370"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1;-inkscape-stroke:none"
+         d="m 37.041664,66.145836 h 2.645834 v 2.645832 h -2.645834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="38.349766"
+         y="68.209587"
+         id="text154374"><tspan
+           id="tspan154372"
+           x="38.349766"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">5</tspan></text>
+    </g>
+    <g
+       id="g154943"
+       transform="matrix(2,0,0,2,-25.135411,-93.927088)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="path154937"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         d="m 37.041664,66.145836 h 2.645834 v 2.645832 h -2.645834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="38.349766"
+         y="68.209587"
+         id="text154941"><tspan
+           id="tspan154939"
+           x="38.349766"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">0</tspan></text>
+    </g>
+    <g
+       id="g154951"
+       transform="matrix(2,0,0,2,-19.843744,-93.927091)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="path154945"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         d="m 37.041664,66.145836 h 2.645834 v 2.645832 h -2.645834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="38.349766"
+         y="68.209587"
+         id="text154949"><tspan
+           id="tspan154947"
+           x="38.349766"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">4</tspan></text>
+    </g>
+    <g
+       id="g154959"
+       transform="matrix(2,0,0,2,-30.427076,-96.572918)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect154953"
+         width="3.9687495"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="42.993736"
+         y="65.563751"
+         id="text154957"><tspan
+           id="tspan154955"
+           x="38.973122"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">5</tspan></text>
+    </g>
+    <g
+       id="g164095"
+       transform="matrix(2,0,0,2,-22.489577,-96.572908)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect164089"
+         width="3.9687495"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="42.993736"
+         y="65.563751"
+         id="text164093"><tspan
+           id="tspan164091"
+           x="38.973122"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">6</tspan></text>
+    </g>
+    <g
+       id="g164103"
+       transform="matrix(2,0,0,2,-14.552077,-96.572918)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect164097"
+         width="3.9687495"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="42.993736"
+         y="65.563751"
+         id="text164101"><tspan
+           id="tspan164099"
+           x="38.973122"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">3</tspan></text>
+    </g>
+    <g
+       id="g164111"
+       transform="matrix(2,0,0,2,-6.6145771,-96.572918)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect164105"
+         width="3.9687495"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="42.993736"
+         y="65.563751"
+         id="text164109"><tspan
+           id="tspan164107"
+           x="38.973122"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">2</tspan></text>
+    </g>
+    <g
+       id="g164119"
+       transform="matrix(2,0,0,2,-34.395837,-109.80208)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1;-inkscape-stroke:none"
+         id="rect164113"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text164117"><tspan
+           id="tspan164115"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">5</tspan></text>
+    </g>
+    <g
+       id="g164419"
+       transform="matrix(2,0,0,2,-23.812504,-109.80209)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         id="rect164413"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text164417"><tspan
+           id="tspan164415"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">6</tspan></text>
+    </g>
+    <g
+       id="g164427"
+       transform="matrix(2,0,0,2,-13.229171,-109.80208)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         id="rect164421"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text164425"><tspan
+           id="tspan164423"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">3</tspan></text>
+    </g>
+    <g
+       id="g164435"
+       transform="matrix(2,0,0,2,-2.6458347,-109.80208)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         id="rect164429"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text164433"><tspan
+           id="tspan164431"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">2</tspan></text>
+    </g>
+    <g
+       id="g199232"
+       transform="matrix(2,0,0,2,-25.135411,-78.052091)"
+       style="display:inline;stroke-width:0.5">
+      <path
+         id="path199226"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         d="m 37.041664,66.145836 h 2.645834 v 2.645832 h -2.645834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="38.349766"
+         y="68.209587"
+         id="text199230"><tspan
+           id="tspan199228"
+           x="38.349766"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">2</tspan></text>
+    </g>
+    <g
+       id="g208526"
+       transform="matrix(2,0,0,2,7.9374955,-109.80209)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         id="rect208520"
+         width="5.291667"
+         height="2.6458318"
+         x="39.026043"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.618961"
+         y="68.209587"
+         id="text208524"><tspan
+           id="tspan208522"
+           x="41.618961"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">6</tspan></text>
+    </g>
+    <g
+       id="g208534"
+       transform="matrix(2,0,0,2,1.3229227,-96.572908)"
+       style="display:inline;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect208528"
+         width="3.9687495"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="42.993736"
+         y="65.563751"
+         id="text208532"><tspan
+           id="tspan208530"
+           x="38.973122"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">6</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/doc/artwork/scenedata-tree.svg
+++ b/doc/artwork/scenedata-tree.svg
@@ -1,0 +1,1290 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="620"
+   height="440"
+   viewBox="0 0 164.04167 116.41666"
+   version="1.1"
+   id="svg1701"
+   sodipodi:docname="scenedata-tree.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview2590"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="293.09576"
+     inkscape:cy="249.25514"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g202829"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:object-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid15296"
+       originx="-2.786671e-07"
+       originy="-2.3253523e-06" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1695" />
+  <metadata
+     id="metadata1698">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer4"
+     style="display:none"
+     transform="translate(-6.6145837,-39.687499)">
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.75,93.927085 c 8.487737,0.106272 -3.046329,-18.646669 5.291664,-18.520836"
+       id="path2947" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.916667,75.40625 c 8.487737,0.106272 -3.046331,-12.032085 5.291662,-11.906253"
+       id="path2949" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.749996,62.17709 c 8.487737,0.106272 18.12034,1.197075 26.458333,1.322907"
+       id="path2951" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.749996,62.17709 c 8.487737,0.106272 -3.046326,13.103328 5.291667,13.22916"
+       id="path2953" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 15.874992,62.17709 c -10.0622813,0.0058 -8.3379889,31.624164 4e-6,31.749996"
+       id="path2955" />
+    <path
+       style="fill:none;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 74.083333,63.499997 C 86.425886,63.523406 47.10833,93.997762 31.75,93.927086"
+       id="path2957" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 7.018763,-6.565536 0,-6.614585"
+       id="path2959" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 7.783875,-2.66637 0,-2.645836"
+       id="path2961" />
+    <path
+       style="fill:none;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 7.018763,5.340713 0,5.291664"
+       id="path2963" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 37.041663,72.760419 C 25.982495,72.801216 38.768763,59.580302 31.75,59.531252"
+       id="path2988" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 51.593746,92.604172 C 40.534578,92.644969 38.768763,59.580302 31.75,59.531252"
+       id="path2990" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 70.114583,82.020836 C 59.055415,82.061633 38.768763,59.580302 31.75,59.531252"
+       id="path2992" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,72.760419 c 8.487737,0.106272 8.594828,-27.599912 1.576065,-27.648961"
+       id="path2994" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 85.989587,82.020836 C 94.477324,82.127108 61.511495,45.160507 54.492732,45.111458"
+       id="path2996" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 85.989587,82.020836 C 94.477324,82.127108 59.93543,66.194883 52.916667,66.145834"
+       id="path2998" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 85.989587,82.020836 c 8.487737,0.106272 7.018763,-2.596787 0,-2.645836"
+       id="path3000" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 85.989587,82.020836 c 8.487737,0.106272 7.018763,-6.565537 0,-6.614586"
+       id="path3002" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 67.46875,92.604172 c 8.487737,0.106272 7.018767,-6.56554 4e-6,-6.614589"
+       id="path3004" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 67.46875,92.604172 c 8.487737,0.106272 7.018763,-2.596787 0,-2.645836"
+       id="path3006" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 67.46875,92.604172 C 75.956487,92.710444 59.93543,66.194883 52.916667,66.145834"
+       id="path3008" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 67.46875,92.604172 c 8.487737,0.106272 7.018763,2.694874 0,2.645825"
+       id="path3010" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#3bd267;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 67.46875,92.604172 C 75.956487,92.710444 61.511495,45.160507 54.492732,45.111458"
+       id="path3012" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 31.75,59.531252 C 40.237737,59.637524 61.511495,45.160507 54.492732,45.111458"
+       id="path3014" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 31.75,59.531252 c 8.487737,0.106272 7.018767,-3.919704 4e-6,-3.968753"
+       id="path3016" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#747474;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 70.114583,82.020836 C 59.055415,82.061633 38.768763,59.580302 31.75,59.531252"
+       id="path3018" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 31.750004,55.562499 c 8.487737,0.106272 7.018755,6.66364 -8e-6,6.614591"
+       id="path3043" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 31.750004,89.958334 c 8.487737,0.106272 7.018759,4.0178 -4e-6,3.968751"
+       id="path3062" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 52.916667,66.145834 c 8.487737,0.106272 7.018763,9.309465 0,9.260416"
+       id="path3064" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 74.083333,59.531251 c 8.487737,0.106272 7.018763,4.017796 0,3.968746"
+       id="path3066" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 37.041667,66.145832 C 21.166663,66.145833 38.768763,93.976134 31.75,93.927085"
+       id="path3070" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 38.617728,45.111458 C 20.461208,45.284993 38.768763,93.976134 31.75,93.927085"
+       id="path3072" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m 54.492732,45.111458 c 8.487737,0.106272 -6.30794,17.800407 3.715597,18.388539"
+       id="path3074" />
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#c7cf2f;stroke-width:0.396875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="M 38.617728,45.111458 C 22.442776,45.221347 59.93543,75.455299 52.916667,75.40625"
+       id="path3076" />
+  </g>
+  <g
+     id="layer5"
+     style="display:none"
+     transform="translate(-7.9374979)">
+    <g
+       id="g3084"
+       transform="translate(-9.2604176,-26.45833)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3078"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="41.234787"
+         y="65.563751"
+         id="text3082"><tspan
+           id="tspan3080"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583">materials</tspan></text>
+    </g>
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect3086"
+       width="3.9026058"
+       height="2.6458318"
+       x="46.302078"
+       y="37.041668" />
+    <g
+       id="g3108"
+       transform="translate(-9.2604176,-25.135411)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3102"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text3106"><tspan
+           id="tspan3104"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">textures</tspan></text>
+    </g>
+    <g
+       id="g3124"
+       transform="translate(-9.2604156,-33.072914)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3118"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text3122"><tspan
+           id="tspan3120"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">meshes</tspan></text>
+    </g>
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect3126"
+       width="7.871356"
+       height="2.6458318"
+       x="46.302078"
+       y="33.072918" />
+    <g
+       id="g3164"
+       transform="translate(-9.2604196,-35.718747)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3158"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="45.033138"
+         y="62.930618"
+         id="text3162"><tspan
+           id="tspan3160"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">transforms</tspan></text>
+    </g>
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect3179"
+       width="2.5796895"
+       height="2.6458318"
+       x="46.302078"
+       y="25.135422" />
+    <g
+       id="g3225"
+       transform="translate(-9.2604176,-44.979165)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3219"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text3223"><tspan
+           id="tspan3221"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">parents</tspan></text>
+    </g>
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect3227"
+       width="2.5796914"
+       height="2.6458318"
+       x="46.302082"
+       y="21.16667" />
+    <g
+       id="g3265"
+       transform="translate(-9.2604176,-37.041666)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3259"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.926247"
+         y="68.158577"
+         id="text3263"><tspan
+           id="tspan3261"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">physics</tspan></text>
+    </g>
+    <g
+       id="g3350"
+       transform="translate(-9.2604196,-51.593747)"
+       style="display:inline">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#747474;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect3344"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="44.968582"
+         y="68.209587"
+         id="text3348"><tspan
+           id="tspan3346"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264583">camera</tspan></text>
+    </g>
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1418"
+       width="5.2255225"
+       height="2.6458318"
+       x="46.335152"
+       y="29.10417" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1427"
+       width="5.2255225"
+       height="2.6458318"
+       x="51.62682"
+       y="29.10417" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1429"
+       width="5.2255225"
+       height="2.6458318"
+       x="62.243229"
+       y="29.10417" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1431"
+       width="5.2255225"
+       height="2.6458318"
+       x="56.918488"
+       y="29.10417" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1434"
+       width="2.5796914"
+       height="2.6458318"
+       x="49.014057"
+       y="21.16667" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1436"
+       width="2.5796914"
+       height="2.6458318"
+       x="51.659889"
+       y="21.16667" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1438"
+       width="2.5796914"
+       height="2.6458318"
+       x="54.305725"
+       y="21.16667" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1440"
+       width="2.5796914"
+       height="2.6458318"
+       x="56.918488"
+       y="21.16667" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1442"
+       width="2.5796914"
+       height="2.6458318"
+       x="56.918488"
+       y="21.16667" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1447"
+       width="2.5796895"
+       height="2.6458318"
+       x="49.014057"
+       y="25.13542" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1449"
+       width="2.5796895"
+       height="2.6458318"
+       x="51.62682"
+       y="25.135422" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1451"
+       width="2.5796895"
+       height="2.6458318"
+       x="54.305725"
+       y="25.13542" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1453"
+       width="2.5796895"
+       height="2.6458318"
+       x="56.951557"
+       y="25.13542" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1455"
+       width="2.5796895"
+       height="2.6458318"
+       x="59.597393"
+       y="25.13542" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1457"
+       width="2.5796895"
+       height="2.6458318"
+       x="62.243225"
+       y="25.13542" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1459"
+       width="2.5796914"
+       height="2.6458318"
+       x="59.53125"
+       y="21.16667" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1462"
+       width="7.871356"
+       height="2.6458318"
+       x="54.305725"
+       y="33.072922" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1464"
+       width="7.871356"
+       height="2.6458318"
+       x="62.210155"
+       y="33.072922" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1469"
+       width="3.9026058"
+       height="2.6458318"
+       x="49.642445"
+       y="37.041668" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1471"
+       width="3.9026058"
+       height="2.6458318"
+       x="52.982811"
+       y="37.041672" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1473"
+       width="10.517187"
+       height="2.6458318"
+       x="46.302082"
+       y="41.010422" />
+    <rect
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.132292;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="rect1475"
+       width="10.517187"
+       height="2.6458318"
+       x="56.918488"
+       y="41.010422" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="bg"
+     sodipodi:insensitive="true">
+    <g
+       id="layer2"
+       transform="matrix(1.8787879,0,0,1.9130435,-12.427399,-75.923905)"
+       style="stroke-width:0.52747">
+      <rect
+         style="vector-effect:none;fill:#2f363f;fill-opacity:1;stroke:none;stroke-width:0.279122;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         id="rect1404"
+         width="87.3125"
+         height="60.854168"
+         x="6.6145835"
+         y="39.687496" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="fg">
+    <g
+       id="layer3"
+       style="display:inline;stroke-width:0.5"
+       transform="matrix(2.0000001,0,0,2.0000001,-13.229167,-79.374993)">
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="m 44.979165,64.822918 c -0.04047,7.883497 32.952175,0.947985 33.07292,9.128124"
+         id="path2871" />
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="m 44.979165,64.822918 c -0.04047,7.883497 14.431342,11.66361 14.552087,19.843749"
+         id="path2936" />
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="M 44.979165,64.822918 C 44.938695,72.706415 23.691757,80.322987 23.812502,88.503126"
+         id="path2869" />
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="M 23.812502,54.239583 C 23.772032,62.12308 17.077174,67.226111 17.197919,75.40625"
+         id="path2865" />
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="m 46.55523,43.65625 c -0.04047,7.883497 19.469856,6.239654 19.590601,14.419793"
+         id="path2861" />
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="M 46.55523,43.65625 C 46.51476,51.539747 23.691757,46.059444 23.812502,54.239583"
+         id="path2858" />
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#2f83cc;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         d="m 46.55523,43.65625 c -0.04047,7.883497 -1.69681,12.986529 -1.576065,21.166668"
+         id="path2863" />
+    </g>
+    <g
+       id="g2510"
+       transform="matrix(2.0000001,0,0,2.0000001,-13.22917,-66.145836)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2440"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.234787"
+         y="65.563751"
+         id="text2467"><tspan
+           id="tspan2465"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.132291">material</tspan></text>
+    </g>
+    <g
+       id="g2515"
+       transform="matrix(2.0000001,0,0,2.0000001,-13.22917,-76.729175)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2459"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text2471"><tspan
+           id="tspan2469"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">mesh</tspan></text>
+    </g>
+    <g
+       id="g2622"
+       transform="matrix(2.0000001,0,0,2.0000001,-13.229162,-66.145841)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2616"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text2620"><tspan
+           id="tspan2618"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">skin</tspan></text>
+    </g>
+    <g
+       id="g2647"
+       transform="matrix(2.0000001,0,0,2.0000001,52.916672,-47.625002)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2641"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.234787"
+         y="65.563751"
+         id="text2645"><tspan
+           id="tspan2643"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.132291">material</tspan></text>
+    </g>
+    <g
+       id="g2655"
+       transform="matrix(2.0000001,0,0,2.0000001,52.916672,-58.208353)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2649"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text2653"><tspan
+           id="tspan2651"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">mesh</tspan></text>
+    </g>
+    <g
+       id="g2663"
+       transform="matrix(2.0000001,0,0,2.0000001,29.104163,-89.958332)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2657"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.926247"
+         y="68.158577"
+         id="text2661"><tspan
+           id="tspan2659"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">light</tspan></text>
+    </g>
+    <g
+       id="g2671"
+       transform="matrix(2.0000001,0,0,2.0000001,15.874997,-26.458336)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2665"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.234787"
+         y="65.563751"
+         id="text2669"><tspan
+           id="tspan2667"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.132291">material</tspan></text>
+    </g>
+    <g
+       id="g2679"
+       transform="matrix(2.0000001,0,0,2.0000001,15.874997,-37.041684)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2673"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text2677"><tspan
+           id="tspan2675"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">mesh</tspan></text>
+    </g>
+    <g
+       id="g2687"
+       transform="matrix(2.0000001,0,0,2.0000001,15.874997,-26.458344)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#2f83cc;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2681"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text2685"><tspan
+           id="tspan2683"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">skin</tspan></text>
+    </g>
+    <g
+       id="g2695"
+       transform="matrix(2.0000001,0,0,2.0000001,-55.628653,-29.104181)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2689"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.926247"
+         y="68.158577"
+         id="text2693"><tspan
+           id="tspan2691"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">light</tspan></text>
+    </g>
+    <g
+       id="g2703"
+       transform="matrix(2.0000001,0,0,2.0000001,-55.562505,-97.89584)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#747474;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2697"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text2701"><tspan
+           id="tspan2699"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">camera</tspan></text>
+    </g>
+    <g
+       id="g2731"
+       transform="matrix(2.0000001,0,0,2.0000001,-55.562513,-92.604165)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#c7cf2f;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2725"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.926247"
+         y="68.158577"
+         id="text2729"><tspan
+           id="tspan2727"
+           x="44.926247"
+           y="68.158577"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">light</tspan></text>
+    </g>
+    <g
+       id="g2589"
+       transform="matrix(2.0000001,0,0,2.0000001,29.104165,-84.66666)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2583"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text2587"><tspan
+           id="tspan2585"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g67147"
+       transform="matrix(2.0000001,0,0,2.0000001,-68.791676,-50.270846)"
+       style="stroke-width:0.5;opacity:0.25">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#a5c9ea;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect67141"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text67145"><tspan
+           id="tspan67143"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g2750"
+       transform="matrix(2.0000001,0,0,2.0000001,52.916673,-52.916661)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2744"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text2748"><tspan
+           id="tspan2746"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g2766"
+       transform="matrix(2.0000001,0,0,2.0000001,15.875006,-31.749995)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2760"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text2764"><tspan
+           id="tspan2762"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g2790"
+       transform="matrix(2.0000001,0,0,2.0000001,-55.562501,-66.145826)"
+       style="stroke-width:0.5">
+      <g
+         id="g2782"
+         transform="translate(21.166665,-2.6458333)"
+         style="stroke-width:0.5">
+        <rect
+           style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+           id="rect2776"
+           width="15.875003"
+           height="2.6458318"
+           x="37.041664"
+           y="60.854168" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+           x="45.033138"
+           y="62.930618"
+           id="text2780"><tspan
+             id="tspan2778"
+             x="45.033138"
+             y="62.930618"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+      </g>
+    </g>
+    <g
+       id="g2798"
+       transform="matrix(2.0000001,0,0,2.0000001,-55.562497,-92.604163)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect2792"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text2796"><tspan
+           id="tspan2794"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g15294"
+       transform="matrix(2.0000001,0,0,2.0000001,-68.791676,-55.562515)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect15288"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text15292"><tspan
+           id="tspan15290"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">mesh</tspan></text>
+    </g>
+    <g
+       id="g69641"
+       transform="matrix(2.0000001,0,0,2.0000001,-10.583343,-113.77084)"
+       style="opacity:0.25;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#a5c9ea;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect69635"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text69639"><tspan
+           id="tspan69637"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g69649"
+       transform="matrix(2.0000001,0,0,2.0000001,-55.562509,-23.812511)"
+       style="opacity:0.25;stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#a5c9ea;fill-opacity:1;fill-rule:evenodd;stroke:#a5c9ea;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect69643"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="60.854168" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="45.033138"
+         y="62.930618"
+         id="text69647"><tspan
+           id="tspan69645"
+           x="45.033138"
+           y="62.930618"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">transform</tspan></text>
+    </g>
+    <g
+       id="g69657"
+       transform="matrix(2.0000001,0,0,2.0000001,-68.85782,-44.979176)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect69651"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="41.234787"
+         y="65.563751"
+         id="text69655"><tspan
+           id="tspan69653"
+           x="41.234787"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.132291">material</tspan></text>
+    </g>
+    <g
+       id="g83971"
+       transform="translate(-5.3529834e-7,2.8442679)">
+      <path
+         id="path2832"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text77362"><tspan
+           id="tspan77360"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">3</tspan></text>
+    </g>
+    <g
+       id="g84619"
+       transform="translate(55.562498,-18.322398)">
+      <path
+         id="path84613"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84617"><tspan
+           id="tspan84615"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">5</tspan></text>
+    </g>
+    <g
+       id="g84627"
+       transform="translate(58.737498,-60.655731)">
+      <path
+         id="path84621"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84625"><tspan
+           id="tspan84623"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">7</tspan></text>
+    </g>
+    <g
+       id="g84715"
+       transform="translate(97.895831,-31.551565)">
+      <path
+         id="path84709"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84713"><tspan
+           id="tspan84711"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">0</tspan></text>
+    </g>
+    <g
+       id="g84723"
+       transform="translate(121.70833,0.19843463)">
+      <path
+         id="path84717"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84721"><tspan
+           id="tspan84719"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">6</tspan></text>
+    </g>
+    <g
+       id="g84731"
+       transform="translate(84.666665,21.365101)">
+      <path
+         id="path84725"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84729"><tspan
+           id="tspan84727"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">2</tspan></text>
+    </g>
+    <g
+       id="g84739"
+       transform="translate(13.229166,-39.489065)">
+      <path
+         id="path84733"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84737"><tspan
+           id="tspan84735"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">1</tspan></text>
+    </g>
+    <g
+       id="g84747"
+       transform="translate(13.229166,29.302601)">
+      <path
+         id="path84741"
+         style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#2f83cc;fill-opacity:1;stroke:#2f363f;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+         d="m 80,240.25 c -6.525017,0 -11.824509,5.24579 -11.912109,11.75 v 7 H 91.91211 v -7 C 91.82451,245.49579 86.525017,240.25 80,240.25 Z"
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="sccccs" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:21.1666px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+         x="21.217466"
+         y="67.397049"
+         id="text84745"><tspan
+           id="tspan84743"
+           x="21.217466"
+           y="67.397049"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23334px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.264582">4</tspan></text>
+    </g>
+    <g
+       id="g202821"
+       transform="matrix(2.0000001,0,0,2.0000001,52.850512,-37.041663)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#cd3431;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect202815"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="63.5" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="49.767071"
+         y="65.563751"
+         id="text202819"><tspan
+           id="tspan202817"
+           x="44.940006"
+           y="65.563751"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">material #2</tspan></text>
+    </g>
+    <g
+       id="g202829"
+       transform="matrix(2.0000001,0,0,2.0000001,52.850512,-47.625014)"
+       style="stroke-width:0.5">
+      <rect
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:#3bd267;fill-opacity:1;fill-rule:evenodd;stroke:#2f363f;stroke-width:0.066146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect202823"
+         width="15.875003"
+         height="2.6458318"
+         x="37.041664"
+         y="66.145836" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.132291"
+         x="44.968582"
+         y="68.209587"
+         id="text202827"><tspan
+           id="tspan202825"
+           x="44.968582"
+           y="68.209587"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke-width:0.132291">mesh #2</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -219,6 +219,9 @@ See also:
     @ref Trade::PhongMaterialData::normalTextureScale() and
     @ref Trade::PhongMaterialData::normalTextureSwizzle() to make new features
     added for PBR materials recognizable also in classic Phong workflows.
+-   A completely redesigned @ref Trade::SceneData class that stores data of
+    the whole scene in a data-oriented way, allowing for storing custom fields
+    as well. See [mosra/magnum#525](https://github.com/mosra/magnum/pull/525).
 -   New @ref Trade::SkinData class and @ref Trade::AbstractImporter::skin2D() /
     @ref Trade::AbstractImporter::skin3D() family of APIs for skin import, as
     well as support in @ref Trade::AnySceneImporter "AnySceneImporter"

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -634,7 +634,7 @@ See also:
     etc.
 -   @ref Trade::SceneData constructor taking a @ref std::vector of 2D and 3D
     children is deprecated in favor of the new scene representation. Use
-    @ref Trade::SceneData::SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+    @ref Trade::SceneData::SceneData(SceneMappingType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
     instead.
 -   @cpp Trade::SceneData::children2D() @ce and
     @cpp Trade::SceneData::children3D() @ce are deprecated in favor of the
@@ -828,7 +828,7 @@ See also:
     desired use case anymore.
 -   @ref Trade::SceneData constructor taking a @ref std::vector of 2D and 3D
     children that got deprecated in favor of
-    @ref Trade::SceneData::SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+    @ref Trade::SceneData::SceneData(SceneMappingType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
     no longer accepts a scene that has both 2D and 3D children.
 -   The deprecated @cpp Trade::AbstractImporter::object*DCount() @ce,
     @cpp Trade::AbstractImporter::object*DForName() @ce,

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -632,6 +632,15 @@ See also:
     directly but rather generated on-the-fly from attribute data, which makes
     them less efficient than calling @ref Trade::MaterialData::hasAttribute()
     etc.
+-   @ref Trade::SceneData constructor taking a @ref std::vector of 2D and 3D
+    children is deprecated in favor of the new scene representation. Use
+    @ref Trade::SceneData::SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+    instead.
+-   @cpp Trade::SceneData::children2D() @ce and
+    @cpp Trade::SceneData::children3D() @ce are deprecated in favor of the
+    new scene representation. Use @ref Trade::SceneData::childrenFor() with
+    @cpp -1 @ce passed as the @p object argument to get a list of top-level
+    objects.
 -   @ref Trade::AbstractImporter::material() now returns
     @ref Corrade::Containers::Optional instead of a @ref Corrade::Containers::Pointer,
     as the new @ref Trade::MaterialData class isn't polymorphic anymore. If
@@ -805,6 +814,10 @@ See also:
     @cpp Trade::AbstractMaterialData @ce aliases to, doesn't have a
     @cpp virtual @ce destructor as subclasses with extra data members aren't a
     desired use case anymore.
+-   @ref Trade::SceneData constructor taking a @ref std::vector of 2D and 3D
+    children that got deprecated in favor of
+    @ref Trade::SceneData::SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+    no longer accepts a scene that has both 2D and 3D children.
 -   @ref Trade::AbstractImporter::doDefaultScene() is now @cpp const @ce ---
     since the function is not expected to fail, no kind of complex lazy
     population can be done anyway. This is now consistent with `do*Count()`

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -830,6 +830,19 @@ See also:
     children that got deprecated in favor of
     @ref Trade::SceneData::SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
     no longer accepts a scene that has both 2D and 3D children.
+-   The deprecated @cpp Trade::AbstractImporter::object*DCount() @ce,
+    @cpp Trade::AbstractImporter::object*DForName() @ce,
+    @cpp Trade::AbstractImporter::object*DName() @ce and
+    @cpp Trade::AbstractImporter::object*D() @ce accessors now behave different
+    for objects with multiple mesh assignments. This handling was originally
+    present in importer plugins themselves, but as the new
+    @ref Trade::SceneData representation supports multiple mesh/camera/...
+    assignments to a single object natively, the handling was moved to a single
+    place in the compatibility layer. Because the compatibility layer cannot
+    renumber object IDs, the newly added objects are not immediately following
+    the original ID but instead allocated at the end of the object ID range
+    reported by the importer. While the newly added objects have different IDs,
+    they retain the parent name like before.
 -   @ref Trade::AbstractImporter::doDefaultScene() is now @cpp const @ce ---
     since the function is not expected to fail, no kind of complex lazy
     population can be done anyway. This is now consistent with `do*Count()`

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -641,6 +641,18 @@ See also:
     new scene representation. Use @ref Trade::SceneData::childrenFor() with
     @cpp -1 @ce passed as the @p object argument to get a list of top-level
     objects.
+-   @cpp Trade::ObjectData*D @ce, @cpp Trade::MeshObjectData*D @ce classes,
+    @cpp Trade::ObjectInstanceType*D @ce, @cpp Trade::ObjectFlag*D @ce,
+    @cpp Trade::ObjectFlags*D @ce enums and the corresponding
+    @cpp Trade::AbstractImporter::object*DCount() @ce,
+    @cpp Trade::AbstractImporter::object*DForName() @ce,
+    @cpp Trade::AbstractImporter::object*DName() @ce and
+    @cpp Trade::AbstractImporter::object*D() @ce accessor APIs are deprecated
+    in favor of the unified representation in @ref Trade::SceneData and the
+    @ref Trade::AbstractImporter::objectCount(),
+    @relativeref{Trade::AbstractImporter,objectForName()} and
+    @relativeref{Trade::AbstractImporter,objectName()} accessors that are
+    shared for 2D and 3D.
 -   @ref Trade::AbstractImporter::material() now returns
     @ref Corrade::Containers::Optional instead of a @ref Corrade::Containers::Pointer,
     as the new @ref Trade::MaterialData class isn't polymorphic anymore. If

--- a/doc/snippets/MagnumTrade.cpp
+++ b/doc/snippets/MagnumTrade.cpp
@@ -47,8 +47,6 @@
 #include "Magnum/Trade/LightData.h"
 #include "Magnum/Trade/MaterialData.h"
 #include "Magnum/Trade/MeshData.h"
-#include "Magnum/Trade/ObjectData2D.h"
-#include "Magnum/Trade/MeshObjectData3D.h"
 #include "Magnum/Trade/PbrClearCoatMaterialData.h"
 #include "Magnum/Trade/PbrSpecularGlossinessMaterialData.h"
 #include "Magnum/Trade/PbrMetallicRoughnessMaterialData.h"
@@ -66,9 +64,12 @@
 
 #ifdef MAGNUM_BUILD_DEPRECATED
 #define _MAGNUM_NO_DEPRECATED_MESHDATA /* So it doesn't yell here */
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
 
 #include "Magnum/Trade/MeshData2D.h"
 #include "Magnum/Trade/MeshData3D.h"
+#include "Magnum/Trade/MeshObjectData3D.h"
+#include "Magnum/Trade/ObjectData2D.h"
 #endif
 
 #define DOXYGEN_ELLIPSIS(...) __VA_ARGS__
@@ -179,21 +180,6 @@ importer->openFile("scene.gltf"); // memory-maps all files
 /* [AbstractImporter-usage-callbacks] */
 }
 #endif
-
-{
-Containers::Pointer<Trade::AbstractImporter> importer;
-Int materialIndex;
-/* [AbstractImporter-usage-cast] */
-Containers::Pointer<Trade::ObjectData3D> data = importer->object3D(12);
-if(data && data->instanceType() == Trade::ObjectInstanceType3D::Mesh) {
-    auto& mesh = static_cast<Trade::MeshObjectData3D&>(*data);
-
-    materialIndex = mesh.material();
-    // ...
-}
-/* [AbstractImporter-usage-cast] */
-static_cast<void>(materialIndex);
-}
 
 {
 Containers::Pointer<Trade::AbstractImporter> importer;
@@ -844,9 +830,9 @@ MeshTools::transformPointsInPlace(transformation, data.positions(0));
 /* [MeshData2D-transform] */
 CORRADE_IGNORE_DEPRECATED_POP
 }
-#endif
 
 {
+CORRADE_IGNORE_DEPRECATED_PUSH
 Trade::ObjectData2D& baz();
 Trade::ObjectData2D& data = baz();
 /* [ObjectData2D-transformation] */
@@ -855,9 +841,9 @@ Matrix3 transformation =
     Matrix3::scaling(data.scaling());
 /* [ObjectData2D-transformation] */
 static_cast<void>(transformation);
+CORRADE_IGNORE_DEPRECATED_POP
 }
 
-#ifdef MAGNUM_BUILD_DEPRECATED
 {
 CORRADE_IGNORE_DEPRECATED_PUSH
 Trade::MeshData3D& bar();
@@ -871,9 +857,9 @@ MeshTools::transformVectorsInPlace(transformation, data.normals(0));
 /* [MeshData3D-transform] */
 CORRADE_IGNORE_DEPRECATED_POP
 }
-#endif
 
 {
+CORRADE_IGNORE_DEPRECATED_PUSH
 Trade::ObjectData3D& fizz();
 Trade::ObjectData3D& data = fizz();
 /* [ObjectData3D-transformation] */
@@ -882,6 +868,8 @@ Matrix4 transformation =
     Matrix4::scaling(data.scaling());
 /* [ObjectData3D-transformation] */
 static_cast<void>(transformation);
+CORRADE_IGNORE_DEPRECATED_POP
 }
+#endif
 
 }

--- a/doc/snippets/README.md
+++ b/doc/snippets/README.md
@@ -14,12 +14,13 @@ smaller file sizes:
 The output printed by the application can be used to update the example output
 in `doc/getting-started.dox`.
 
-### triangulate.svg
+### triangulate.svg, scenedata-tree.svg, scenedata-dod.svg
 
 Created by Inkscape from `doc/artwork/triangulate.svg` by saving as Optimized
 SVG and:
 
--   cleaning up the `<svg>` header
+-   cleaning up the `<svg>` header (removing `version`, `xmlns`)
 -   converting to a `style=""`, *keeping* `viewBox`
 -   adding `class="m-image"`
--   removing metadata and the background layer
+-   removing metadata, the background layer and all layers that have
+    `display: none`

--- a/doc/snippets/scenedata-dod.svg
+++ b/doc/snippets/scenedata-dod.svg
@@ -1,0 +1,148 @@
+<svg class="m-image" style="width: 530px; height: 240px;" viewBox="0 0 140.23 63.5">
+ <g transform="translate(-1.3229 -1.3229)" stroke-width=".5">
+  <g transform="matrix(2 0 0 2 -67.469 -96.573)">
+   <rect x="37.042" y="63.5" width="15.875" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="40.784985" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" style="line-height:1.25" xml:space="preserve"><tspan x="40.784985" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">materials</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -67.469 -78.052)">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">skins</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -67.469 -109.8)">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">meshes</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -67.469 -107.16)">
+   <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transforms</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -67.469 -125.68)">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">parents</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -67.469 -93.927)">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="44.926247" y="68.158577" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.926247" y="68.158577" stroke-width=".13229"><tspan x="44.926247" y="68.158577" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">lights</tspan></tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -67.469 -85.99)">
+   <path d="m37.042 66.146h15.875v2.6458h-15.875z" fill="#747474" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">cameras</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -34.396 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">7</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -23.813 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">1</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -13.229 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">0</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -2.6458 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">5</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 7.9375 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">3</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 18.521 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 29.104 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">2</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 39.687 -125.68)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">4</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -30.427 -107.16)">
+   <rect x="37.042" y="60.854" width="9.2604" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.68034" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.68034" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">1</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -11.906 -107.16)">
+   <rect x="37.042" y="60.854" width="9.2604" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.68034" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.68034" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">0</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 6.6146 -107.16)">
+   <rect x="37.042" y="60.854" width="9.2604" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.68034" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.68034" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">5</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 25.135 -107.16)">
+   <rect x="37.042" y="60.854" width="9.2604" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.68034" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.68034" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 43.656 -107.16)">
+   <rect x="37.042" y="60.854" width="9.2604" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="41.68034" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.68034" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">2</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -30.427 -85.99)">
+   <path d="m37.042 66.146h2.6458v2.6458h-2.6458z" fill="#747474" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="38.349766" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.349766" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">1</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -30.427 -93.927)">
+   <path d="m37.042 66.146h2.6458v2.6458h-2.6458z" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="38.349766" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.349766" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">1</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -30.427 -78.052)">
+   <path d="m37.042 66.146h2.6458v2.6458h-2.6458z" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="38.349766" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.349766" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">5</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -25.135 -93.927)">
+   <path d="m37.042 66.146h2.6458v2.6458h-2.6458z" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="38.349766" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.349766" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">0</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -19.844 -93.927)">
+   <path d="m37.042 66.146h2.6458v2.6458h-2.6458z" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="38.349766" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.349766" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">4</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -30.427 -96.573)">
+   <rect x="37.042" y="63.5" width="3.9687" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="42.993736" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.973122" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">5</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -22.49 -96.573)">
+   <rect x="37.042" y="63.5" width="3.9687" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="42.993736" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.973122" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -14.552 -96.573)">
+   <rect x="37.042" y="63.5" width="3.9687" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="42.993736" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.973122" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">3</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -6.6146 -96.573)">
+   <rect x="37.042" y="63.5" width="3.9687" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="42.993736" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.973122" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">2</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -34.396 -109.8)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">5</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -23.813 -109.8)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -13.229 -109.8)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">3</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -2.6458 -109.8)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">2</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 -25.135 -78.052)">
+   <path d="m37.042 66.146h2.6458v2.6458h-2.6458z" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="38.349766" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.349766" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">2</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 7.9375 -109.8)">
+   <rect x="39.026" y="66.146" width="5.2917" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="-inkscape-stroke:none;font-variation-settings:normal"/>
+   <text x="41.618961" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="41.618961" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+  </g>
+  <g transform="matrix(2 0 0 2 1.3229 -96.573)">
+   <rect x="37.042" y="63.5" width="3.9687" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="42.993736" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="38.973122" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+  </g>
+ </g>
+</svg>

--- a/doc/snippets/scenedata-tree.svg
+++ b/doc/snippets/scenedata-tree.svg
@@ -1,0 +1,255 @@
+<svg class="m-image" style="width: 620px; height: 440px" viewBox="0 0 164.04 116.42">
+ <g transform="translate(-6.6146 -39.687)" display="none" fill="none" stroke-width=".39688">
+  <g stroke="#c7cf2f">
+   <path d="m31.75 93.927c8.4877 0.10627-3.0463-18.647 5.2917-18.521"/>
+   <path d="m52.917 75.406c8.4877 0.10627-3.0463-12.032 5.2917-11.906"/>
+   <path d="m31.75 62.177c8.4877 0.10627 18.12 1.1971 26.458 1.3229"/>
+   <path d="m31.75 62.177c8.4877 0.10627-3.0463 13.103 5.2917 13.229"/>
+   <path d="m15.875 62.177c-10.062 0.0058-8.338 31.624 4e-6 31.75"/>
+   <path d="m74.083 63.5c12.343 0.023409-26.975 30.498-42.333 30.427"/>
+  </g>
+  <g stroke="#3bd267">
+   <path d="m52.917 72.76c8.4877 0.10627 7.0188-6.5655 0-6.6146" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m52.917 72.76c8.4877 0.10627 7.7839-2.6664 0-2.6458" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m52.917 72.76c8.4877 0.10627 7.0188 5.3407 0 5.2917"/>
+  </g>
+  <g stroke="#747474">
+   <path d="m37.042 72.76c-11.059 0.040797 1.7271-13.18-5.2917-13.229" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m51.594 92.604c-11.059 0.040797-12.825-33.024-19.844-33.073" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m70.115 82.021c-11.059 0.040797-31.346-22.441-38.365-22.49" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+  <g stroke="#3bd267">
+   <path d="m52.917 72.76c8.4877 0.10627 8.5948-27.6 1.5761-27.649" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m85.99 82.021c8.4877 0.10627-24.478-36.86-31.497-36.909" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m85.99 82.021c8.4877 0.10627-26.054-15.826-33.073-15.875" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m85.99 82.021c8.4877 0.10627 7.0188-2.5968 0-2.6458" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m85.99 82.021c8.4877 0.10627 7.0188-6.5655 0-6.6146" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m67.469 92.604c8.4877 0.10627 7.0188-6.5655 4e-6 -6.6146" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m67.469 92.604c8.4877 0.10627 7.0188-2.5968 0-2.6458" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m67.469 92.604c8.4877 0.10627-7.5333-26.409-14.552-26.458" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m67.469 92.604c8.4877 0.10627 7.0188 2.6949 0 2.6458" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m67.469 92.604c8.4877 0.10627-5.9573-47.444-12.976-47.493" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+  <g stroke="#747474">
+   <path d="m31.75 59.531c8.4877 0.10627 29.761-14.371 22.743-14.42" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m31.75 59.531c8.4877 0.10627 7.0188-3.9197 4e-6 -3.9688" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m70.115 82.021c-11.059 0.040797-31.346-22.441-38.365-22.49" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+  <g stroke="#c7cf2f">
+   <path d="m31.75 55.562c8.4877 0.10627 7.0188 6.6636-8e-6 6.6146" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m31.75 89.958c8.4877 0.10627 7.0188 4.0178-4e-6 3.9688" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m52.917 66.146c8.4877 0.10627 7.0188 9.3095 0 9.2604" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m74.083 59.531c8.4877 0.10627 7.0188 4.0178 0 3.9687" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m37.042 66.146c-15.875 1e-6 1.7271 27.83-5.2917 27.781" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m38.618 45.111c-18.157 0.17354 0.15104 48.865-6.8677 48.816" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m54.493 45.111c8.4877 0.10627-6.3079 17.8 3.7156 18.389" stop-color="#000000" style="font-variation-settings:normal"/>
+   <path d="m38.618 45.111c-16.175 0.10989 21.318 30.344 14.299 30.295" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+ </g>
+ <g transform="translate(-7.9375)" display="none">
+  <g transform="translate(-9.2604 -26.458)" display="inline">
+   <rect x="37.042" y="63.5" width="15.875" height="2.6458" display="inline" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="41.234787" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" style="line-height:1.25" xml:space="preserve"><tspan x="41.234787" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">materials</tspan></text>
+  </g>
+  <rect x="46.302" y="37.042" width="3.9026" height="2.6458" display="inline" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+  <g transform="translate(-9.2604 -25.135)" display="inline">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" display="inline" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">textures</tspan></text>
+  </g>
+  <g transform="translate(-9.2604 -33.073)" display="inline">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" display="inline" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">meshes</tspan></text>
+  </g>
+  <rect x="46.302" y="33.073" width="7.8714" height="2.6458" display="inline" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+  <g transform="translate(-9.2604 -35.719)" display="inline">
+   <rect x="37.042" y="60.854" width="15.875" height="2.6458" display="inline" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transforms</tspan></text>
+  </g>
+  <rect x="46.302" y="25.135" width="2.5797" height="2.6458" display="inline" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+  <g transform="translate(-9.2604 -44.979)" display="inline">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" display="inline" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">parents</tspan></text>
+  </g>
+  <rect x="46.302" y="21.167" width="2.5797" height="2.6458" display="inline" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+  <g transform="translate(-9.2604 -37.042)" display="inline">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" display="inline" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="44.926247" y="68.158577" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.926247" y="68.158577" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">physics</tspan></text>
+  </g>
+  <g transform="translate(-9.2604 -51.594)" display="inline">
+   <rect x="37.042" y="66.146" width="15.875" height="2.6458" display="inline" fill="#747474" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".13229" style="font-variation-settings:normal"/>
+   <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">camera</tspan></text>
+  </g>
+  <g fill="#c7cf2f" fill-rule="evenodd" stroke="#2f363f" stroke-width=".13229">
+   <rect x="46.335" y="29.104" width="5.2255" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="51.627" y="29.104" width="5.2255" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="62.243" y="29.104" width="5.2255" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="56.918" y="29.104" width="5.2255" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+  <g fill="#2f83cc" fill-rule="evenodd" stroke="#2f363f" stroke-width=".13229">
+   <rect x="49.014" y="21.167" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="51.66" y="21.167" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="54.306" y="21.167" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="56.918" y="21.167" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="56.918" y="21.167" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+  <g fill="#a5c9ea" fill-rule="evenodd" stroke="#2f363f" stroke-width=".13229">
+   <rect x="49.014" y="25.135" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="51.627" y="25.135" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="54.306" y="25.135" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="56.952" y="25.135" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="59.597" y="25.135" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="62.243" y="25.135" width="2.5797" height="2.6458" display="inline" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+  <g fill-rule="evenodd" stroke="#2f363f" stroke-width=".13229">
+   <rect x="59.531" y="21.167" width="2.5797" height="2.6458" display="inline" fill="#2f83cc" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="54.306" y="33.073" width="7.8714" height="2.6458" display="inline" fill="#3bd267" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="62.21" y="33.073" width="7.8714" height="2.6458" display="inline" fill="#3bd267" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="49.642" y="37.042" width="3.9026" height="2.6458" display="inline" fill="#cd3431" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="52.983" y="37.042" width="3.9026" height="2.6458" display="inline" fill="#cd3431" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="46.302" y="41.01" width="10.517" height="2.6458" display="inline" fill="#2f83cc" stop-color="#000000" style="font-variation-settings:normal"/>
+   <rect x="56.918" y="41.01" width="10.517" height="2.6458" display="inline" fill="#2f83cc" stop-color="#000000" style="font-variation-settings:normal"/>
+  </g>
+ </g>
+ <g transform="matrix(1.8788 0 0 1.913 -12.427 -75.924)" stroke-width=".52747">
+  <rect x="6.6146" y="39.687" width="87.312" height="60.854" fill="#2f363f" stop-color="#000000"/>
+ </g>
+ <g transform="matrix(2 0 0 2 -13.229 -79.375)" fill="none" stroke="#2f83cc" stroke-width=".066146">
+  <path d="m44.979 64.823c-0.04047 7.8835 32.952 0.94798 33.073 9.1281" stop-color="#000000" style="font-variation-settings:normal"/>
+  <path d="m44.979 64.823c-0.04047 7.8835 14.431 11.664 14.552 19.844" stop-color="#000000" style="font-variation-settings:normal"/>
+  <path d="m44.979 64.823c-0.04047 7.8835-21.287 15.5-21.167 23.68" stop-color="#000000" style="font-variation-settings:normal"/>
+  <path d="m23.813 54.24c-0.04047 7.8835-6.7353 12.987-6.6146 21.167" stop-color="#000000" style="font-variation-settings:normal"/>
+  <path d="m46.555 43.656c-0.04047 7.8835 19.47 6.2397 19.591 14.42" stop-color="#000000" style="font-variation-settings:normal"/>
+  <path d="m46.555 43.656c-0.04047 7.8835-22.863 2.4032-22.743 10.583" stop-color="#000000" style="font-variation-settings:normal"/>
+  <path d="m46.555 43.656c-0.04047 7.8835-1.6968 12.987-1.5761 21.167" stop-color="#000000" style="font-variation-settings:normal"/>
+ </g>
+ <g transform="matrix(2 0 0 2 -13.229 -66.146)">
+  <rect x="37.042" y="63.5" width="15.875" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="41.234787" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" style="line-height:1.25" xml:space="preserve"><tspan x="41.234787" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">material</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -13.229 -76.729)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">mesh</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -13.229 -66.146)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">skin</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 52.917 -47.625)">
+  <rect x="37.042" y="63.5" width="15.875" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="41.234787" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" style="line-height:1.25" xml:space="preserve"><tspan x="41.234787" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">material</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 52.917 -58.208)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">mesh</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 29.104 -89.958)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.926247" y="68.158577" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.926247" y="68.158577" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">light</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 15.875 -26.458)">
+  <rect x="37.042" y="63.5" width="15.875" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="41.234787" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" style="line-height:1.25" xml:space="preserve"><tspan x="41.234787" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">material</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 15.875 -37.042)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">mesh</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 15.875 -26.458)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#2f83cc" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">skin</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -55.629 -29.104)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.926247" y="68.158577" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.926247" y="68.158577" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">light</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -55.563 -97.896)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#747474" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">camera</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -55.563 -92.604)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#c7cf2f" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.926247" y="68.158577" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.926247" y="68.158577" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">light</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 29.104 -84.667)">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -68.792 -50.271)" opacity=".25">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" opacity="1" stop-color="#000000" stroke="#a5c9ea" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 52.917 -52.917)">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 15.875 -31.75)">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -55.563 -66.146)" stroke-width=".5">
+  <g transform="translate(21.167 -2.6458)">
+   <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+   <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+  </g>
+ </g>
+ <g transform="matrix(2 0 0 2 -55.562 -92.604)">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -68.792 -55.563)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">mesh</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -10.583 -113.77)" opacity=".25">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" opacity="1" stop-color="#000000" stroke="#a5c9ea" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -55.563 -23.813)" opacity=".25">
+  <rect x="37.042" y="60.854" width="15.875" height="2.6458" fill="#a5c9ea" fill-rule="evenodd" opacity="1" stop-color="#000000" stroke="#a5c9ea" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="45.033138" y="62.930618" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="45.033138" y="62.930618" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">transform</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 -68.858 -44.979)">
+  <rect x="37.042" y="63.5" width="15.875" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="41.234787" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" style="line-height:1.25" xml:space="preserve"><tspan x="41.234787" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">material</tspan></text>
+ </g>
+ <g transform="translate(-5.353e-7 2.8443)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">3</tspan></text>
+ </g>
+ <g transform="translate(55.562 -18.322)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">5</tspan></text>
+ </g>
+ <g transform="translate(58.737 -60.656)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">7</tspan></text>
+ </g>
+ <g transform="translate(97.896 -31.552)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">0</tspan></text>
+ </g>
+ <g transform="translate(121.71 .19843)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">6</tspan></text>
+ </g>
+ <g transform="translate(84.667 21.365)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">2</tspan></text>
+ </g>
+ <g transform="translate(13.229 -39.489)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">1</tspan></text>
+ </g>
+ <g transform="translate(13.229 29.303)">
+  <path transform="scale(.26458)" d="m80 240.25c-6.525 0-11.825 5.2458-11.912 11.75v7h23.824v-7c-0.0876-6.5042-5.3871-11.75-11.912-11.75z" fill="#2f83cc" stop-color="#000000" stroke="#2f363f" stroke-width=".5" style="font-variation-settings:normal"/>
+  <text x="21.217466" y="67.397049" fill="#000000" font-family="sans-serif" font-size="21.167px" stroke-width=".26458" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="21.217466" y="67.397049" font-family="'Source Sans Pro'" font-size="4.2333px" stroke-width=".26458" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">4</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 52.851 -37.042)">
+  <rect x="37.042" y="63.5" width="15.875" height="2.6458" fill="#cd3431" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="49.767071" y="65.563751" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.940006" y="65.563751" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">material #2</tspan></text>
+ </g>
+ <g transform="matrix(2 0 0 2 52.851 -47.625)">
+  <rect x="37.042" y="66.146" width="15.875" height="2.6458" fill="#3bd267" fill-rule="evenodd" stop-color="#000000" stroke="#2f363f" stroke-width=".066146" style="font-variation-settings:normal"/>
+  <text x="44.968582" y="68.209587" fill="#000000" font-family="sans-serif" font-size="10.583px" stroke-width=".13229" text-align="center" text-anchor="middle" style="line-height:1.25" xml:space="preserve"><tspan x="44.968582" y="68.209587" font-family="'Source Sans Pro'" font-size="2.1167px" stroke-width=".13229" text-align="center" text-anchor="middle" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal">mesh #2</tspan></text>
+ </g>
+</svg>

--- a/doc/vulkan-mapping.dox
+++ b/doc/vulkan-mapping.dox
@@ -429,7 +429,7 @@ Vulkan structure                        | Matching API
 @type_vk{ClearColorValue}               | convertible from/to @ref Magnum::Vector3 "Vector3", @ref Magnum::Color3 "Color3", @ref Magnum::Vector4 "Vector4", @ref Magnum::Color4 "Color4", @ref Magnum::Vector4i "Vector4i", @ref Magnum::Vector4ui "Vector4ui" using @ref Magnum/Vk/Integration.h; only exposed through @ref RenderPassBeginInfo::clearColor() and @ref CommandBuffer::clearColorImage() overloads
 @type_vk{ClearDepthStencilValue}        | only exposed through @ref RenderPassBeginInfo::clearDepthStencil(), @ref CommandBuffer::clearDepthStencilImage() and friends
 @type_vk{ClearValue}                    | only exposed through @ref RenderPassBeginInfo::clearColor() and @relativeref{RenderPassBeginInfo,clearDepthStencil()} overloads
-@type_vk{ClearRect}                     | convertible from/to @ref Range3Di using @ref Magnum/Vk/Integration.h
+@type_vk{ClearRect}                     | convertible from/to @relativeref{Magnum,Range3Di} using @ref Magnum/Vk/Integration.h
 @type_vk{CommandBufferAllocateInfo}     | not exposed, internal to @ref CommandPool::allocate()
 @type_vk{CommandBufferBeginInfo}        | @ref CommandBufferBeginInfo
 @type_vk{CommandBufferInheritanceInfo}  | |
@@ -692,7 +692,7 @@ Vulkan structure                        | Matching API
 @type_vk{RayTracingPipelineCreateInfoKHR} @m_class{m-label m-flat m-warning} **KHR** | |
 @type_vk{RayTracingPipelineInterfaceCreateInfoKHR} @m_class{m-label m-flat m-warning} **KHR** | |
 @type_vk{RayTracingShaderGroupCreateInfoKHR} @m_class{m-label m-flat m-warning} **KHR** | |
-@type_vk{Rect2D}                        | convertible from/to @ref Range2Di using @ref Magnum/Vk/Integration.h
+@type_vk{Rect2D}                        | convertible from/to @relativeref{Magnum,Range2Di} using @ref Magnum/Vk/Integration.h
 @type_vk{RenderPassBeginInfo}           | @ref RenderPassBeginInfo
 @type_vk{RenderPassAttachmentBeginInfo} @m_class{m-label m-flat m-success} **KHR, 1.2** | |
 @type_vk{RenderPassCreateInfo}, \n @type_vk{RenderPassCreateInfo2} @m_class{m-label m-flat m-success} **KHR, 1.2** | @ref RenderPassCreateInfo
@@ -755,7 +755,7 @@ Vulkan structure                        | Matching API
 @type_vk{VertexInputBindingDescription} | @ref MeshLayout
 @type_vk{VertexInputBindingDivisorDescriptionEXT} @m_class{m-label m-flat m-warning} **EXT** | @ref MeshLayout
 @type_vk{VertexInputAttributeDescription} | @ref MeshLayout
-@type_vk{Viewport}                      | convertible from/to @ref Range3D using @ref Magnum/Vk/Integration.h
+@type_vk{Viewport}                      | convertible from/to @relativeref{Magnum,Range3D} using @ref Magnum/Vk/Integration.h
 
 @subsection vulkan-mapping-structures-w W
 

--- a/src/Magnum/MeshTools/sceneconverter.cpp
+++ b/src/Magnum/MeshTools/sceneconverter.cpp
@@ -386,8 +386,8 @@ used.)")
 
         struct SceneInfo {
             UnsignedInt scene;
-            Trade::SceneObjectType objectType;
-            UnsignedLong objectCount;
+            Trade::SceneMappingType mappingType;
+            UnsignedLong mappingBound;
             Containers::Array<SceneFieldInfo> fields;
             std::size_t dataSize;
             std::string name;
@@ -410,8 +410,8 @@ used.)")
 
             SceneInfo info{};
             info.scene = i;
-            info.objectType = scene->objectType();
-            info.objectCount = scene->objectCount();
+            info.mappingType = scene->mappingType();
+            info.mappingBound = scene->mappingBound();
             info.dataSize = scene->data().size();
             info.name = importer->sceneName(i);
             for(UnsignedInt j = 0; j != scene->fieldCount(); ++j) {
@@ -666,7 +666,7 @@ used.)")
             d << "Scene" << info.scene << Debug::nospace << ":";
             if(!info.name.empty()) d << info.name;
             d << Debug::newline;
-            d << "   " << info.objectCount << "objects," << info.objectType
+            d << "    bound:" << info.mappingBound << "objects," << info.mappingType
                 << "(" << Debug::nospace << Utility::formatString("{:.1f}", info.dataSize/1024.0f) << "kB)";
 
             for(const SceneFieldInfo& field: info.fields) {

--- a/src/Magnum/MeshTools/sceneconverter.cpp
+++ b/src/Magnum/MeshTools/sceneconverter.cpp
@@ -379,6 +379,7 @@ used.)")
         struct SceneFieldInfo {
             Trade::SceneField name;
             std::string customName;
+            Trade::SceneFieldFlags flags;
             Trade::SceneFieldType type;
             UnsignedInt arraySize;
             std::size_t size;
@@ -439,6 +440,7 @@ used.)")
                     name,
                     Trade::isSceneFieldCustom(name) ?
                         importer->sceneFieldName(name) : "",
+                    scene->fieldFlags(j),
                     scene->fieldType(j),
                     scene->fieldArraySize(j),
                     scene->fieldSize(j));
@@ -679,6 +681,8 @@ used.)")
                 if(field.arraySize)
                     d << Debug::nospace << Utility::formatString("[{}]", field.arraySize);
                 d << Debug::nospace << "," << field.size << "entries";
+                if(field.flags)
+                    d << Debug::newline << "   " << field.flags;
             }
         }
 

--- a/src/Magnum/MeshTools/sceneconverter.cpp
+++ b/src/Magnum/MeshTools/sceneconverter.cpp
@@ -417,22 +417,22 @@ used.)")
             for(UnsignedInt j = 0; j != scene->fieldCount(); ++j) {
                 const Trade::SceneField name = scene->fieldName(j);
 
-                if(name == Trade::SceneField::Mesh) for(const Containers::Pair<UnsignedInt, Int>& meshMaterial: scene->meshesMaterialsAsArray()) {
+                if(name == Trade::SceneField::Mesh) for(const Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>& meshMaterial: scene->meshesMaterialsAsArray()) {
                     if(meshMaterial.first() < meshReferenceCount.size())
                         ++meshReferenceCount[meshMaterial.first()];
-                    if(UnsignedInt(meshMaterial.second()) < materialReferenceCount.size())
-                        ++materialReferenceCount[meshMaterial.second()];
+                    if(UnsignedInt(meshMaterial.second().second()) < materialReferenceCount.size())
+                        ++materialReferenceCount[meshMaterial.second().second()];
                 }
 
-                if(name == Trade::SceneField::Skin) for(const UnsignedInt skin: scene->skinsAsArray()) {
-                    if(skin < skinReferenceCount.size())
-                        ++skinReferenceCount[skin];
+                if(name == Trade::SceneField::Skin) for(const Containers::Pair<UnsignedInt, UnsignedInt> skin: scene->skinsAsArray()) {
+                    if(skin.second() < skinReferenceCount.size())
+                        ++skinReferenceCount[skin.second()];
                     /** @todo 2D/3D distinction */
                 }
 
-                if(name == Trade::SceneField::Light) for(const UnsignedInt light: scene->lightsAsArray()) {
-                    if(light < lightReferenceCount.size())
-                        ++lightReferenceCount[light];
+                if(name == Trade::SceneField::Light) for(const Containers::Pair<UnsignedInt, UnsignedInt>& light: scene->lightsAsArray()) {
+                    if(light.second() < lightReferenceCount.size())
+                        ++lightReferenceCount[light.second()];
                 }
 
                 arrayAppend(info.fields, InPlaceInit,

--- a/src/Magnum/MeshTools/sceneconverter.cpp
+++ b/src/Magnum/MeshTools/sceneconverter.cpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <sstream>
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Utility/Arguments.h>
 #include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/Directory.h>
@@ -37,6 +38,7 @@
 #include "Magnum/PixelFormat.h"
 #include "Magnum/Implementation/converterUtilities.h"
 #include "Magnum/Math/Color.h"
+#include "Magnum/Math/Matrix4.h"
 #include "Magnum/Math/FunctionsBatch.h"
 #include "Magnum/MeshTools/RemoveDuplicates.h"
 #include "Magnum/Trade/AbstractImporter.h"
@@ -44,7 +46,7 @@
 #include "Magnum/Trade/LightData.h"
 #include "Magnum/Trade/MaterialData.h"
 #include "Magnum/Trade/MeshData.h"
-#include "Magnum/Trade/MeshObjectData3D.h"
+#include "Magnum/Trade/SceneData.h"
 #include "Magnum/Trade/SkinData.h"
 #include "Magnum/Trade/TextureData.h"
 #include "Magnum/Trade/AbstractSceneConverter.h"
@@ -213,6 +215,7 @@ bool isInfoRequested(const Utility::Arguments& args) {
            args.isSet("info-lights") ||
            args.isSet("info-materials") ||
            args.isSet("info-meshes") ||
+           args.isSet("info-scenes") ||
            args.isSet("info-skins") ||
            args.isSet("info-textures") ||
            args.isSet("info");
@@ -242,6 +245,7 @@ int main(int argc, char** argv) {
         .addBooleanOption("info-lights").setHelp("info-lights", "print info about images in the input file and exit")
         .addBooleanOption("info-materials").setHelp("info-materials", "print info about materials in the input file and exit")
         .addBooleanOption("info-meshes").setHelp("info-meshes", "print info about meshes in the input file and exit")
+        .addBooleanOption("info-scenes").setHelp("info-scenes", "print info about textures in the input file and exit")
         .addBooleanOption("info-skins").setHelp("info-skins", "print info about skins in the input file and exit")
         .addBooleanOption("info-textures").setHelp("info-textures", "print info about textures in the input file and exit")
         .addBooleanOption("info").setHelp("info", "print info about everything in the input file and exit, same as specifying all other --info-* options together")
@@ -372,30 +376,79 @@ used.)")
             std::string name;
         };
 
+        struct SceneFieldInfo {
+            Trade::SceneField name;
+            std::string customName;
+            Trade::SceneFieldType type;
+            UnsignedInt arraySize;
+            std::size_t size;
+        };
+
+        struct SceneInfo {
+            UnsignedInt scene;
+            Trade::SceneObjectType objectType;
+            UnsignedLong objectCount;
+            Containers::Array<SceneFieldInfo> fields;
+            std::size_t dataSize;
+            std::string name;
+            /** @todo object names? */
+        };
+
         /* Parse everything first to avoid errors interleaved with output */
 
-        /* Scene properties. Currently just counting how much is each mesh /
-           light / material shared. Texture reference count is calculated when
-           parsing materials. */
+        /* Scene properties, together with counting how much is each mesh /
+           light / material / skin shared. Texture reference count is
+           calculated when parsing materials. */
+        Containers::Array<SceneInfo> sceneInfos;
         Containers::Array<UnsignedInt> materialReferenceCount{importer->materialCount()};
         Containers::Array<UnsignedInt> lightReferenceCount{importer->lightCount()};
         Containers::Array<UnsignedInt> meshReferenceCount{importer->meshCount()};
         Containers::Array<UnsignedInt> skinReferenceCount{importer->skin3DCount()};
-        for(UnsignedInt i = 0; i != importer->object3DCount(); ++i) {
-            Containers::Pointer<Trade::ObjectData3D> object = importer->object3D(i);
-            if(!object) continue;
-            if(object->instanceType() == Trade::ObjectInstanceType3D::Mesh) {
-                auto& meshObject = static_cast<Trade::MeshObjectData3D&>(*object);
-                if(std::size_t(meshObject.instance()) < meshReferenceCount.size())
-                    ++meshReferenceCount[meshObject.instance()];
-                if(std::size_t(meshObject.material()) < materialReferenceCount.size())
-                    ++materialReferenceCount[meshObject.material()];
-                if(std::size_t(meshObject.skin()) < skinReferenceCount.size())
-                    ++skinReferenceCount[meshObject.skin()];
-            } else if(object->instanceType() == Trade::ObjectInstanceType3D::Light) {
-                if(std::size_t(object->instance()) < lightReferenceCount.size())
-                    ++lightReferenceCount[object->instance()];
+        if(args.isSet("info") || args.isSet("info-scenes") || args.isSet("info-materials") || args.isSet("info-lights") || args.isSet("info-meshes") || args.isSet("info-skins")) for(UnsignedInt i = 0; i != importer->sceneCount(); ++i) {
+            Containers::Optional<Trade::SceneData> scene = importer->scene(i);
+            if(!scene) continue;
+
+            SceneInfo info{};
+            info.scene = i;
+            info.objectType = scene->objectType();
+            info.objectCount = scene->objectCount();
+            info.dataSize = scene->data().size();
+            info.name = importer->sceneName(i);
+            for(UnsignedInt j = 0; j != scene->fieldCount(); ++j) {
+                const Trade::SceneField name = scene->fieldName(j);
+
+                if(name == Trade::SceneField::Mesh) for(const Containers::Pair<UnsignedInt, Int>& meshMaterial: scene->meshesMaterialsAsArray()) {
+                    if(meshMaterial.first() < meshReferenceCount.size())
+                        ++meshReferenceCount[meshMaterial.first()];
+                    if(UnsignedInt(meshMaterial.second()) < materialReferenceCount.size())
+                        ++materialReferenceCount[meshMaterial.second()];
+                }
+
+                if(name == Trade::SceneField::Skin) for(const UnsignedInt skin: scene->skinsAsArray()) {
+                    if(skin < skinReferenceCount.size())
+                        ++skinReferenceCount[skin];
+                    /** @todo 2D/3D distinction */
+                }
+
+                if(name == Trade::SceneField::Light) for(const UnsignedInt light: scene->lightsAsArray()) {
+                    if(light < lightReferenceCount.size())
+                        ++lightReferenceCount[light];
+                }
+
+                arrayAppend(info.fields, InPlaceInit,
+                    name,
+                    Trade::isSceneFieldCustom(name) ?
+                        importer->sceneFieldName(name) : "",
+                    scene->fieldType(j),
+                    scene->fieldArraySize(j),
+                    scene->fieldSize(j));
             }
+
+            /* Add it to the array only if scene info was requested. We're
+               going through this loop also if just light / material / mesh /
+               skin info is requested, to gather reference count */
+            if(args.isSet("info") || args.isSet("info-scenes"))
+                arrayAppend(sceneInfos, std::move(info));
         }
 
         /* Animation properties */
@@ -608,6 +661,27 @@ used.)")
         if(args.isSet("info") || args.isSet("info-images")) imageInfos =
             Trade::Implementation::imageInfo(*importer, error, compactImages);
 
+        for(const SceneInfo& info: sceneInfos) {
+            Debug d;
+            d << "Scene" << info.scene << Debug::nospace << ":";
+            if(!info.name.empty()) d << info.name;
+            d << Debug::newline;
+            d << "   " << info.objectCount << "objects," << info.objectType
+                << "(" << Debug::nospace << Utility::formatString("{:.1f}", info.dataSize/1024.0f) << "kB)";
+
+            for(const SceneFieldInfo& field: info.fields) {
+                d << Debug::newline << " " << field.name;
+                if(Trade::isSceneFieldCustom(field.name)) {
+                    d << "(" << Debug::nospace << field.customName
+                        << Debug::nospace << ")";
+                }
+                d << "@" << field.type;
+                if(field.arraySize)
+                    d << Debug::nospace << Utility::formatString("[{}]", field.arraySize);
+                d << Debug::nospace << "," << field.size << "entries";
+            }
+        }
+
         for(const AnimationInfo& info: animationInfos) {
             Debug d;
             d << "Animation" << info.animation << Debug::nospace << ":";
@@ -641,7 +715,7 @@ used.)")
             d << "Skin" << info.skin;
             /* Print reference count only if there actually is a scene,
                otherwise this information is useless */
-            if(importer->object3DCount())
+            if(importer->objectCount())
                 d << Utility::formatString("(referenced by {} objects)", info.references);
             d << Debug::nospace << ":";
             if(!info.name.empty()) d << info.name;
@@ -654,7 +728,7 @@ used.)")
             d << "Light" << info.light;
             /* Print reference count only if there actually is a scene,
                otherwise this information is useless */
-            if(importer->object3DCount())
+            if(importer->objectCount())
                 d << Utility::formatString("(referenced by {} objects)", info.references);
             d << Debug::nospace << ":";
             if(!info.name.empty()) d << info.name;
@@ -673,7 +747,7 @@ used.)")
             d << "Material" << info.material;
             /* Print reference count only if there actually is a scene,
                otherwise this information is useless */
-            if(importer->object3DCount())
+            if(importer->objectCount())
                 d << Utility::formatString("(referenced by {} objects)", info.references);
             d << Debug::nospace << ":";
             if(!info.name.empty()) d << info.name;
@@ -756,7 +830,7 @@ used.)")
                 d << "Mesh" << info.mesh;
                 /* Print reference count only if there actually is a scene,
                    otherwise this information is useless */
-                if(importer->object3DCount())
+                if(importer->objectCount())
                     d << Utility::formatString("(referenced by {} objects)", info.references);
                 d << Debug::nospace << ":";
                 if(!info.name.empty()) d << info.name;

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -621,7 +621,7 @@ std::string AbstractImporter::doObject2DName(const UnsignedInt id) {
            _cachedScenes->scenes[i]->mappingBound() <= id)
             continue;
 
-        if(Containers::Optional<Int> parent = _cachedScenes->scenes[i]->parentFor(id))
+        if(Containers::Optional<Long> parent = _cachedScenes->scenes[i]->parentFor(id))
             return doObjectName(*parent);
     }
 
@@ -678,7 +678,7 @@ Containers::Pointer<ObjectData2D> AbstractImporter::doObject2D(const UnsignedInt
 
     std::vector<UnsignedInt> children; /* not const so we can move it */
     {
-        Containers::Array<UnsignedInt> childrenArray = scene.childrenFor(id);
+        Containers::Array<UnsignedLong> childrenArray = scene.childrenFor(id);
         children = {childrenArray.begin(), childrenArray.end()};
     }
     const Containers::Array<Containers::Pair<UnsignedInt, Int>> mesh = scene.meshesMaterialsFor(id);
@@ -799,7 +799,7 @@ std::string AbstractImporter::doObject3DName(const UnsignedInt id) {
            _cachedScenes->scenes[i]->mappingBound() <= id)
             continue;
 
-        if(Containers::Optional<Int> parent = _cachedScenes->scenes[i]->parentFor(id))
+        if(Containers::Optional<Long> parent = _cachedScenes->scenes[i]->parentFor(id))
             return doObjectName(*parent);
     }
 
@@ -856,7 +856,7 @@ Containers::Pointer<ObjectData3D> AbstractImporter::doObject3D(const UnsignedInt
 
     std::vector<UnsignedInt> children; /* not const so we can move it */
     {
-        Containers::Array<UnsignedInt> childrenArray = scene.childrenFor(id);
+        Containers::Array<UnsignedLong> childrenArray = scene.childrenFor(id);
         children = {childrenArray.begin(), childrenArray.end()};
     }
     const Containers::Array<Containers::Pair<UnsignedInt, Int>> mesh = scene.meshesMaterialsFor(id);

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -538,13 +538,13 @@ void AbstractImporter::populateCachedScenes() {
                except for the above, also because it doesn't take into account
                the restriction for unique-functioning objects. */
             if(_cachedScenes->scenes[i]->is2D())
-                _cachedScenes->object2DCount = Math::max(_cachedScenes->object2DCount, UnsignedInt(_cachedScenes->scenes[i]->objectCount()));
+                _cachedScenes->object2DCount = Math::max(_cachedScenes->object2DCount, UnsignedInt(_cachedScenes->scenes[i]->mappingBound()));
             if(_cachedScenes->scenes[i]->is3D())
-                _cachedScenes->object3DCount = Math::max(_cachedScenes->object3DCount, UnsignedInt(_cachedScenes->scenes[i]->objectCount()));
+                _cachedScenes->object3DCount = Math::max(_cachedScenes->object3DCount, UnsignedInt(_cachedScenes->scenes[i]->mappingBound()));
 
             /* Ensure the newly added objects for each scene don't overlap each
                other */
-            newObjectOffset = Math::max(newObjectOffset, _cachedScenes->scenes[i]->objectCount());
+            newObjectOffset = Math::max(newObjectOffset, _cachedScenes->scenes[i]->mappingBound());
         }
     }
 
@@ -618,7 +618,7 @@ std::string AbstractImporter::doObject2DName(const UnsignedInt id) {
     for(UnsignedInt i = 0; i != _cachedScenes->scenes.size(); ++i) {
         if(!_cachedScenes->scenes[i] ||
            !_cachedScenes->scenes[i]->is2D() ||
-           _cachedScenes->scenes[i]->objectCount() <= id)
+           _cachedScenes->scenes[i]->mappingBound() <= id)
             continue;
 
         if(Containers::Optional<Int> parent = _cachedScenes->scenes[i]->parentFor(id))
@@ -643,7 +643,7 @@ Containers::Pointer<ObjectData2D> AbstractImporter::doObject2D(const UnsignedInt
     populateCachedScenes();
 
     /* Find the first 2D scene with this object, which we'll detect from the
-       object count reported for the scene, whether it's 2D or 3D, and a
+       mapping bound reported for the scene, whether it's 2D or 3D, and a
        presence of a parent attribute. If a parent attribute is not present, it
        means the object isn't a part of this scene, in which case we skip it.
        It could also mean isn't a part of the hierarchy and is standalone
@@ -652,7 +652,7 @@ Containers::Pointer<ObjectData2D> AbstractImporter::doObject2D(const UnsignedInt
     std::size_t sceneCandidate = ~std::size_t{};
     for(std::size_t i = 0; i != _cachedScenes->scenes.size(); ++i) {
         const Containers::Optional<SceneData>& scene = _cachedScenes->scenes[i];
-        if(scene && scene->is2D() && id < scene->objectCount() && scene->parentFor(id)) {
+        if(scene && scene->is2D() && id < scene->mappingBound() && scene->parentFor(id)) {
             sceneCandidate = i;
             break;
         }
@@ -796,7 +796,7 @@ std::string AbstractImporter::doObject3DName(const UnsignedInt id) {
     for(UnsignedInt i = 0; i != _cachedScenes->scenes.size(); ++i) {
         if(!_cachedScenes->scenes[i] ||
            !_cachedScenes->scenes[i]->is3D() ||
-           _cachedScenes->scenes[i]->objectCount() <= id)
+           _cachedScenes->scenes[i]->mappingBound() <= id)
             continue;
 
         if(Containers::Optional<Int> parent = _cachedScenes->scenes[i]->parentFor(id))
@@ -821,7 +821,7 @@ Containers::Pointer<ObjectData3D> AbstractImporter::doObject3D(const UnsignedInt
     populateCachedScenes();
 
     /* Find the first 3D scene with this object, which we'll detect from the
-       object count reported for the scene, whether it's 2D or 3D, and a
+       mapping bound reported for the scene, whether it's 2D or 3D, and a
        presence of a parent attribute. If a parent attribute is not present, it
        means the object isn't a part of this scene, in which case we skip it.
        It could also mean isn't a part of the hierarchy and is standalone
@@ -830,7 +830,7 @@ Containers::Pointer<ObjectData3D> AbstractImporter::doObject3D(const UnsignedInt
     std::size_t sceneCandidate = ~std::size_t{};
     for(std::size_t i = 0; i != _cachedScenes->scenes.size(); ++i) {
         const Containers::Optional<SceneData>& scene = _cachedScenes->scenes[i];
-        if(scene && scene->is3D() && id < scene->objectCount() && scene->parentFor(id)) {
+        if(scene && scene->is3D() && id < scene->mappingBound() && scene->parentFor(id)) {
             sceneCandidate = i;
             break;
         }

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -68,7 +68,7 @@ namespace Magnum { namespace Trade {
 std::string AbstractImporter::pluginInterface() {
     return
 /* [interface] */
-"cz.mosra.magnum.Trade.AbstractImporter/0.3.4"
+"cz.mosra.magnum.Trade.AbstractImporter/0.4"
 /* [interface] */
     ;
 }

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -519,6 +519,8 @@ void AbstractImporter::populateCachedScenes() {
 
     _cachedScenes.emplace();
     _cachedScenes->scenes = Containers::Array<Containers::Optional<SceneData>>{sceneCount()};
+
+    UnsignedLong newObjectOffset = objectCount();
     for(UnsignedInt i = 0; i != _cachedScenes->scenes.size(); ++i) {
         _cachedScenes->scenes[i] = scene(i);
         if(_cachedScenes->scenes[i]) {
@@ -529,7 +531,7 @@ void AbstractImporter::populateCachedScenes() {
                compatibility code path anyway, so just skip the processing
                altogether in that case. */
             if(_cachedScenes->scenes[i]->hasField(SceneField::Parent))
-                _cachedScenes->scenes[i] = Implementation::sceneConvertToSingleFunctionObjects(*_cachedScenes->scenes[i], Containers::arrayView({SceneField::Mesh, SceneField::Camera, SceneField::Light}), objectCount());
+                _cachedScenes->scenes[i] = Implementation::sceneConvertToSingleFunctionObjects(*_cachedScenes->scenes[i], Containers::arrayView({SceneField::Mesh, SceneField::Camera, SceneField::Light}), newObjectOffset);
 
             /* Return the 2D/3D object count based on which scenes are 2D and
                which not. The objectCount() provided by the importer is ignored
@@ -539,6 +541,10 @@ void AbstractImporter::populateCachedScenes() {
                 _cachedScenes->object2DCount = Math::max(_cachedScenes->object2DCount, UnsignedInt(_cachedScenes->scenes[i]->objectCount()));
             if(_cachedScenes->scenes[i]->is3D())
                 _cachedScenes->object3DCount = Math::max(_cachedScenes->object3DCount, UnsignedInt(_cachedScenes->scenes[i]->objectCount()));
+
+            /* Ensure the newly added objects for each scene don't overlap each
+               other */
+            newObjectOffset = Math::max(newObjectOffset, _cachedScenes->scenes[i]->objectCount());
         }
     }
 }

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -547,6 +547,17 @@ void AbstractImporter::populateCachedScenes() {
             newObjectOffset = Math::max(newObjectOffset, _cachedScenes->scenes[i]->objectCount());
         }
     }
+
+    /* If there are scenes but no objects (because for example all scenes
+       failed to import), use the dimension-less object count at least, and
+       assume the scene was 3D. Otherwise this may cause unexpected assertions
+       in code that expected proper object count to be reported even if a scene
+       contains errors.
+
+       Not ideal, especially regarding the 3D assumption, but better than
+       nothing. */
+    if(!_cachedScenes->scenes.empty() && !_cachedScenes->object2DCount && !_cachedScenes->object3DCount)
+        _cachedScenes->object3DCount = objectCount();
 }
 
 UnsignedInt AbstractImporter::object2DCount() const {

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -48,6 +48,8 @@
 #include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/Triple.h>
 
+#include "Magnum/Trade/Implementation/sceneTools.h"
+
 #define _MAGNUM_NO_DEPRECATED_MESHDATA /* So it doesn't yell here */
 #define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
 
@@ -519,12 +521,20 @@ void AbstractImporter::populateCachedScenes() {
     _cachedScenes->scenes = Containers::Array<Containers::Optional<SceneData>>{sceneCount()};
     for(UnsignedInt i = 0; i != _cachedScenes->scenes.size(); ++i) {
         _cachedScenes->scenes[i] = scene(i);
-
-        /* Return the 2D/3D object count based on which scenes are 2D and which
-           not. The objectCount() provided by the importer is ignored except
-           for the above, also because it doesn't take into account the
-           restriction for unique-functioning objects. */
         if(_cachedScenes->scenes[i]) {
+            /* Convert the scene so that each object has only either a mesh
+               (potentially with a material and a skin), a camera or a light.
+               The tool requires SceneField::Parent to be present, however if
+               it's not then we treat the scene as empty in the backwards
+               compatibility code path anyway, so just skip the processing
+               altogether in that case. */
+            if(_cachedScenes->scenes[i]->hasField(SceneField::Parent))
+                _cachedScenes->scenes[i] = Implementation::sceneConvertToSingleFunctionObjects(*_cachedScenes->scenes[i], Containers::arrayView({SceneField::Mesh, SceneField::Camera, SceneField::Light}), objectCount());
+
+            /* Return the 2D/3D object count based on which scenes are 2D and
+               which not. The objectCount() provided by the importer is ignored
+               except for the above, also because it doesn't take into account
+               the restriction for unique-functioning objects. */
             if(_cachedScenes->scenes[i]->is2D())
                 _cachedScenes->object2DCount = Math::max(_cachedScenes->object2DCount, UnsignedInt(_cachedScenes->scenes[i]->objectCount()));
             if(_cachedScenes->scenes[i]->is3D())
@@ -578,8 +588,23 @@ std::string AbstractImporter::object2DName(const UnsignedInt id) {
 }
 
 std::string AbstractImporter::doObject2DName(const UnsignedInt id) {
-    /* Alias to the new interface */
-    return doObjectName(id);
+    /* Alias to the new interface if the ID is known to the new interface,
+       return an empty string for objects that got newly added in order to make
+       them single-functioning */
+    if(id < doObjectCount()) return doObjectName(id);
+
+    populateCachedScenes();
+    for(UnsignedInt i = 0; i != _cachedScenes->scenes.size(); ++i) {
+        if(!_cachedScenes->scenes[i] ||
+           !_cachedScenes->scenes[i]->is2D() ||
+           _cachedScenes->scenes[i]->objectCount() <= id)
+            continue;
+
+        if(Containers::Optional<Int> parent = _cachedScenes->scenes[i]->parentFor(id))
+            return doObjectName(*parent);
+    }
+
+    return "";
 }
 
 CORRADE_IGNORE_DEPRECATED_PUSH
@@ -638,8 +663,10 @@ Containers::Pointer<ObjectData2D> AbstractImporter::doObject2D(const UnsignedInt
     const Containers::Array<UnsignedInt> skin = scene.skinsFor(id);
     const Containers::Optional<const void*> importerState = scene.importerStateFor(id);
 
-    /* All these should have at most 1 item as the old API doesn't have
-       any way to represent multi-function objects. */
+    /* All these should have at most 1 item as the SceneData got processed to
+       have each object contain either just one mesh or one camera (materials
+       are implicitly shared with a mesh, skins also). Thus it doesn't matter
+       in which order we decide on the legacy object type. */
     CORRADE_INTERNAL_ASSERT(camera.size() + mesh.size() <= 1);
 
     if(!mesh.empty()) {
@@ -733,8 +760,23 @@ std::string AbstractImporter::object3DName(const UnsignedInt id) {
 }
 
 std::string AbstractImporter::doObject3DName(const UnsignedInt id) {
-    /* Alias to the new interface */
-    return doObjectName(id);
+    /* Alias to the new interface if the ID is known to the new interface,
+       return an empty string for objects that got newly added in order to make
+       them single-functioning */
+    if(id < doObjectCount()) return doObjectName(id);
+
+    populateCachedScenes();
+    for(UnsignedInt i = 0; i != _cachedScenes->scenes.size(); ++i) {
+        if(!_cachedScenes->scenes[i] ||
+           !_cachedScenes->scenes[i]->is3D() ||
+           _cachedScenes->scenes[i]->objectCount() <= id)
+            continue;
+
+        if(Containers::Optional<Int> parent = _cachedScenes->scenes[i]->parentFor(id))
+            return doObjectName(*parent);
+    }
+
+    return "";
 }
 
 CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
@@ -794,8 +836,10 @@ Containers::Pointer<ObjectData3D> AbstractImporter::doObject3D(const UnsignedInt
     const Containers::Array<UnsignedInt> light = scene.lightsFor(id);
     const Containers::Optional<const void*> importerState = scene.importerStateFor(id);
 
-    /* All these should have at most 1 item as the old API doesn't have
-       any way to represent multi-function objects. */
+    /* All these should have at most 1 item as the SceneData got processed to
+       have each object contain either just one mesh, one camera or one light
+       (materials are implicitly shared with a mesh, skins also). Thus it
+       doesn't matter in which order we decide on the legacy object type. */
     CORRADE_INTERNAL_ASSERT(camera.size() + light.size() + mesh.size() <= 1);
 
     if(!mesh.empty()) {

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -589,7 +589,11 @@ Int AbstractImporter::object2DForName(const std::string& name) {
 Int AbstractImporter::doObject2DForName(const std::string& name) {
     /* Alias to the new interface. If it returns an ID that's larger than
        reported 2D object count, then it's probably for a 3D object instead
-       -- ignore it in that case. */
+       -- ignore it in that case. Ideally this would be solved by checking if
+       the ID is actually present in a 2D scene (and same in doObject2DName())
+       but that's a lot of extra code for just a backwards compatibility
+       feature that almost nobody needs. The only pre-existing 2D importer is
+       PrimitiveImporter, which is rarely used. */
     const Long id = doObjectForName(name);
     CORRADE_IGNORE_DEPRECATED_PUSH
     return id < doObject2DCount() ? id : -1;
@@ -763,7 +767,11 @@ Int AbstractImporter::object3DForName(const std::string& name) {
 Int AbstractImporter::doObject3DForName(const std::string& name) {
     /* Alias to the new interface. If it returns an ID that's larger than
        reported 3D object count, then it's probably for a 2D object instead
-       -- ignore it in that case. */
+       -- ignore it in that case. Ideally this would be solved by checking if
+       the ID is actually present in a 3D scene (and same in doObject3DName())
+       but that's a lot of extra code for just a backwards compatibility
+       feature that almost nobody needs. The only pre-existing 2D importer is
+       PrimitiveImporter, which is rarely used. */
     const Long id = doObjectForName(name);
     CORRADE_IGNORE_DEPRECATED_PUSH
     return id < doObject3DCount() ? id : -1;

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -653,11 +653,13 @@ Containers::Pointer<ObjectData2D> AbstractImporter::doObject2D(const UnsignedInt
     ObjectFlags2D flags;
     Containers::Optional<Matrix3> transformation = scene.transformation2DFor(id);
     Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> trs = scene.translationRotationScaling2DFor(id);
+    /* If the object has neither a TRS nor a transformation field, assign an
+       empty TRS transform. Not a matrix, because a TRS is more flexible and
+       thus more desired. */
+    if(!transformation && !trs)
+        trs.emplace(Vector2{}, Complex{}, Vector2{1.0f});
     if(trs)
         flags |= ObjectFlag2D::HasTranslationRotationScaling;
-    /* If the object has neither a TRS nor a transformation field, assign an
-       identity transform to it */
-    else if(!transformation) transformation = Matrix3{};
 
     std::vector<UnsignedInt> children; /* not const so we can move it */
     {
@@ -825,11 +827,13 @@ Containers::Pointer<ObjectData3D> AbstractImporter::doObject3D(const UnsignedInt
     ObjectFlags3D flags;
     Containers::Optional<Matrix4> transformation = scene.transformation3DFor(id);
     Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> trs = scene.translationRotationScaling3DFor(id);
+    /* If the object has neither a TRS nor a transformation field, assign an
+       empty TRS transform. Not a matrix, because a TRS is more flexible and
+       thus more desired. */
+    if(!transformation && !trs)
+        trs.emplace(Vector3{}, Quaternion{}, Vector3{1.0f});
     if(trs)
         flags |= ObjectFlag3D::HasTranslationRotationScaling;
-    /* If the object has neither a TRS nor a transformation field, assign an
-       identity transform to it */
-    else if(!transformation) transformation = Matrix4{};
 
     std::vector<UnsignedInt> children; /* not const so we can move it */
     {

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -531,7 +531,7 @@ void AbstractImporter::populateCachedScenes() {
                compatibility code path anyway, so just skip the processing
                altogether in that case. */
             if(_cachedScenes->scenes[i]->hasField(SceneField::Parent))
-                _cachedScenes->scenes[i] = Implementation::sceneConvertToSingleFunctionObjects(*_cachedScenes->scenes[i], Containers::arrayView({SceneField::Mesh, SceneField::Camera, SceneField::Light}), newObjectOffset);
+                _cachedScenes->scenes[i] = Implementation::sceneConvertToSingleFunctionObjects(*_cachedScenes->scenes[i], Containers::arrayView({SceneField::Mesh, SceneField::Camera, SceneField::Light}), Containers::arrayView({SceneField::Skin}), newObjectOffset);
 
             /* Return the 2D/3D object count based on which scenes are 2D and
                which not. The objectCount() provided by the importer is ignored

--- a/src/Magnum/Trade/AbstractImporter.cpp
+++ b/src/Magnum/Trade/AbstractImporter.cpp
@@ -306,6 +306,25 @@ Containers::Optional<SceneData> AbstractImporter::scene(const std::string& name)
     return scene(id); /* not doScene(), so we get the range checks also */
 }
 
+SceneField AbstractImporter::sceneFieldForName(const std::string& name) {
+    const SceneField out = doSceneFieldForName(name);
+    CORRADE_ASSERT(out == SceneField{} || isSceneFieldCustom(out),
+        "Trade::AbstractImporter::sceneFieldForName(): implementation-returned" << out << "is neither custom nor invalid", {});
+    return out;
+}
+
+SceneField AbstractImporter::doSceneFieldForName(const std::string&) {
+    return {};
+}
+
+std::string AbstractImporter::sceneFieldName(SceneField name) {
+    CORRADE_ASSERT(isSceneFieldCustom(name),
+        "Trade::AbstractImporter::sceneFieldName():" << name << "is not custom", {});
+    return doSceneFieldName(sceneFieldCustom(name));
+}
+
+std::string AbstractImporter::doSceneFieldName(UnsignedInt) { return {}; }
+
 UnsignedInt AbstractImporter::animationCount() const {
     CORRADE_ASSERT(isOpened(), "Trade::AbstractImporter::animationCount(): no file opened", {});
     return doAnimationCount();

--- a/src/Magnum/Trade/AbstractImporter.h
+++ b/src/Magnum/Trade/AbstractImporter.h
@@ -307,7 +307,9 @@ name doesn't exist.
     @ref object2DForName() / @ref object3DForName(), imported with
     @ref object2D(const std::string&) / @ref object3D(const std::string&)
 -   Scene names using @ref sceneName() & @ref sceneForName(), imported with
-    @ref scene(const std::string&)
+    @ref scene(const std::string&). Scenes themselves can have custom fields,
+    for which the name mapping can be retrieved using @ref sceneFieldName() and
+    @ref sceneFieldForName().
 -   Skin names using @ref skin2DName() / @ref skin3DName() &
     @ref skin2DForName() / @ref skin3DForName(), imported with
     @ref skin2D(const std::string&) / @ref skin3D(const std::string&)
@@ -762,6 +764,34 @@ class MAGNUM_TRADE_EXPORT AbstractImporter: public PluginManager::AbstractManagi
          * Expects that a file is opened.
          */
         Containers::Optional<SceneData> scene(const std::string& name);
+
+        /**
+         * @brief Scene field for given name
+         * @m_since_latest
+         *
+         * If the name is not recognized, returns a zero (invalid)
+         * @ref SceneField, otherwise returns a custom scene field. Note that
+         * the value returned by this function may depend on whether a file is
+         * opened or not and also be different for different files --- see
+         * documentation of a particular importer for more information.
+         * @see @ref isSceneFieldCustom()
+         */
+        SceneField sceneFieldForName(const std::string& name);
+
+        /**
+         * @brief String name for given custom scene field
+         * @m_since_latest
+         *
+         * Given a custom @p name returned by @ref scene() in a @ref SceneData,
+         * returns a string identifier. If a string representation is not
+         * available or @p name is not recognized, returns an empty string.
+         * Expects that @p name is custom. Note that the value returned by
+         * this function may depend on whether a file is opened or not and also
+         * be different for different files --- see documentation of a
+         * particular importer for more information.
+         * @see @ref isSceneFieldCustom()
+         */
+        std::string sceneFieldName(SceneField name);
 
         /**
          * @brief Animation count
@@ -1758,6 +1788,23 @@ class MAGNUM_TRADE_EXPORT AbstractImporter: public PluginManager::AbstractManagi
 
         /** @brief Implementation for @ref scene() */
         virtual Containers::Optional<SceneData> doScene(UnsignedInt id);
+
+        /**
+         * @brief Implementation for @ref sceneFieldForName()
+         * @m_since_latest
+         *
+         * Default implementation returns an invalid (zero) value.
+         */
+        virtual SceneField doSceneFieldForName(const std::string& name);
+
+        /**
+         * @brief Implementation for @ref sceneFieldName()
+         * @m_since_latest
+         *
+         * Receives the custom ID extracted via @ref sceneFieldCustom(SceneField).
+         * Default implementation returns an empty string.
+         */
+        virtual std::string doSceneFieldName(UnsignedInt name);
 
         /**
          * @brief Implementation for @ref animationCount()

--- a/src/Magnum/Trade/AnimationData.cpp
+++ b/src/Magnum/Trade/AnimationData.cpp
@@ -92,7 +92,7 @@ AnimationTrackTargetType AnimationData::trackTargetType(UnsignedInt id) const {
     return _tracks[id]._targetType;
 }
 
-UnsignedInt AnimationData::trackTarget(UnsignedInt id) const {
+UnsignedLong AnimationData::trackTarget(UnsignedInt id) const {
     CORRADE_ASSERT(id < _tracks.size(), "Trade::AnimationData::trackTarget(): index out of range", {});
     return _tracks[id]._target;
 }

--- a/src/Magnum/Trade/AnimationData.h
+++ b/src/Magnum/Trade/AnimationData.h
@@ -238,14 +238,14 @@ class AnimationTrackData {
          * @param target        Track target
          * @param view          Type-erased @ref Animation::TrackView instance
          */
-        explicit AnimationTrackData(AnimationTrackType type, AnimationTrackType resultType, AnimationTrackTargetType targetType, UnsignedInt target, Animation::TrackViewStorage<const Float> view) noexcept: _type{type}, _resultType{resultType}, _targetType{targetType}, _target{target}, _view{view} {}
+        explicit AnimationTrackData(AnimationTrackType type, AnimationTrackType resultType, AnimationTrackTargetType targetType, UnsignedLong target, Animation::TrackViewStorage<const Float> view) noexcept: _type{type}, _resultType{resultType}, _targetType{targetType}, _target{target}, _view{view} {}
 
         /** @overload
          *
          * Equivalent to the above with @p type used as both value type and
          * result type.
          */
-        explicit AnimationTrackData(AnimationTrackType type, AnimationTrackTargetType targetType, UnsignedInt target, Animation::TrackViewStorage<const Float> view) noexcept: _type{type}, _resultType{type}, _targetType{targetType}, _target{target}, _view{view} {}
+        explicit AnimationTrackData(AnimationTrackType type, AnimationTrackTargetType targetType, UnsignedLong target, Animation::TrackViewStorage<const Float> view) noexcept: _type{type}, _resultType{type}, _targetType{targetType}, _target{target}, _view{view} {}
 
         /**
          * @brief Constructor
@@ -257,14 +257,14 @@ class AnimationTrackData {
          * Detects @ref AnimationTrackType from @p view type and delegates to
          * @ref AnimationTrackData(AnimationTrackType, AnimationTrackType, AnimationTrackTargetType, UnsignedInt, Animation::TrackViewStorage<const Float>).
          */
-        template<class V, class R> explicit AnimationTrackData(AnimationTrackTargetType targetType, UnsignedInt target, Animation::TrackView<const Float, const V, R> view) noexcept;
+        template<class V, class R> explicit AnimationTrackData(AnimationTrackTargetType targetType, UnsignedLong target, Animation::TrackView<const Float, const V, R> view) noexcept;
 
     private:
         friend AnimationData;
 
         AnimationTrackType _type, _resultType;
         AnimationTrackTargetType _targetType;
-        UnsignedInt _target;
+        UnsignedLong _target;
         Animation::TrackViewStorage<const Float> _view;
 };
 
@@ -512,7 +512,7 @@ class MAGNUM_TRADE_EXPORT AnimationData {
          * @see @ref trackCount(), @ref AbstractImporter::object2D(),
          *      @ref AbstractImporter::object3D()
          */
-        UnsignedInt trackTarget(UnsignedInt id) const;
+        UnsignedLong trackTarget(UnsignedInt id) const;
 
         /**
          * @brief Track data storage
@@ -649,7 +649,7 @@ namespace Implementation {
     /* LCOV_EXCL_STOP */
 }
 
-template<class V, class R> inline AnimationTrackData::AnimationTrackData(AnimationTrackTargetType targetType, UnsignedInt target, Animation::TrackView<const Float, const V, R> view) noexcept: AnimationTrackData{Implementation::animationTypeFor<V>(), Implementation::animationTypeFor<R>(), targetType, target, view} {}
+template<class V, class R> inline AnimationTrackData::AnimationTrackData(AnimationTrackTargetType targetType, UnsignedLong target, Animation::TrackView<const Float, const V, R> view) noexcept: AnimationTrackData{Implementation::animationTypeFor<V>(), Implementation::animationTypeFor<R>(), targetType, target, view} {}
 
 template<class V, class R> const Animation::TrackView<const Float, const V, R>& AnimationData::track(UnsignedInt id) const {
     const Animation::TrackViewStorage<const Float>& storage = track(id);

--- a/src/Magnum/Trade/CMakeLists.txt
+++ b/src/Magnum/Trade/CMakeLists.txt
@@ -30,7 +30,6 @@ set(MagnumTrade_SRCS
     Data.cpp
     MeshObjectData2D.cpp
     MeshObjectData3D.cpp
-    SceneData.cpp
     TextureData.cpp)
 
 set(MagnumTrade_GracefulAssert_SRCS
@@ -50,6 +49,7 @@ set(MagnumTrade_GracefulAssert_SRCS
     PbrMetallicRoughnessMaterialData.cpp
     PbrSpecularGlossinessMaterialData.cpp
     PhongMaterialData.cpp
+    SceneData.cpp
     SkinData.cpp)
 
 set(MagnumTrade_HEADERS

--- a/src/Magnum/Trade/CMakeLists.txt
+++ b/src/Magnum/Trade/CMakeLists.txt
@@ -28,8 +28,6 @@ find_package(Corrade REQUIRED PluginManager)
 set(MagnumTrade_SRCS
     ArrayAllocator.cpp
     Data.cpp
-    MeshObjectData2D.cpp
-    MeshObjectData3D.cpp
     TextureData.cpp)
 
 set(MagnumTrade_GracefulAssert_SRCS
@@ -43,8 +41,6 @@ set(MagnumTrade_GracefulAssert_SRCS
     LightData.cpp
     MaterialData.cpp
     MeshData.cpp
-    ObjectData2D.cpp
-    ObjectData3D.cpp
     PbrClearCoatMaterialData.cpp
     PbrMetallicRoughnessMaterialData.cpp
     PbrSpecularGlossinessMaterialData.cpp
@@ -66,10 +62,6 @@ set(MagnumTrade_HEADERS
     MaterialData.h
     MaterialLayerData.h
     MeshData.h
-    MeshObjectData2D.h
-    MeshObjectData3D.h
-    ObjectData2D.h
-    ObjectData3D.h
     PbrClearCoatMaterialData.h
     PbrMetallicRoughnessMaterialData.h
     PbrSpecularGlossinessMaterialData.h
@@ -87,6 +79,9 @@ set(MagnumTrade_PRIVATE_HEADERS
     Implementation/materialAttributeProperties.hpp)
 
 if(MAGNUM_BUILD_DEPRECATED)
+    list(APPEND MagnumTrade_SRCS
+        MeshObjectData2D.cpp
+        MeshObjectData3D.cpp)
     list(APPEND MagnumTrade_GracefulAssert_SRCS
         # These have to be here instead of in MagnumTrade_SRCS because they
         # include MeshData.h and call (and thus instantiate) various functions
@@ -96,12 +91,19 @@ if(MAGNUM_BUILD_DEPRECATED)
         # causing the tests to blow up. Happens only on the MSVC linker, but
         # let's be safe and do this everywhere.
         MeshData2D.cpp
-        MeshData3D.cpp)
+        MeshData3D.cpp
+
+        ObjectData2D.cpp
+        ObjectData3D.cpp)
     list(APPEND MagnumTrade_HEADERS
         AbstractMaterialData.h
 
         MeshData2D.h
-        MeshData3D.h)
+        MeshData3D.h
+        MeshObjectData2D.h
+        MeshObjectData3D.h
+        ObjectData2D.h
+        ObjectData3D.h)
 endif()
 
 if(NOT CORRADE_PLUGINMANAGER_NO_DYNAMIC_PLUGIN_SUPPORT)

--- a/src/Magnum/Trade/CMakeLists.txt
+++ b/src/Magnum/Trade/CMakeLists.txt
@@ -76,7 +76,8 @@ set(MagnumTrade_HEADERS
 set(MagnumTrade_PRIVATE_HEADERS
     Implementation/arrayUtilities.h
     Implementation/converterUtilities.h
-    Implementation/materialAttributeProperties.hpp)
+    Implementation/materialAttributeProperties.hpp
+    Implementation/sceneTools.h)
 
 if(MAGNUM_BUILD_DEPRECATED)
     list(APPEND MagnumTrade_SRCS

--- a/src/Magnum/Trade/Implementation/sceneTools.h
+++ b/src/Magnum/Trade/Implementation/sceneTools.h
@@ -1,0 +1,193 @@
+#ifndef Magnum_Trade_Implementation_sceneTools_h
+#define Magnum_Trade_Implementation_sceneTools_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <unordered_map>
+#include <Corrade/Containers/ArrayTuple.h>
+#include <Corrade/Containers/GrowableArray.h>
+#include <Corrade/Containers/Pair.h>
+#include <Corrade/Utility/Algorithms.h>
+
+#include "Magnum/Math/PackingBatch.h"
+#include "Magnum/Trade/SceneData.h"
+
+namespace Magnum { namespace Trade { namespace Implementation {
+
+/* These two are needed because there (obviously) isn't any overload of
+   castInto with the same input and output type */
+template<class T, class U> void copyOrCastInto(const Containers::StridedArrayView1D<const T>& src, const Containers::StridedArrayView1D<U>& dst) {
+    Math::castInto(Containers::arrayCast<2, const T>(src), Containers::arrayCast<2, U>(dst));
+}
+template<class T> void copyOrCastInto(const Containers::StridedArrayView1D<const T>& src, const Containers::StridedArrayView1D<T>& dst) {
+    Utility::copy(src, dst);
+}
+
+template<class T> void sceneCombineCopyObjects(const Containers::ArrayView<const SceneFieldData> fields, const Containers::ArrayView<const Containers::StridedArrayView2D<char>> itemViews, const Containers::ArrayView<const Containers::Pair<UnsignedInt, UnsignedInt>> itemViewMappings) {
+    std::size_t latestMapping = 0;
+    for(std::size_t i = 0; i != fields.size(); ++i) {
+        /* If there are no aliased object mappings, itemViewMappings should be
+           monotonically increasing. If it's not, it means the mapping is
+           shared with something earlier and it got already copied -- skip. */
+        const std::size_t mapping = itemViewMappings[i].first();
+        if(i && mapping <= latestMapping) continue;
+        latestMapping = mapping;
+
+        /* If the field has null object data, no need to copy anything. This
+           covers reserved fields but also fields of zero size. */
+        if(!fields[i].objectData()) continue;
+
+        const Containers::StridedArrayView1D<const void> src = fields[i].objectData();
+        const Containers::StridedArrayView1D<T> dst = Containers::arrayCast<1, T>(itemViews[mapping]);
+        if(fields[i].objectType() == SceneObjectType::UnsignedByte)
+            copyOrCastInto(Containers::arrayCast<const UnsignedByte>(src), dst);
+        else if(fields[i].objectType() == SceneObjectType::UnsignedShort)
+            copyOrCastInto(Containers::arrayCast<const UnsignedShort>(src), dst);
+        else if(fields[i].objectType() == SceneObjectType::UnsignedInt)
+            copyOrCastInto(Containers::arrayCast<const UnsignedInt>(src), dst);
+        else if(fields[i].objectType() == SceneObjectType::UnsignedLong)
+            copyOrCastInto(Containers::arrayCast<const UnsignedLong>(src), dst);
+        else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+    }
+}
+
+/* Combine fields of varying object type together into a SceneData of a single
+   given objectType. The fields are expected to point to existing object/field
+   memory, which will be then copied to the resulting scene. If you supply a
+   field with null object or field data, the object or field data will not get
+   copied, only a placeholder for copying the data later will be allocated. If
+   you however need to have placeholder object data shared among
+   Offset-only fields are not allowed.
+
+   The resulting fields are always tightly packed (not interleaved).
+
+   If multiple fields share the same object mapping views, those are preserved,
+   however they have to have the exact same length. Sharing object mappings
+   with different lengths will assert. */
+/** @todo when published, add an initializer_list overload and turn all
+    internal asserts into (tested!) message asserts */
+inline SceneData sceneCombine(const SceneObjectType objectType, const UnsignedLong objectCount, const Containers::ArrayView<const SceneFieldData> fields) {
+    const std::size_t objectTypeSize = sceneObjectTypeSize(objectType);
+    const std::size_t objectTypeAlignment = sceneObjectTypeAlignment(objectType);
+
+    /* Go through all fields and collect ArrayTuple allocations for these */
+    std::unordered_map<const void*, UnsignedInt> objectMappings;
+    Containers::Array<Containers::ArrayTuple::Item> items;
+    Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> itemViewMappings{NoInit, fields.size()};
+
+    /* The item views are referenced from ArrayTuple::Item, not using a
+       growable array in order to avoid an accidental reallocation */
+    /** @todo once never-reallocating allocators are present, use them instead
+        of the manual offset */
+    Containers::Array<Containers::StridedArrayView2D<char>> itemViews{fields.size()*2};
+    std::size_t itemViewOffset = 0;
+
+    for(std::size_t i = 0; i != fields.size(); ++i) {
+        const SceneFieldData& field = fields[i];
+        CORRADE_INTERNAL_ASSERT(!field.isOffsetOnly());
+
+        /* Object data. Allocate if the view is a placeholder of if it wasn't
+           used by other fields yet. */
+        std::pair<std::unordered_map<const void*, UnsignedInt>::iterator, bool> inserted;
+        if(field.objectData().data())
+            inserted = objectMappings.emplace(field.objectData().data(), itemViewOffset);
+        if(field.objectData().data() && !inserted.second) {
+            itemViewMappings[i].first() = inserted.first->second;
+            /* Expect that fields sharing the same object mapping view have the
+               exact same length (the length gets stored in the output view
+               during the ArrayTuple::Item construction).
+
+               We could just ignore the sharing in that case, but that'd only
+               lead to misery down the line -- imagine a field that shares the
+               first two items with a mesh and a material object mapping. If it
+               would be the last, it gets duplicated and everything is great,
+               however if it's the first then both mesh and the material get
+               duplicated, and that then asserts inside the SceneData
+               constructor, as those are always expected to share.
+
+               One option that would solve this would be to store pointer+size
+               in the objectMappings map (and then only mappings that share
+               also the same size would be shared), another would be to use the
+               longest used view (and then the shorter prefixes would share
+               with it). The ultimate option would be to have some range map
+               where it'd be possible to locate also arbitrary subranges, not
+               just prefixes. A whole other topic altogether is checking for
+               the same stride, which is not done at all.
+
+               This might theoretically lead to assertions also when two
+               compile-time arrays share a common prefix and get deduplicated
+               by the compiler. But that's unlikely, at least for the internal
+               use case we have right now. */
+            CORRADE_INTERNAL_ASSERT(itemViews[inserted.first->second].size()[0] == field.size());
+        } else {
+            itemViewMappings[i].first() = itemViewOffset;
+            arrayAppend(items, InPlaceInit, NoInit, std::size_t(field.size()), objectTypeSize, objectTypeAlignment, itemViews[itemViewOffset]);
+            ++itemViewOffset;
+        }
+
+        /* Field data. No aliasing here right now, no sharing between object
+           and field data either. */
+        /** @todo field aliasing might be useful at some point */
+        itemViewMappings[i].second() = itemViewOffset;
+        arrayAppend(items, InPlaceInit, NoInit, std::size_t(field.size()), sceneFieldTypeSize(field.fieldType())*(field.fieldArraySize() ? field.fieldArraySize() : 1), sceneFieldTypeAlignment(field.fieldType()), itemViews[itemViewOffset]);
+        ++itemViewOffset;
+    }
+
+    /* Allocate the data */
+    Containers::Array<char> outData = Containers::ArrayTuple{items};
+    CORRADE_INTERNAL_ASSERT(!outData.deleter());
+
+    /* Copy the object data over and cast them as necessary */
+    if(objectType == SceneObjectType::UnsignedByte)
+        sceneCombineCopyObjects<UnsignedByte>(fields, itemViews, itemViewMappings);
+    else if(objectType == SceneObjectType::UnsignedShort)
+        sceneCombineCopyObjects<UnsignedShort>(fields, itemViews, itemViewMappings);
+    else if(objectType == SceneObjectType::UnsignedInt)
+        sceneCombineCopyObjects<UnsignedInt>(fields, itemViews, itemViewMappings);
+    else if(objectType == SceneObjectType::UnsignedLong)
+        sceneCombineCopyObjects<UnsignedLong>(fields, itemViews, itemViewMappings);
+
+    /* Copy the field data over. No special handling needed here. */
+    for(std::size_t i = 0; i != fields.size(); ++i) {
+        /* If the field has null field data, no need to copy anything. This
+           covers reserved fields but also fields of zero size. */
+        if(!fields[i].fieldData()) continue;
+
+        /** @todo isn't there some less awful way to create a 2D view, sigh */
+        Utility::copy(Containers::arrayCast<2, const char>(fields[i].fieldData(), sceneFieldTypeSize(fields[i].fieldType())*(fields[i].fieldArraySize() ? fields[i].fieldArraySize() : 1)), itemViews[itemViewMappings[i].second()]);
+    }
+
+    /* Map the fields to the new data */
+    Containers::Array<SceneFieldData> outFields{fields.size()};
+    for(std::size_t i = 0; i != fields.size(); ++i) {
+        outFields[i] = SceneFieldData{fields[i].name(), itemViews[itemViewMappings[i].first()], fields[i].fieldType(), itemViews[itemViewMappings[i].second()], fields[i].fieldArraySize()};
+    }
+
+    return SceneData{objectType, objectCount, std::move(outData), std::move(outFields)};
+}
+
+}}}
+
+#endif

--- a/src/Magnum/Trade/Implementation/sceneTools.h
+++ b/src/Magnum/Trade/Implementation/sceneTools.h
@@ -109,7 +109,7 @@ inline SceneData sceneCombine(const SceneMappingType mappingType, const Unsigned
 
     for(std::size_t i = 0; i != fields.size(); ++i) {
         const SceneFieldData& field = fields[i];
-        CORRADE_INTERNAL_ASSERT(!field.isOffsetOnly());
+        CORRADE_INTERNAL_ASSERT(!(field.flags() & SceneFieldFlag::OffsetOnly));
 
         /* Mapping data. Allocate if the view is a placeholder of if it wasn't
            used by other fields yet. */

--- a/src/Magnum/Trade/Implementation/sceneTools.h
+++ b/src/Magnum/Trade/Implementation/sceneTools.h
@@ -254,8 +254,7 @@ inline SceneData sceneConvertToSingleFunctionObjects(const SceneData& scene, Con
     /* Copy existing parent object/field data to a prefix of the output */
     const Containers::StridedArrayView1D<UnsignedInt> outParentObjects = out.mutableObjects<UnsignedInt>(parentFieldId);
     const Containers::StridedArrayView1D<Int> outParents = out.mutableField<Int>(parentFieldId);
-    CORRADE_INTERNAL_ASSERT_OUTPUT(scene.objectsInto(parentFieldId, 0, outParentObjects) == scene.fieldSize(parentFieldId));
-    CORRADE_INTERNAL_ASSERT_OUTPUT(scene.parentsInto(0, outParents) == scene.fieldSize(parentFieldId));
+    CORRADE_INTERNAL_ASSERT_OUTPUT(scene.parentsInto(0, outParentObjects, outParents) == scene.fieldSize(parentFieldId));
 
     /* List new objects at the end of the extended parent field */
     const Containers::StridedArrayView1D<UnsignedInt> newParentObjects = outParentObjects.suffix(scene.fieldSize(parentFieldId));

--- a/src/Magnum/Trade/Implementation/sceneTools.h
+++ b/src/Magnum/Trade/Implementation/sceneTools.h
@@ -285,9 +285,8 @@ inline SceneData sceneConvertToSingleFunctionObjects(const SceneData& scene, Con
                    attached, then attach the field to a new object and make
                    that new object a child of the previous one. */
                 if(fieldObject < objectAttachmentCount.size() && objectAttachmentCount[fieldObject]) {
-                    /* Find an index of the old object and then use that index
-                       to denote the parent of the new object */
-                    newParents[newParentIndex] = out.fieldObjectOffset(parentFieldId, fieldObject);
+                    /* Use the old object as a parent of the new object */
+                    newParents[newParentIndex] = fieldObject;
                     /* Assign the field to the new object */
                     fieldObject = newParentObjects[newParentIndex];
                     /* Move to the next reserved object */

--- a/src/Magnum/Trade/MeshObjectData2D.cpp
+++ b/src/Magnum/Trade/MeshObjectData2D.cpp
@@ -23,12 +23,18 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
+
 #include "MeshObjectData2D.h"
 
 namespace Magnum { namespace Trade {
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 MeshObjectData2D::MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, const UnsignedInt instance, const Int material, const Int skin, const void* const importerState): ObjectData2D{std::move(children), transformation, ObjectInstanceType2D::Mesh, instance, importerState}, _material{material}, _skin{skin} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 MeshObjectData2D::MeshObjectData2D(std::vector<UnsignedInt> children, const Vector2& translation, const Complex& rotation, const Vector2& scaling, const UnsignedInt instance, const Int material, const Int skin, const void* const importerState): ObjectData2D{std::move(children), translation, rotation, scaling, ObjectInstanceType2D::Mesh, instance, importerState}, _material{material}, _skin{skin} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
 }}

--- a/src/Magnum/Trade/MeshObjectData2D.h
+++ b/src/Magnum/Trade/MeshObjectData2D.h
@@ -25,21 +25,33 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#ifdef MAGNUM_BUILD_DEPRECATED
 /** @file
  * @brief Class @ref Magnum::Trade::MeshObjectData2D
  */
+#endif
 
+#include "Magnum/configure.h"
+
+#ifdef MAGNUM_BUILD_DEPRECATED
 #include "Magnum/Trade/ObjectData2D.h"
+
+#ifndef _MAGNUM_NO_DEPRECATED_OBJECTDATA
+CORRADE_DEPRECATED_FILE("use Magnum/Trade/SceneData.h and the SceneData class instead")
+#endif
 
 namespace Magnum { namespace Trade {
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* MSVC warns on the inheritance */
+
 /**
 @brief Two-dimensional mesh object data
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 Provides access to material information for given mesh instance.
 @see @ref AbstractImporter::object2D(), @ref MeshObjectData3D
 */
-class MAGNUM_TRADE_EXPORT MeshObjectData2D: public ObjectData2D {
+class CORRADE_DEPRECATED("use SceneData instead") MAGNUM_TRADE_EXPORT MeshObjectData2D: public ObjectData2D {
     public:
         /**
          * @brief Construct with combined transformation
@@ -54,13 +66,11 @@ class MAGNUM_TRADE_EXPORT MeshObjectData2D: public ObjectData2D {
          */
         explicit MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, UnsignedInt instance, Int material, Int skin, const void* importerState = nullptr);
 
-        #ifdef MAGNUM_BUILD_DEPRECATED
         /** @brief @copybrief MeshObjectData2D(std::vector<UnsignedInt>, const Matrix3&, UnsignedInt, Int, Int, const void*)
          * @m_deprecated_since_latest Use @ref MeshObjectData2D(std::vector<UnsignedInt>, const Matrix3&, UnsignedInt, Int, Int, const void*)
          *      instead.
          */
         explicit CORRADE_DEPRECATED("use MeshObjectData2D(std::vector<UnsignedInt>, const Matrix4&, UnsignedInt, Int, Int, const void*) instead") MeshObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, UnsignedInt instance, Int material, const void* importerState = nullptr): MeshObjectData2D{std::move(children), transformation, instance, material, -1, importerState} {}
-        #endif
 
         /**
          * @brief Construct with separate transformations
@@ -132,6 +142,11 @@ class MAGNUM_TRADE_EXPORT MeshObjectData2D: public ObjectData2D {
         Int _material, _skin;
 };
 
+CORRADE_IGNORE_DEPRECATED_POP /* MSVC warns on the inheritance */
+
 }}
+#else
+#error use Magnum/Trade/SceneData.h and the SceneData class instead
+#endif
 
 #endif

--- a/src/Magnum/Trade/MeshObjectData3D.cpp
+++ b/src/Magnum/Trade/MeshObjectData3D.cpp
@@ -23,12 +23,18 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
+
 #include "MeshObjectData3D.h"
 
 namespace Magnum { namespace Trade {
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 MeshObjectData3D::MeshObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, const UnsignedInt instance, const Int material, const Int skin, const void* const importerState): ObjectData3D{std::move(children), transformation, ObjectInstanceType3D::Mesh, instance, importerState}, _material{material}, _skin{skin} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 MeshObjectData3D::MeshObjectData3D(std::vector<UnsignedInt> children, const Vector3& translation, const Quaternion& rotation, const Vector3& scaling, const UnsignedInt instance, const Int material, const Int skin, const void* const importerState): ObjectData3D{std::move(children), translation, rotation, scaling, ObjectInstanceType3D::Mesh, instance, importerState}, _material{material}, _skin{skin} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
 }}

--- a/src/Magnum/Trade/MeshObjectData3D.h
+++ b/src/Magnum/Trade/MeshObjectData3D.h
@@ -25,21 +25,33 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#ifdef MAGNUM_BUILD_DEPRECATED
 /** @file
  * @brief Class @ref Magnum::Trade::MeshObjectData3D
  */
+#endif
 
+#include "Magnum/configure.h"
+
+#ifdef MAGNUM_BUILD_DEPRECATED
 #include "Magnum/Trade/ObjectData3D.h"
+
+#ifndef _MAGNUM_NO_DEPRECATED_OBJECTDATA
+CORRADE_DEPRECATED_FILE("use Magnum/Trade/SceneData.h and the SceneData class instead")
+#endif
 
 namespace Magnum { namespace Trade {
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* MSVC warns on the inheritance */
+
 /**
 @brief Three-dimensional mesh object data
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 Provides access to material information for given mesh instance.
 @see @ref AbstractImporter::object3D(), @ref MeshObjectData2D
 */
-class MAGNUM_TRADE_EXPORT MeshObjectData3D: public ObjectData3D {
+class CORRADE_DEPRECATED("use SceneData instead") MAGNUM_TRADE_EXPORT MeshObjectData3D: public ObjectData3D {
     public:
         /**
          * @brief Construct with combined transformation
@@ -132,6 +144,11 @@ class MAGNUM_TRADE_EXPORT MeshObjectData3D: public ObjectData3D {
         Int _material, _skin;
 };
 
+CORRADE_IGNORE_DEPRECATED_POP /* MSVC warns on the inheritance */
+
 }}
+#else
+#error use Magnum/Trade/SceneData.h and the SceneData class instead
+#endif
 
 #endif

--- a/src/Magnum/Trade/ObjectData2D.cpp
+++ b/src/Magnum/Trade/ObjectData2D.cpp
@@ -23,62 +23,85 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
+
 #include "ObjectData2D.h"
 
 #include <Corrade/Containers/EnumSet.hpp>
 
 namespace Magnum { namespace Trade {
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData2D::ObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, const ObjectInstanceType2D instanceType, const UnsignedInt instance, const void* const importerState): _children{std::move(children)}, _transformation{transformation}, _instanceType{instanceType}, _flags{}, _instance{Int(instance)}, _importerState{importerState} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData2D::ObjectData2D(std::vector<UnsignedInt> children, const Vector2& translation, const Complex& rotation, const Vector2& scaling, const ObjectInstanceType2D instanceType, const UnsignedInt instance, const void* const importerState): _children{std::move(children)}, _transformation{translation, rotation, scaling}, _instanceType{instanceType}, _flags{ObjectFlag2D::HasTranslationRotationScaling}, _instance{Int(instance)}, _importerState{importerState} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData2D::ObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, const void* const importerState): _children{std::move(children)}, _transformation{transformation}, _instanceType{ObjectInstanceType2D::Empty}, _flags{}, _instance{-1}, _importerState{importerState} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData2D::ObjectData2D(std::vector<UnsignedInt> children, const Vector2& translation, const Complex& rotation, const Vector2& scaling, const void* const importerState): _children{std::move(children)}, _transformation{translation, rotation, scaling}, _instanceType{ObjectInstanceType2D::Empty}, _flags{ObjectFlag2D::HasTranslationRotationScaling}, _instance{-1}, _importerState{importerState} {}
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* MSVC warns here */
 ObjectData2D::ObjectData2D(ObjectData2D&&)
     #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
     noexcept
     #endif
     = default;
+CORRADE_IGNORE_DEPRECATED_POP
 
 ObjectData2D::~ObjectData2D() = default;
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* GCC why you warn on return and not on param */
 ObjectData2D& ObjectData2D::operator=(ObjectData2D&&)
     #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
     noexcept
     #endif
     = default;
+CORRADE_IGNORE_DEPRECATED_POP
 
 Vector2 ObjectData2D::translation() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     CORRADE_ASSERT(_flags & ObjectFlag2D::HasTranslationRotationScaling,
         "Trade::ObjectData2D::translation(): object has only a combined transformation", {});
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.trs.translation;
 }
 
 Complex ObjectData2D::rotation() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     CORRADE_ASSERT(_flags & ObjectFlag2D::HasTranslationRotationScaling,
         "Trade::ObjectData2D::rotation(): object has only a combined transformation", {});
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.trs.rotation;
 }
 
 Vector2 ObjectData2D::scaling() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     CORRADE_ASSERT(_flags & ObjectFlag2D::HasTranslationRotationScaling,
         "Trade::ObjectData2D::scaling(): object has only a combined transformation", {});
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.trs.scaling;
 }
 
 Matrix3 ObjectData2D::transformation() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     if(_flags & ObjectFlag2D::HasTranslationRotationScaling)
         /* Has to be on a single line otherwise lcov reports an uncovered
            line. Ugh. */
         return Matrix3::from(_transformation.trs.rotation.toMatrix(), _transformation.trs.translation)*
                Matrix3::scaling(_transformation.trs.scaling);
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.matrix;
 }
 
 #ifndef DOXYGEN_GENERATING_OUTPUT
+CORRADE_IGNORE_DEPRECATED_PUSH
 Debug& operator<<(Debug& debug, const ObjectInstanceType2D value) {
     debug << "Trade::ObjectInstanceType2D" << Debug::nospace;
 
@@ -113,6 +136,7 @@ Debug& operator<<(Debug& debug, const ObjectFlags2D value) {
     return enumSetDebugOutput(debug, value, "Trade::ObjectFlags2D{}", {
         ObjectFlag2D::HasTranslationRotationScaling});
 }
+CORRADE_IGNORE_DEPRECATED_POP
 #endif
 
 }}

--- a/src/Magnum/Trade/ObjectData2D.h
+++ b/src/Magnum/Trade/ObjectData2D.h
@@ -25,10 +25,17 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#ifdef MAGNUM_BUILD_DEPRECATED
 /** @file
  * @brief Class @ref Magnum::Trade::ObjectData2D, enum @ref Magnum::Trade::ObjectInstanceType2D
+ * @m_deprecated_since_latest Use @ref Magnum/Trade/SceneData.h and the
+ *      @relativeref{Magnum::Trade,SceneData} class instead.
  */
+#endif
 
+#include "Magnum/configure.h"
+
+#ifdef MAGNUM_BUILD_DEPRECATED
 #include <vector>
 
 #include "Magnum/Magnum.h"
@@ -36,14 +43,19 @@
 #include "Magnum/Math/Complex.h"
 #include "Magnum/Trade/visibility.h"
 
+#ifndef _MAGNUM_NO_DEPRECATED_OBJECTDATA
+CORRADE_DEPRECATED_FILE("use Magnum/Trade/SceneData.h and the SceneData class instead")
+#endif
+
 namespace Magnum { namespace Trade {
 
 /**
 @brief Type of instance held by given 2D object
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 @see @ref ObjectData2D::instanceType()
 */
-enum class ObjectInstanceType2D: UnsignedByte {
+enum class CORRADE_DEPRECATED_ENUM("use SceneData instead") ObjectInstanceType2D: UnsignedByte {
     Camera,     /**< Camera instance (see @ref CameraData) */
 
     /**
@@ -57,10 +69,11 @@ enum class ObjectInstanceType2D: UnsignedByte {
 
 /**
 @brief 2D object flag
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 @see @ref ObjectFlags2D, @ref ObjectData2D::flags()
 */
-enum class ObjectFlag2D: UnsignedByte {
+enum class CORRADE_DEPRECATED_ENUM("use SceneData instead") ObjectFlag2D: UnsignedByte {
     /**
      * The object provides separate translation / rotation / scaling
      * properties. The @ref ObjectData2D::transformation() matrix returns them
@@ -73,21 +86,27 @@ enum class ObjectFlag2D: UnsignedByte {
 
 /**
 @brief 2D object flags
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 @see @ref ObjectData2D::flags()
 */
-typedef Containers::EnumSet<ObjectFlag2D> ObjectFlags2D;
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
+typedef CORRADE_DEPRECATED("use SceneData instead") Containers::EnumSet<ObjectFlag2D> ObjectFlags2D;
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH
 CORRADE_ENUMSET_OPERATORS(ObjectFlags2D)
+CORRADE_IGNORE_DEPRECATED_POP
 
 /**
 @brief Two-dimensional object data
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 Provides access to object transformation and hierarchy.
 @see @ref AbstractImporter::object2D(), @ref MeshObjectData2D,
     @ref ObjectData3D
 */
-class MAGNUM_TRADE_EXPORT ObjectData2D {
+class CORRADE_DEPRECATED("use SceneData instead") MAGNUM_TRADE_EXPORT ObjectData2D {
     public:
         /**
          * @brief Construct with combined transformation
@@ -97,7 +116,9 @@ class MAGNUM_TRADE_EXPORT ObjectData2D {
          * @param instance          Instance ID
          * @param importerState     Importer-specific state
          */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         explicit ObjectData2D(std::vector<UnsignedInt> children, const Matrix3& transformation, ObjectInstanceType2D instanceType, UnsignedInt instance, const void* importerState = nullptr);
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Construct with separate transformations
@@ -109,7 +130,9 @@ class MAGNUM_TRADE_EXPORT ObjectData2D {
          * @param instance          Instance ID
          * @param importerState     Importer-specific state
          */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         explicit ObjectData2D(std::vector<UnsignedInt> children, const Vector2& translation, const Complex& rotation, const Vector2& scaling, ObjectInstanceType2D instanceType, UnsignedInt instance, const void* importerState = nullptr);
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Construct empty instance with combined transformation
@@ -163,7 +186,9 @@ class MAGNUM_TRADE_EXPORT ObjectData2D {
         const std::vector<UnsignedInt>& children() const { return _children; } /**< @overload */
 
         /** @brief Flags */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         ObjectFlags2D flags() const { return _flags; }
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Translation (relative to parent)
@@ -224,7 +249,9 @@ class MAGNUM_TRADE_EXPORT ObjectData2D {
          *
          * @see @ref instance()
          */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         ObjectInstanceType2D instanceType() const { return _instanceType; }
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Instance ID
@@ -256,21 +283,37 @@ class MAGNUM_TRADE_EXPORT ObjectData2D {
                 Vector2 scaling;
             } trs;
         } _transformation;
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         ObjectInstanceType2D _instanceType;
         ObjectFlags2D _flags;
+        CORRADE_IGNORE_DEPRECATED_POP
         Int _instance;
         const void* _importerState;
 };
 
-/** @debugoperatorenum{ObjectInstanceType2D} */
+CORRADE_IGNORE_DEPRECATED_PUSH
+/**
+@debugoperatorenum{ObjectInstanceType2D}
+@m_deprecated_since_latest Use @ref SceneData instead.
+*/
 MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, ObjectInstanceType2D value);
 
-/** @debugoperatorenum{ObjectFlag2D} */
+/**
+@debugoperatorenum{ObjectFlag2D}
+@m_deprecated_since_latest Use @ref SceneData instead.
+*/
 MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, ObjectFlag2D value);
 
-/** @debugoperatorenum{ObjectFlags2D} */
+/**
+@debugoperatorenum{ObjectFlags2D}
+@m_deprecated_since_latest Use @ref SceneData instead.
+*/
 MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, ObjectFlags2D value);
+CORRADE_IGNORE_DEPRECATED_POP
 
 }}
+#else
+#error use Magnum/Trade/SceneData.h and the SceneData class instead
+#endif
 
 #endif

--- a/src/Magnum/Trade/ObjectData3D.cpp
+++ b/src/Magnum/Trade/ObjectData3D.cpp
@@ -23,62 +23,81 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
+
 #include "ObjectData3D.h"
 
 #include <Corrade/Containers/EnumSet.hpp>
 
 namespace Magnum { namespace Trade {
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData3D::ObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, const ObjectInstanceType3D instanceType, const UnsignedInt instance, const void* const importerState): _children{std::move(children)}, _transformation{transformation}, _instanceType{instanceType}, _flags{}, _instance{Int(instance)}, _importerState{importerState} {}
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData3D::ObjectData3D(std::vector<UnsignedInt> children, const Vector3& translation, const Quaternion& rotation, const Vector3& scaling, const ObjectInstanceType3D instanceType, const UnsignedInt instance, const void* const importerState): _children{std::move(children)}, _transformation{translation, rotation, scaling}, _instanceType{instanceType}, _flags{ObjectFlag3D::HasTranslationRotationScaling}, _instance{Int(instance)}, _importerState{importerState} {}
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData3D::ObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, const void* const importerState): _children{std::move(children)}, _transformation{transformation}, _instanceType{ObjectInstanceType3D::Empty}, _flags{}, _instance{-1}, _importerState{importerState} {}
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
 ObjectData3D::ObjectData3D(std::vector<UnsignedInt> children, const Vector3& translation, const Quaternion& rotation, const Vector3& scaling, const void* const importerState): _children{std::move(children)}, _transformation{translation, rotation, scaling}, _instanceType{ObjectInstanceType3D::Empty}, _flags{ObjectFlag3D::HasTranslationRotationScaling}, _instance{-1}, _importerState{importerState} {}
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* MSVC warns here */
 ObjectData3D::ObjectData3D(ObjectData3D&&)
     #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
     noexcept
     #endif
     = default;
+CORRADE_IGNORE_DEPRECATED_POP
 
 ObjectData3D::~ObjectData3D() = default;
 
+CORRADE_IGNORE_DEPRECATED_PUSH /* GCC why you warn on return and not on param */
 ObjectData3D& ObjectData3D::operator=(ObjectData3D&&)
     #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
     noexcept
     #endif
     = default;
+CORRADE_IGNORE_DEPRECATED_POP
 
 Vector3 ObjectData3D::translation() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     CORRADE_ASSERT(_flags & ObjectFlag3D::HasTranslationRotationScaling,
         "Trade::ObjectData3D::translation(): object has only a combined transformation", {});
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.trs.translation;
 }
 
 Quaternion ObjectData3D::rotation() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     CORRADE_ASSERT(_flags & ObjectFlag3D::HasTranslationRotationScaling,
         "Trade::ObjectData3D::rotation(): object has only a combined transformation", {});
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.trs.rotation;
 }
 
 Vector3 ObjectData3D::scaling() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     CORRADE_ASSERT(_flags & ObjectFlag3D::HasTranslationRotationScaling,
         "Trade::ObjectData3D::scaling(): object has only a combined transformation", {});
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.trs.scaling;
 }
 
 Matrix4 ObjectData3D::transformation() const {
+    CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
     if(_flags & ObjectFlag3D::HasTranslationRotationScaling)
         /* Has to be on a single line otherwise lcov reports an uncovered
            line. Ugh. */
         return Matrix4::from(_transformation.trs.rotation.toMatrix(), _transformation.trs.translation)*
                Matrix4::scaling(_transformation.trs.scaling);
+    CORRADE_IGNORE_DEPRECATED_POP
     return _transformation.matrix;
 }
 
 #ifndef DOXYGEN_GENERATING_OUTPUT
+CORRADE_IGNORE_DEPRECATED_PUSH
 Debug& operator<<(Debug& debug, const ObjectInstanceType3D value) {
     debug << "Trade::ObjectInstanceType3D" << Debug::nospace;
 
@@ -114,6 +133,7 @@ Debug& operator<<(Debug& debug, const ObjectFlags3D value) {
     return enumSetDebugOutput(debug, value, "Trade::ObjectFlags3D{}", {
         ObjectFlag3D::HasTranslationRotationScaling});
 }
+CORRADE_IGNORE_DEPRECATED_POP
 #endif
 
 }}

--- a/src/Magnum/Trade/ObjectData3D.h
+++ b/src/Magnum/Trade/ObjectData3D.h
@@ -25,10 +25,17 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#ifdef MAGNUM_BUILD_DEPRECATED
 /** @file
  * @brief Class @ref Magnum::Trade::ObjectData3D, enum @ref Magnum::Trade::ObjectInstanceType3D
+ * @m_deprecated_since_latest Use @ref Magnum/Trade/SceneData.h and the
+ *      @relativeref{Magnum::Trade,SceneData} class instead.
  */
+#endif
 
+#include "Magnum/configure.h"
+
+#ifdef MAGNUM_BUILD_DEPRECATED
 #include <vector>
 
 #include "Magnum/Magnum.h"
@@ -36,14 +43,19 @@
 #include "Magnum/Math/Quaternion.h"
 #include "Magnum/Trade/visibility.h"
 
+#ifndef _MAGNUM_NO_DEPRECATED_OBJECTDATA
+CORRADE_DEPRECATED_FILE("use Magnum/Trade/SceneData.h and the SceneData class instead")
+#endif
+
 namespace Magnum { namespace Trade {
 
 /**
 @brief Type of instance held by given 3D object
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 @see @ref ObjectData3D::instanceType()
 */
-enum class ObjectInstanceType3D: UnsignedByte {
+enum class CORRADE_DEPRECATED_ENUM("use SceneData instead") ObjectInstanceType3D: UnsignedByte {
     Camera,     /**< Camera instance (see @ref CameraData) */
     Light,      /**< Light instance (see @ref LightData) */
 
@@ -58,10 +70,11 @@ enum class ObjectInstanceType3D: UnsignedByte {
 
 /**
 @brief 3D object flag
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 @see @ref ObjectFlags3D, @ref ObjectData3D::flags()
 */
-enum class ObjectFlag3D: UnsignedByte {
+enum class CORRADE_DEPRECATED_ENUM("use SceneData instead") ObjectFlag3D: UnsignedByte {
     /**
      * The object provides separate translation / rotation / scaling
      * properties. The @ref ObjectData3D::transformation() matrix returns them
@@ -74,21 +87,27 @@ enum class ObjectFlag3D: UnsignedByte {
 
 /**
 @brief 3D object flags
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 @see @ref ObjectData3D::flags()
 */
-typedef Containers::EnumSet<ObjectFlag3D> ObjectFlags3D;
+CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
+typedef CORRADE_DEPRECATED("use SceneData instead") Containers::EnumSet<ObjectFlag3D> ObjectFlags3D;
+CORRADE_IGNORE_DEPRECATED_POP
 
+CORRADE_IGNORE_DEPRECATED_PUSH
 CORRADE_ENUMSET_OPERATORS(ObjectFlags3D)
+CORRADE_IGNORE_DEPRECATED_POP
 
 /**
 @brief Three-dimensional object data
+@m_deprecated_since_latest Use @ref SceneData instead.
 
 Provides access to object transformation and hierarchy.
 @see @ref AbstractImporter::object3D(), @ref MeshObjectData3D,
     @ref ObjectData2D
 */
-class MAGNUM_TRADE_EXPORT ObjectData3D {
+class CORRADE_DEPRECATED("use SceneData instead") MAGNUM_TRADE_EXPORT ObjectData3D {
     public:
         /**
          * @brief Construct with combined transformation
@@ -98,7 +117,9 @@ class MAGNUM_TRADE_EXPORT ObjectData3D {
          * @param instance          Instance ID
          * @param importerState     Importer-specific state
          */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         explicit ObjectData3D(std::vector<UnsignedInt> children, const Matrix4& transformation, ObjectInstanceType3D instanceType, UnsignedInt instance, const void* importerState = nullptr);
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Construct with separate transformations
@@ -110,7 +131,9 @@ class MAGNUM_TRADE_EXPORT ObjectData3D {
          * @param instance          Instance ID
          * @param importerState     Importer-specific state
          */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         explicit ObjectData3D(std::vector<UnsignedInt> children, const Vector3& translation, const Quaternion& rotation, const Vector3& scaling, ObjectInstanceType3D instanceType, UnsignedInt instance, const void* importerState = nullptr);
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Construct empty instance with combined transformation
@@ -164,7 +187,9 @@ class MAGNUM_TRADE_EXPORT ObjectData3D {
         const std::vector<UnsignedInt>& children() const { return _children; } /**< @overload */
 
         /** @brief Flags */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         ObjectFlags3D flags() const { return _flags; }
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Translation (relative to parent)
@@ -225,7 +250,9 @@ class MAGNUM_TRADE_EXPORT ObjectData3D {
          *
          * @see @ref instance()
          */
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         ObjectInstanceType3D instanceType() const { return _instanceType; }
+        CORRADE_IGNORE_DEPRECATED_POP
 
         /**
          * @brief Instance ID
@@ -255,21 +282,37 @@ class MAGNUM_TRADE_EXPORT ObjectData3D {
                 Vector3 scaling;
             } trs;
         } _transformation;
+        CORRADE_IGNORE_DEPRECATED_PUSH /* Clang doesn't warn, but GCC does */
         ObjectInstanceType3D _instanceType;
         ObjectFlags3D _flags;
+        CORRADE_IGNORE_DEPRECATED_POP
         Int _instance;
         const void* _importerState;
 };
 
-/** @debugoperatorenum{ObjectInstanceType3D} */
+CORRADE_IGNORE_DEPRECATED_PUSH
+/**
+@debugoperatorenum{ObjectInstanceType3D}
+@m_deprecated_since_latest Use @ref SceneData instead.
+*/
 MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, ObjectInstanceType3D value);
 
-/** @debugoperatorenum{ObjectFlag3D} */
+/**
+@debugoperatorenum{ObjectFlag3D}
+@m_deprecated_since_latest Use @ref SceneData instead.
+*/
 MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, ObjectFlag3D value);
 
-/** @debugoperatorenum{ObjectFlags3D} */
+/**
+@debugoperatorenum{ObjectFlags3D}
+@m_deprecated_since_latest Use @ref SceneData instead.
+*/
 MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, ObjectFlags3D value);
+CORRADE_IGNORE_DEPRECATED_POP
 
 }}
+#else
+#error use Magnum/Trade/SceneData.h and the SceneData class instead
+#endif
 
 #endif

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -54,12 +54,19 @@ Debug& operator<<(Debug& debug, const SceneObjectType value) {
 }
 
 UnsignedInt sceneObjectTypeSize(const SceneObjectType type) {
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic error "-Wswitch"
+    #endif
     switch(type) {
         case SceneObjectType::UnsignedByte: return 1;
         case SceneObjectType::UnsignedShort: return 2;
         case SceneObjectType::UnsignedInt: return 4;
         case SceneObjectType::UnsignedLong: return 8;
     }
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic pop
+    #endif
 
     CORRADE_ASSERT_UNREACHABLE("Trade::sceneObjectTypeSize(): invalid type" << type, {});
 }
@@ -198,6 +205,10 @@ Debug& operator<<(Debug& debug, const SceneFieldType value) {
 }
 
 UnsignedInt sceneFieldTypeSize(const SceneFieldType type) {
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic error "-Wswitch"
+    #endif
     switch(type) {
         case SceneFieldType::UnsignedByte:
         case SceneFieldType::Byte:
@@ -308,6 +319,9 @@ UnsignedInt sceneFieldTypeSize(const SceneFieldType type) {
         case SceneFieldType::Matrix4x4d:
             return 128;
     }
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic pop
+    #endif
 
     CORRADE_ASSERT_UNREACHABLE("Trade::sceneFieldTypeSize(): invalid type" << type, {});
 }

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -715,8 +715,7 @@ Containers::Array<UnsignedInt> SceneData::objectsAsArray(const SceneField name) 
     return objectsAsArray(fieldId);
 }
 
-void SceneData::parentsInto(const Containers::StridedArrayView1D<Int>& destination) const {
-    const UnsignedInt fieldId = fieldFor(SceneField::Parent);
+void SceneData::parentsIntoInternal(const UnsignedInt fieldId, const Containers::StridedArrayView1D<Int>& destination) const {
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::parentsInto(): field not found", );
     const SceneFieldData& field = _fields[fieldId];
@@ -737,6 +736,10 @@ void SceneData::parentsInto(const Containers::StridedArrayView1D<Int>& destinati
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
+void SceneData::parentsInto(const Containers::StridedArrayView1D<Int>& destination) const {
+    parentsIntoInternal(fieldFor(SceneField::Parent), destination);
+}
+
 Containers::Array<Int> SceneData::parentsAsArray() const {
     const UnsignedInt fieldId = fieldFor(SceneField::Parent);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
@@ -744,7 +747,7 @@ Containers::Array<Int> SceneData::parentsAsArray() const {
            strings in the binary */
         "Trade::SceneData::parentsInto(): field not found", {});
     Containers::Array<Int> out{NoInit, std::size_t(_fields[fieldId]._size)};
-    parentsInto(out);
+    parentsIntoInternal(fieldId, out);
     return out;
 }
 
@@ -1022,9 +1025,8 @@ void SceneData::indexFieldIntoInternal(
     #ifndef CORRADE_NO_ASSERT
     const char* const prefix,
     #endif
-    const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const
+    const UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const
 {
-    const UnsignedInt fieldId = fieldFor(name);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         prefix << "field not found", );
     const SceneFieldData& field = _fields[fieldId];
@@ -1055,7 +1057,7 @@ Containers::Array<UnsignedInt> SceneData::indexFieldAsArrayInternal(
         #ifndef CORRADE_NO_ASSERT
         prefix,
         #endif
-        name, out);
+        fieldId, out);
     return out;
 }
 
@@ -1064,7 +1066,7 @@ void SceneData::meshesInto(const Containers::StridedArrayView1D<UnsignedInt>& de
         #ifndef CORRADE_NO_ASSERT
         "Trade::SceneData::meshesInto():",
         #endif
-        SceneField::Mesh, destination);
+        fieldFor(SceneField::Mesh), destination);
 }
 
 Containers::Array<UnsignedInt> SceneData::meshesAsArray() const {
@@ -1082,7 +1084,7 @@ void SceneData::meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedI
         #ifndef CORRADE_NO_ASSERT
         "Trade::SceneData::meshMaterialsInto():",
         #endif
-        SceneField::MeshMaterial, destination);
+        fieldFor(SceneField::MeshMaterial), destination);
 }
 
 Containers::Array<UnsignedInt> SceneData::meshMaterialsAsArray() const {
@@ -1100,7 +1102,7 @@ void SceneData::lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& de
         #ifndef CORRADE_NO_ASSERT
         "Trade::SceneData::lightsInto():",
         #endif
-        SceneField::Light, destination);
+        fieldFor(SceneField::Light), destination);
 }
 
 Containers::Array<UnsignedInt> SceneData::lightsAsArray() const {
@@ -1118,7 +1120,7 @@ void SceneData::camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& d
         #ifndef CORRADE_NO_ASSERT
         "Trade::SceneData::camerasInto():",
         #endif
-        SceneField::Camera, destination);
+        fieldFor(SceneField::Camera), destination);
 }
 
 Containers::Array<UnsignedInt> SceneData::camerasAsArray() const {
@@ -1136,7 +1138,7 @@ void SceneData::skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& des
         #ifndef CORRADE_NO_ASSERT
         "Trade::SceneData::skinsInto():",
         #endif
-        SceneField::Skin, destination);
+        fieldFor(SceneField::Skin), destination);
 }
 
 Containers::Array<UnsignedInt> SceneData::skinsAsArray() const {

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -82,6 +82,24 @@ UnsignedInt sceneObjectTypeSize(const SceneObjectType type) {
     CORRADE_ASSERT_UNREACHABLE("Trade::sceneObjectTypeSize(): invalid type" << type, {});
 }
 
+UnsignedInt sceneObjectTypeAlignment(const SceneObjectType type) {
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic error "-Wswitch"
+    #endif
+    switch(type) {
+        case SceneObjectType::UnsignedByte: return 1;
+        case SceneObjectType::UnsignedShort: return 2;
+        case SceneObjectType::UnsignedInt: return 4;
+        case SceneObjectType::UnsignedLong: return 8;
+    }
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic pop
+    #endif
+
+    CORRADE_ASSERT_UNREACHABLE("Trade::sceneObjectTypeAlignment(): invalid type" << type, {});
+}
+
 Debug& operator<<(Debug& debug, const SceneField value) {
     debug << "Trade::SceneField" << Debug::nospace;
 
@@ -341,6 +359,118 @@ UnsignedInt sceneFieldTypeSize(const SceneFieldType type) {
     #endif
 
     CORRADE_ASSERT_UNREACHABLE("Trade::sceneFieldTypeSize(): invalid type" << type, {});
+}
+
+UnsignedInt sceneFieldTypeAlignment(const SceneFieldType type) {
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic error "-Wswitch"
+    #endif
+    switch(type) {
+        case SceneFieldType::UnsignedByte:
+        case SceneFieldType::Vector2ub:
+        case SceneFieldType::Vector3ub:
+        case SceneFieldType::Vector4ub:
+        case SceneFieldType::Byte:
+        case SceneFieldType::Vector2b:
+        case SceneFieldType::Vector3b:
+        case SceneFieldType::Vector4b:
+            return 1;
+        case SceneFieldType::UnsignedShort:
+        case SceneFieldType::Vector2us:
+        case SceneFieldType::Vector3us:
+        case SceneFieldType::Vector4us:
+        case SceneFieldType::Short:
+        case SceneFieldType::Vector2s:
+        case SceneFieldType::Vector3s:
+        case SceneFieldType::Vector4s:
+        case SceneFieldType::Half:
+        case SceneFieldType::Vector2h:
+        case SceneFieldType::Vector3h:
+        case SceneFieldType::Vector4h:
+        case SceneFieldType::Matrix2x2h:
+        case SceneFieldType::Matrix2x3h:
+        case SceneFieldType::Matrix2x4h:
+        case SceneFieldType::Matrix3x2h:
+        case SceneFieldType::Matrix3x3h:
+        case SceneFieldType::Matrix3x4h:
+        case SceneFieldType::Matrix4x2h:
+        case SceneFieldType::Matrix4x3h:
+        case SceneFieldType::Matrix4x4h:
+        case SceneFieldType::Range1Dh:
+        case SceneFieldType::Range2Dh:
+        case SceneFieldType::Range3Dh:
+        case SceneFieldType::Degh:
+        case SceneFieldType::Radh:
+            return 2;
+        case SceneFieldType::UnsignedInt:
+        case SceneFieldType::Vector2ui:
+        case SceneFieldType::Vector3ui:
+        case SceneFieldType::Vector4ui:
+        case SceneFieldType::Int:
+        case SceneFieldType::Vector2i:
+        case SceneFieldType::Vector3i:
+        case SceneFieldType::Vector4i:
+        case SceneFieldType::Float:
+        case SceneFieldType::Vector2:
+        case SceneFieldType::Vector3:
+        case SceneFieldType::Vector4:
+        case SceneFieldType::Matrix2x2:
+        case SceneFieldType::Matrix2x3:
+        case SceneFieldType::Matrix2x4:
+        case SceneFieldType::Matrix3x2:
+        case SceneFieldType::Matrix3x3:
+        case SceneFieldType::Matrix3x4:
+        case SceneFieldType::Matrix4x2:
+        case SceneFieldType::Matrix4x3:
+        case SceneFieldType::Matrix4x4:
+        case SceneFieldType::Range1Di:
+        case SceneFieldType::Range2Di:
+        case SceneFieldType::Range3Di:
+        case SceneFieldType::Range1D:
+        case SceneFieldType::Range2D:
+        case SceneFieldType::Range3D:
+        case SceneFieldType::Complex:
+        case SceneFieldType::Quaternion:
+        case SceneFieldType::DualComplex:
+        case SceneFieldType::DualQuaternion:
+        case SceneFieldType::Deg:
+        case SceneFieldType::Rad:
+            return 4;
+        case SceneFieldType::UnsignedLong:
+        case SceneFieldType::Long:
+        case SceneFieldType::Double:
+        case SceneFieldType::Vector2d:
+        case SceneFieldType::Vector3d:
+        case SceneFieldType::Vector4d:
+        case SceneFieldType::Matrix2x2d:
+        case SceneFieldType::Matrix2x3d:
+        case SceneFieldType::Matrix2x4d:
+        case SceneFieldType::Matrix3x2d:
+        case SceneFieldType::Matrix3x3d:
+        case SceneFieldType::Matrix3x4d:
+        case SceneFieldType::Matrix4x2d:
+        case SceneFieldType::Matrix4x3d:
+        case SceneFieldType::Matrix4x4d:
+        case SceneFieldType::Range1Dd:
+        case SceneFieldType::Range2Dd:
+        case SceneFieldType::Range3Dd:
+        case SceneFieldType::Complexd:
+        case SceneFieldType::Quaterniond:
+        case SceneFieldType::DualComplexd:
+        case SceneFieldType::DualQuaterniond:
+        case SceneFieldType::Degd:
+        case SceneFieldType::Radd:
+            return 8;
+        case SceneFieldType::Pointer:
+        case SceneFieldType::MutablePointer:
+            return sizeof(void*);
+    }
+    #ifdef CORRADE_TARGET_GCC
+    #pragma GCC diagnostic pop
+    #endif
+
+    CORRADE_ASSERT_UNREACHABLE("Trade::sceneFieldTypeAlignment(): invalid type" << type, {});
 }
 
 SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView2D<const char>& objectData, const SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, const UnsignedShort fieldArraySize) noexcept: SceneFieldData{name, {}, Containers::StridedArrayView1D<const void>{{objectData.data(), ~std::size_t{}}, objectData.size()[0], objectData.stride()[0]}, fieldType, Containers::StridedArrayView1D<const void>{{fieldData.data(), ~std::size_t{}}, fieldData.size()[0], fieldData.stride()[0]}, fieldArraySize} {

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -25,20 +25,1127 @@
 
 #include "SceneData.h"
 
+#include <Corrade/Utility/Algorithms.h>
+
+#include "Magnum/Math/Matrix3.h"
+#include "Magnum/Math/Matrix4.h"
+#include "Magnum/Math/DualComplex.h"
+#include "Magnum/Math/DualQuaternion.h"
+#include "Magnum/Math/PackingBatch.h"
+#include "Magnum/Trade/Implementation/arrayUtilities.h"
+
 namespace Magnum { namespace Trade {
 
-SceneData::SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* const importerState): _children2D{std::move(children2D)}, _children3D{std::move(children3D)}, _importerState{importerState} {}
+Debug& operator<<(Debug& debug, const SceneObjectType value) {
+    debug << "Trade::SceneObjectType" << Debug::nospace;
 
-SceneData::SceneData(SceneData&&)
-    #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
-    noexcept
-    #endif
-    = default;
+    switch(value) {
+        /* LCOV_EXCL_START */
+        #define _c(value) case SceneObjectType::value: return debug << "::" #value;
+        _c(UnsignedByte)
+        _c(UnsignedInt)
+        _c(UnsignedShort)
+        _c(UnsignedLong)
+        #undef _c
+        /* LCOV_EXCL_STOP */
+    }
 
-SceneData& SceneData::operator=(SceneData&&)
-    #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
-    noexcept
+    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedByte(value)) << Debug::nospace << ")";
+}
+
+UnsignedInt sceneObjectTypeSize(const SceneObjectType type) {
+    switch(type) {
+        case SceneObjectType::UnsignedByte: return 1;
+        case SceneObjectType::UnsignedShort: return 2;
+        case SceneObjectType::UnsignedInt: return 4;
+        case SceneObjectType::UnsignedLong: return 8;
+    }
+
+    CORRADE_ASSERT_UNREACHABLE("Trade::sceneObjectTypeSize(): invalid type" << type, {});
+}
+
+Debug& operator<<(Debug& debug, const SceneField value) {
+    debug << "Trade::SceneField" << Debug::nospace;
+
+    if(UnsignedInt(value) >= UnsignedInt(SceneField::Custom))
+        return debug << "::Custom(" << Debug::nospace << (UnsignedInt(value) - UnsignedInt(SceneField::Custom)) << Debug::nospace << ")";
+
+    switch(value) {
+        /* LCOV_EXCL_START */
+        #define _c(value) case SceneField::value: return debug << "::" #value;
+        _c(Parent)
+        _c(Transformation)
+        _c(Translation)
+        _c(Rotation)
+        _c(Scaling)
+        _c(Mesh)
+        _c(MeshMaterial)
+        _c(Light)
+        _c(Camera)
+        _c(Skin)
+        #undef _c
+        /* LCOV_EXCL_STOP */
+
+        /* To silence compiler warning about unhandled values */
+        case SceneField::Custom: CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+    }
+
+    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedInt(value)) << Debug::nospace << ")";
+}
+
+Debug& operator<<(Debug& debug, const SceneFieldType value) {
+    debug << "Trade::SceneFieldType" << Debug::nospace;
+
+    switch(value) {
+        /* LCOV_EXCL_START */
+        #define _c(value) case SceneFieldType::value: return debug << "::" #value;
+        _c(Float)
+        _c(Half)
+        _c(Double)
+        _c(UnsignedByte)
+        _c(Byte)
+        _c(UnsignedShort)
+        _c(Short)
+        _c(UnsignedInt)
+        _c(Int)
+        _c(UnsignedLong)
+        _c(Long)
+        _c(Vector2)
+        _c(Vector2h)
+        _c(Vector2d)
+        _c(Vector2ub)
+        _c(Vector2b)
+        _c(Vector2us)
+        _c(Vector2s)
+        _c(Vector2ui)
+        _c(Vector2i)
+        _c(Vector3)
+        _c(Vector3h)
+        _c(Vector3d)
+        _c(Vector3ub)
+        _c(Vector3b)
+        _c(Vector3us)
+        _c(Vector3s)
+        _c(Vector3ui)
+        _c(Vector3i)
+        _c(Vector4)
+        _c(Vector4h)
+        _c(Vector4d)
+        _c(Vector4ub)
+        _c(Vector4b)
+        _c(Vector4us)
+        _c(Vector4s)
+        _c(Vector4ui)
+        _c(Vector4i)
+        _c(Matrix2x2)
+        _c(Matrix2x2h)
+        _c(Matrix2x2d)
+        _c(Matrix2x3)
+        _c(Matrix2x3h)
+        _c(Matrix2x3d)
+        _c(Matrix2x4)
+        _c(Matrix2x4h)
+        _c(Matrix2x4d)
+        _c(Matrix3x2)
+        _c(Matrix3x2h)
+        _c(Matrix3x2d)
+        _c(Matrix3x3)
+        _c(Matrix3x3h)
+        _c(Matrix3x3d)
+        _c(Matrix3x4)
+        _c(Matrix3x4h)
+        _c(Matrix3x4d)
+        _c(Matrix4x2)
+        _c(Matrix4x2h)
+        _c(Matrix4x2d)
+        _c(Matrix4x3)
+        _c(Matrix4x3h)
+        _c(Matrix4x3d)
+        _c(Matrix4x4)
+        _c(Matrix4x4h)
+        _c(Matrix4x4d)
+        _c(Range1D)
+        _c(Range1Dh)
+        _c(Range1Dd)
+        _c(Range1Di)
+        _c(Range2D)
+        _c(Range2Dh)
+        _c(Range2Dd)
+        _c(Range2Di)
+        _c(Range3D)
+        _c(Range3Dh)
+        _c(Range3Dd)
+        _c(Range3Di)
+        _c(Complex)
+        _c(Complexd)
+        _c(DualComplex)
+        _c(DualComplexd)
+        _c(Quaternion)
+        _c(Quaterniond)
+        _c(DualQuaternion)
+        _c(DualQuaterniond)
+        _c(Deg)
+        _c(Degh)
+        _c(Degd)
+        _c(Rad)
+        _c(Radh)
+        _c(Radd)
+        #undef _c
+        /* LCOV_EXCL_STOP */
+    }
+
+    return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedShort(value)) << Debug::nospace << ")";
+}
+
+UnsignedInt sceneFieldTypeSize(const SceneFieldType type) {
+    switch(type) {
+        case SceneFieldType::UnsignedByte:
+        case SceneFieldType::Byte:
+            return 1;
+        case SceneFieldType::UnsignedShort:
+        case SceneFieldType::Short:
+        case SceneFieldType::Half:
+        case SceneFieldType::Vector2ub:
+        case SceneFieldType::Vector2b:
+        case SceneFieldType::Degh:
+        case SceneFieldType::Radh:
+            return 2;
+        case SceneFieldType::Vector3ub:
+        case SceneFieldType::Vector3b:
+            return 3;
+        case SceneFieldType::UnsignedInt:
+        case SceneFieldType::Int:
+        case SceneFieldType::Float:
+        case SceneFieldType::Vector2us:
+        case SceneFieldType::Vector2s:
+        case SceneFieldType::Vector2h:
+        case SceneFieldType::Vector4ub:
+        case SceneFieldType::Vector4b:
+        case SceneFieldType::Range1Dh:
+        case SceneFieldType::Deg:
+        case SceneFieldType::Rad:
+            return 4;
+        case SceneFieldType::Vector3us:
+        case SceneFieldType::Vector3s:
+        case SceneFieldType::Vector3h:
+            return 6;
+        case SceneFieldType::UnsignedLong:
+        case SceneFieldType::Long:
+        case SceneFieldType::Double:
+        case SceneFieldType::Vector2:
+        case SceneFieldType::Vector2ui:
+        case SceneFieldType::Vector2i:
+        case SceneFieldType::Vector4us:
+        case SceneFieldType::Vector4s:
+        case SceneFieldType::Vector4h:
+        case SceneFieldType::Matrix2x2h:
+        case SceneFieldType::Range1D:
+        case SceneFieldType::Range1Di:
+        case SceneFieldType::Range2Dh:
+        case SceneFieldType::Complex:
+        case SceneFieldType::Degd:
+        case SceneFieldType::Radd:
+            return 8;
+        case SceneFieldType::Vector3:
+        case SceneFieldType::Vector3ui:
+        case SceneFieldType::Vector3i:
+        case SceneFieldType::Matrix2x3h:
+        case SceneFieldType::Matrix3x2h:
+        case SceneFieldType::Range3Dh:
+            return 12;
+        case SceneFieldType::Vector2d:
+        case SceneFieldType::Vector4:
+        case SceneFieldType::Vector4ui:
+        case SceneFieldType::Vector4i:
+        case SceneFieldType::Matrix2x2:
+        case SceneFieldType::Matrix2x4h:
+        case SceneFieldType::Matrix4x2h:
+        case SceneFieldType::Range1Dd:
+        case SceneFieldType::Range2D:
+        case SceneFieldType::Range2Di:
+        case SceneFieldType::Complexd:
+        case SceneFieldType::DualComplex:
+        case SceneFieldType::Quaternion:
+            return 16;
+        case SceneFieldType::Matrix3x3h:
+            return 18;
+        case SceneFieldType::Vector3d:
+        case SceneFieldType::Matrix2x3:
+        case SceneFieldType::Matrix3x4h:
+        case SceneFieldType::Matrix3x2:
+        case SceneFieldType::Matrix4x3h:
+        case SceneFieldType::Range3D:
+        case SceneFieldType::Range3Di:
+            return 24;
+        case SceneFieldType::Vector4d:
+        case SceneFieldType::Matrix2x2d:
+        case SceneFieldType::Matrix2x4:
+        case SceneFieldType::Matrix4x2:
+        case SceneFieldType::Matrix4x4h:
+        case SceneFieldType::Range2Dd:
+        case SceneFieldType::DualComplexd:
+        case SceneFieldType::Quaterniond:
+        case SceneFieldType::DualQuaternion:
+            return 32;
+        case SceneFieldType::Matrix3x3:
+            return 36;
+        case SceneFieldType::Matrix2x3d:
+        case SceneFieldType::Matrix3x4:
+        case SceneFieldType::Matrix3x2d:
+        case SceneFieldType::Matrix4x3:
+        case SceneFieldType::Range3Dd:
+            return 48;
+        case SceneFieldType::Matrix2x4d:
+        case SceneFieldType::Matrix4x2d:
+        case SceneFieldType::Matrix4x4:
+        case SceneFieldType::DualQuaterniond:
+            return 64;
+        case SceneFieldType::Matrix3x3d:
+            return 72;
+        case SceneFieldType::Matrix3x4d:
+        case SceneFieldType::Matrix4x3d:
+            return 96;
+        case SceneFieldType::Matrix4x4d:
+            return 128;
+    }
+
+    CORRADE_ASSERT_UNREACHABLE("Trade::sceneFieldTypeSize(): invalid type" << type, {});
+}
+
+SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView2D<const char>& objectData, const SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, const UnsignedShort fieldArraySize) noexcept: SceneFieldData{name, {}, Containers::StridedArrayView1D<const void>{{objectData.data(), ~std::size_t{}}, objectData.size()[0], objectData.stride()[0]}, fieldType, Containers::StridedArrayView1D<const void>{{fieldData.data(), ~std::size_t{}}, fieldData.size()[0], fieldData.stride()[0]}, fieldArraySize} {
+    /* Yes, this calls into a constexpr function defined in the header --
+       because I feel that makes more sense than duplicating the full assert
+       logic */
+    #ifndef CORRADE_NO_ASSERT
+    if(fieldArraySize) CORRADE_ASSERT(fieldData.empty()[0] || fieldData.size()[1] == sceneFieldTypeSize(fieldType)*fieldArraySize,
+        "Trade::SceneFieldData: second field view dimension size" << fieldData.size()[1] << "doesn't match" << fieldType << "and field array size" << fieldArraySize, );
+    else CORRADE_ASSERT(fieldData.empty()[0] || fieldData.size()[1] == sceneFieldTypeSize(fieldType),
+        "Trade::SceneFieldData: second field view dimension size" << fieldData.size()[1] << "doesn't match" << fieldType, );
     #endif
-    = default;
+
+    if(objectData.size()[1] == 8) _objectType = SceneObjectType::UnsignedLong;
+    else if(objectData.size()[1] == 4) _objectType = SceneObjectType::UnsignedInt;
+    else if(objectData.size()[1] == 2) _objectType = SceneObjectType::UnsignedShort;
+    else if(objectData.size()[1] == 1) _objectType = SceneObjectType::UnsignedByte;
+    else CORRADE_ASSERT_UNREACHABLE("Trade::SceneFieldData: expected second object view dimension size 1, 2, 4 or 8 but got" << objectData.size()[1], );
+
+    CORRADE_ASSERT(fieldData.isContiguous<1>(), "Trade::SceneFieldData: second field view dimension is not contiguous", );
+    CORRADE_ASSERT(objectData.isContiguous<1>(), "Trade::SceneFieldData: second object view dimension is not contiguous", );
+}
+
+Containers::Array<SceneFieldData> sceneFieldDataNonOwningArray(const Containers::ArrayView<const SceneFieldData> view) {
+    /* Ugly, eh? */
+    return Containers::Array<SceneFieldData>{const_cast<SceneFieldData*>(view.data()), view.size(), reinterpret_cast<void(*)(SceneFieldData*, std::size_t)>(Implementation::nonOwnedArrayDeleter)};
+}
+
+SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, Containers::Array<char>&& data, Containers::Array<SceneFieldData>&& fields, const void* const importerState) noexcept: _dataFlags{DataFlag::Owned|DataFlag::Mutable}, _objectType{objectType}, _objectCount{objectCount}, _importerState{importerState}, _fields{std::move(fields)}, _data{std::move(data)} {
+    /* Check that object type is large enough */
+    CORRADE_ASSERT(
+        (objectType == SceneObjectType::UnsignedByte && objectCount <= 0xffull) ||
+        (objectType == SceneObjectType::UnsignedShort && objectCount <= 0xffffull) ||
+        (objectType == SceneObjectType::UnsignedInt && objectCount <= 0xffffffffull) ||
+        objectType == SceneObjectType::UnsignedLong,
+        "Trade::SceneData:" << objectType << "is too small for" << objectCount << "objects", );
+
+    #ifndef CORRADE_NO_ASSERT
+    /* Check various assumptions about field data */
+    Math::BoolVector<11> fieldsPresent; /** @todo some constant for this */
+    const UnsignedInt objectTypeSize = sceneObjectTypeSize(_objectType);
+    UnsignedInt translationField = ~UnsignedInt{};
+    UnsignedInt rotationField = ~UnsignedInt{};
+    UnsignedInt scalingField = ~UnsignedInt{};
+    UnsignedInt meshField = ~UnsignedInt{};
+    UnsignedInt meshMaterialField = ~UnsignedInt{};
+    for(std::size_t i = 0; i != _fields.size(); ++i) {
+        const SceneFieldData& field = _fields[i];
+
+        /* The object type has to be the same among all fields. Technically it
+           wouldn't need to be, but if there's 60k objects then using a 8bit
+           type for certain fields would mean only the first 256 objects can be
+           referenced, which makes no practical sense, and to improve the
+           situation there would need to be some additional per-field object
+           offset and ... it's simpler to just require the object type to be
+           large enough to reference all objects (checked outside of the loop
+           above) and that it's the same for all fields. This also makes it
+           more convenient for the user. */
+        CORRADE_ASSERT(field._objectType == _objectType,
+            "Trade::SceneData: inconsistent object type, got" << field._objectType << "for field" << i << "but expected" << _objectType, );
+
+        /* We could check that object indices are in bounds, but that's rather
+           expensive. OTOH it's fine if field size is larger than object count,
+           as a single object can have multiple instances of the same field
+           attached, so checking that would be wrong. */
+
+        /* Check that there are only unique fields. To avoid a O(n^2) operation
+           always (or allocating a sorted field map), builtin fields are
+           checked against a map and only custom fields are checked in an
+           O(n^2) way with the assumption there isn't many of them (and that
+           they'll gradually become builtin). */
+        if(!isSceneFieldCustom(_fields[i]._name)) {
+            CORRADE_INTERNAL_ASSERT(UnsignedInt(_fields[i]._name) < fieldsPresent.Size);
+            CORRADE_ASSERT(!fieldsPresent[UnsignedInt(_fields[i]._name)],
+                "Trade::SceneData: duplicate field" << _fields[i]._name, );
+            fieldsPresent.set(UnsignedInt(_fields[i]._name), true);
+        } else for(std::size_t j = 0; j != i; ++j) {
+            CORRADE_ASSERT(_fields[j]._name != _fields[i]._name,
+                "Trade::SceneData: duplicate field" << _fields[i]._name, );
+        }
+
+        /* Check that both the object and field view fits into the provided
+           data array. If the field is empty, we don't check anything --
+           accessing the memory would be invalid anyway and enforcing this
+           would lead to unnecessary friction with optional fields. */
+        if(field._size) {
+            const UnsignedInt fieldTypeSize = sceneFieldTypeSize(field._fieldType)*
+                (field._fieldArraySize ? field._fieldArraySize : 1);
+            if(field._isOffsetOnly) {
+                const std::size_t objectSize = field._objectData.offset + (field._size - 1)*field._objectStride + objectTypeSize;
+                const std::size_t fieldSize = field._fieldData.offset + (field._size - 1)*field._fieldStride + fieldTypeSize;
+                CORRADE_ASSERT(objectSize <= _data.size(),
+                    "Trade::SceneData: offset-only object data of field" << i << "span" << objectSize << "bytes but passed data array has only" << _data.size(), );
+                CORRADE_ASSERT(fieldSize <= _data.size(),
+                    "Trade::SceneData: offset-only field data of field" << i << "span" << fieldSize << "bytes but passed data array has only" << _data.size(), );
+            } else {
+                const void* const objectBegin = field._objectData.pointer;
+                const void* const fieldBegin = field._fieldData.pointer;
+                const void* const objectEnd = static_cast<const char*>(field._objectData.pointer) + (field._size - 1)*field._objectStride + objectTypeSize;
+                const void* const fieldEnd = static_cast<const char*>(field._fieldData.pointer) + (field._size - 1)*field._fieldStride + fieldTypeSize;
+                CORRADE_ASSERT(objectBegin >= _data.begin() && objectEnd <= _data.end(),
+                    "Trade::SceneData: object data [" << Debug::nospace << objectBegin << Debug::nospace << ":" << Debug::nospace << objectEnd << Debug::nospace << "] of field" << i << "are not contained in passed data array [" << Debug::nospace << static_cast<const void*>(_data.begin()) << Debug::nospace << ":" << Debug::nospace << static_cast<const void*>(_data.end()) << Debug::nospace << "]", );
+                CORRADE_ASSERT(fieldBegin >= _data.begin() && fieldEnd <= _data.end(),
+                    "Trade::SceneData: field data [" << Debug::nospace << fieldBegin << Debug::nospace << ":" << Debug::nospace << fieldEnd << Debug::nospace << "] of field" << i << "are not contained in passed data array [" << Debug::nospace << static_cast<const void*>(_data.begin()) << Debug::nospace << ":" << Debug::nospace << static_cast<const void*>(_data.end()) << Debug::nospace << "]", );
+            }
+        }
+
+        /* Remember TRS and mesh/material fields to check their object mapping
+           consistency outside of the loop below */
+        if(_fields[i]._name == SceneField::Translation) {
+            translationField = i;
+        } else if(_fields[i]._name == SceneField::Rotation) {
+            rotationField = i;
+        } else if(_fields[i]._name == SceneField::Scaling) {
+            scalingField = i;
+        } else if(_fields[i]._name == SceneField::Mesh) {
+            meshField = i;
+        } else if(_fields[i]._name == SceneField::MeshMaterial) {
+            meshMaterialField = i;
+        }
+    }
+
+    /* Check that certain fields share the same object mapping. Printing as if
+       all would be pointers (and not offset-only), it's not worth the extra
+       effort just for an assert message. Also, compared to above, where
+       "begin" was always zero, here we're always comparing four values, so the
+       message for offset-only wouldn't be simpler either. */
+    const auto checkFieldObjectDataMatch = [](const SceneFieldData& a, const SceneFieldData& b) {
+        const std::size_t objectTypeSize = sceneObjectTypeSize(a._objectType);
+        const void* const aBegin = a._objectData.pointer;
+        const void* const bBegin = b._objectData.pointer;
+        const void* const aEnd = static_cast<const char*>(a._objectData.pointer) + a._size*objectTypeSize;
+        const void* const bEnd = static_cast<const char*>(b._objectData.pointer) + b._size*objectTypeSize;
+        CORRADE_ASSERT(aBegin == bBegin && aEnd == bEnd,
+            "Trade::SceneData:" << b._name << "object data [" << Debug::nospace << bBegin << Debug::nospace << ":" << Debug::nospace << bEnd << Debug::nospace << "] is different from" << a._name << "object data [" << Debug::nospace << aBegin << Debug::nospace << ":" << Debug::nospace << aEnd << Debug::nospace << "]", );
+    };
+
+    /* All present TRS fields should share the same object mapping */
+    if(translationField != ~UnsignedInt{}) {
+        if(rotationField != ~UnsignedInt{})
+            checkFieldObjectDataMatch(_fields[translationField], _fields[rotationField]);
+        if(scalingField != ~UnsignedInt{})
+            checkFieldObjectDataMatch(_fields[translationField], _fields[scalingField]);
+    }
+    if(rotationField != ~UnsignedInt{} && scalingField != ~UnsignedInt{})
+        checkFieldObjectDataMatch(_fields[rotationField], _fields[scalingField]);
+
+    /* Mesh and materials also */
+    if(meshField != ~UnsignedInt{} && meshMaterialField != ~UnsignedInt{})
+        checkFieldObjectDataMatch(_fields[meshField], _fields[meshMaterialField]);
+    #endif
+}
+
+SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, Containers::Array<char>&& data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{objectType, objectCount, std::move(data), Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}
+
+SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, const DataFlags dataFlags, const Containers::ArrayView<const void> data, Containers::Array<SceneFieldData>&& fields, const void* const importerState) noexcept: SceneData{objectType, objectCount, Containers::Array<char>{const_cast<char*>(static_cast<const char*>(data.data())), data.size(), Implementation::nonOwnedArrayDeleter}, std::move(fields), importerState} {
+    CORRADE_ASSERT(!(dataFlags & DataFlag::Owned),
+        "Trade::SceneData: can't construct with non-owned data but" << dataFlags, );
+    _dataFlags = dataFlags;
+}
+
+SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, const DataFlags dataFlags, const Containers::ArrayView<const void> data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{objectType, objectCount, dataFlags, data, Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}
+
+SceneData::SceneData(SceneData&&) noexcept = default;
+
+SceneData::~SceneData() = default;
+
+SceneData& SceneData::operator=(SceneData&&) noexcept = default;
+
+Containers::ArrayView<char> SceneData::mutableData() & {
+    CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
+        "Trade::SceneData::mutableData(): data not mutable", {});
+    return _data;
+}
+
+Containers::StridedArrayView1D<const void> SceneData::fieldDataObjectViewInternal(const SceneFieldData& field) const {
+    return Containers::StridedArrayView1D<const void>{
+        /* We're *sure* the view is correct, so faking the view size */
+        /** @todo better ideas for the StridedArrayView API? */
+        {field._isOffsetOnly ? _data.data() + field._objectData.offset :
+            field._objectData.pointer, ~std::size_t{}},
+        field._size, field._objectStride};
+}
+
+Containers::StridedArrayView1D<const void> SceneData::fieldDataFieldViewInternal(const SceneFieldData& field) const {
+    return Containers::StridedArrayView1D<const void>{
+        /* We're *sure* the view is correct, so faking the view size */
+        /** @todo better ideas for the StridedArrayView API? */
+        {field._isOffsetOnly ? _data.data() + field._fieldData.offset :
+            field._fieldData.pointer, ~std::size_t{}},
+        field._size, field._fieldStride};
+}
+
+SceneFieldData SceneData::fieldData(const UnsignedInt id) const {
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::fieldData(): index" << id << "out of range for" << _fields.size() << "fields", SceneFieldData{});
+    const SceneFieldData& field = _fields[id];
+    return SceneFieldData{field._name, field._objectType, fieldDataObjectViewInternal(field), field._fieldType, fieldDataFieldViewInternal(field), field._fieldArraySize};
+}
+
+SceneField SceneData::fieldName(const UnsignedInt id) const {
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::fieldName(): index" << id << "out of range for" << _fields.size() << "fields", {});
+    return _fields[id]._name;
+}
+
+SceneFieldType SceneData::fieldType(const UnsignedInt id) const {
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::fieldType(): index" << id << "out of range for" << _fields.size() << "fields", {});
+    return _fields[id]._fieldType;
+}
+
+std::size_t SceneData::fieldSize(const UnsignedInt id) const {
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::fieldSize(): index" << id << "out of range for" << _fields.size() << "fields", {});
+    return _fields[id]._size;
+}
+
+UnsignedShort SceneData::fieldArraySize(const UnsignedInt id) const {
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::fieldArraySize(): index" << id << "out of range for" << _fields.size() << "fields", {});
+    return _fields[id]._fieldArraySize;
+}
+
+UnsignedInt SceneData::fieldFor(const SceneField name) const {
+    for(std::size_t i = 0; i != _fields.size(); ++i)
+        if(_fields[i]._name == name) return i;
+    return ~UnsignedInt{};
+}
+
+bool SceneData::hasField(const SceneField name) const {
+    return fieldFor(name) != ~UnsignedInt{};
+}
+
+UnsignedInt SceneData::fieldId(const SceneField name) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::fieldId(): field" << name << "not found", {});
+    return fieldId;
+}
+
+SceneFieldType SceneData::fieldType(const SceneField name) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::fieldType(): field" << name << "not found", {});
+    return _fields[fieldId]._fieldType;
+}
+
+std::size_t SceneData::fieldSize(const SceneField name) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::fieldSize(): field" << name << "not found", {});
+    return _fields[fieldId]._size;
+}
+
+UnsignedShort SceneData::fieldArraySize(const SceneField name) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::fieldArraySize(): field" << name << "not found", {});
+    return _fields[fieldId]._fieldArraySize;
+}
+
+Containers::StridedArrayView2D<const char> SceneData::objects(const UnsignedInt fieldId) const {
+    CORRADE_ASSERT(fieldId < _fields.size(),
+        "Trade::SceneData::objects(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+    const SceneFieldData& field = _fields[fieldId];
+    /* Build a 2D view using information about object type size */
+    return Containers::arrayCast<2, const char>(
+        fieldDataObjectViewInternal(field),
+        sceneObjectTypeSize(field._objectType));
+}
+
+Containers::StridedArrayView2D<char> SceneData::mutableObjects(const UnsignedInt fieldId) {
+    CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
+        "Trade::SceneData::mutableObjects(): data not mutable", {});
+    CORRADE_ASSERT(fieldId < _fields.size(),
+        "Trade::SceneData::mutableObjects(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+    const SceneFieldData& field = _fields[fieldId];
+    /* Build a 2D view using information about attribute type size */
+    const auto out = Containers::arrayCast<2, const char>(
+        fieldDataObjectViewInternal(field),
+        sceneObjectTypeSize(field._objectType));
+    /** @todo some arrayConstCast? UGH */
+    return Containers::StridedArrayView2D<char>{
+        /* The view size is there only for a size assert, we're pretty sure the
+           view is valid */
+        {static_cast<char*>(const_cast<void*>(out.data())), ~std::size_t{}},
+        out.size(), out.stride()};
+}
+
+Containers::StridedArrayView2D<const char> SceneData::objects(const SceneField fieldName) const {
+    const UnsignedInt fieldId = fieldFor(fieldName);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::objects(): field" << fieldName << "not found", {});
+    return objects(fieldId);
+}
+
+Containers::StridedArrayView2D<char> SceneData::mutableObjects(const SceneField fieldName) {
+    CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
+        "Trade::SceneData::mutableObjects(): data not mutable", {});
+    const UnsignedInt fieldId = fieldFor(fieldName);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::mutableObjects(): field" << fieldName << "not found", {});
+    return mutableObjects(fieldId);
+}
+
+Containers::StridedArrayView2D<const char> SceneData::field(const UnsignedInt id) const {
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::field(): index" << id << "out of range for" << _fields.size() << "fields", {});
+    const SceneFieldData& field = _fields[id];
+    /* Build a 2D view using information about object type size */
+    return Containers::arrayCast<2, const char>(
+        fieldDataFieldViewInternal(field),
+        sceneFieldTypeSize(field._fieldType)*(field._fieldArraySize ? field._fieldArraySize : 1));
+}
+
+Containers::StridedArrayView2D<char> SceneData::mutableField(const UnsignedInt id) {
+    CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
+        "Trade::SceneData::mutableField(): data not mutable", {});
+    CORRADE_ASSERT(id < _fields.size(),
+        "Trade::SceneData::mutableField(): index" << id << "out of range for" << _fields.size() << "fields", {});
+    const SceneFieldData& field = _fields[id];
+    /* Build a 2D view using information about attribute type size */
+    const auto out = Containers::arrayCast<2, const char>(
+        fieldDataFieldViewInternal(field),
+        sceneFieldTypeSize(field._fieldType)*(field._fieldArraySize ? field._fieldArraySize : 1));
+    /** @todo some arrayConstCast? UGH */
+    return Containers::StridedArrayView2D<char>{
+        /* The view size is there only for a size assert, we're pretty sure the
+           view is valid */
+        {static_cast<char*>(const_cast<void*>(out.data())), ~std::size_t{}},
+        out.size(), out.stride()};
+}
+
+Containers::StridedArrayView2D<const char> SceneData::field(const SceneField name) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        "Trade::SceneData::field(): field" << name << "not found", {});
+    return field(fieldId);
+}
+
+Containers::StridedArrayView2D<char> SceneData::mutableField(const SceneField name) {
+    CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
+        "Trade::SceneData::mutableField(): data not mutable", {});
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        "Trade::SceneData::mutableField(): field" << name << "not found", {});
+    return mutableField(fieldId);
+}
+
+void SceneData::objectsInto(const UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    CORRADE_ASSERT(fieldId < _fields.size(),
+        "Trade::SceneData::objectsInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", );
+    const SceneFieldData& field = _fields[fieldId];
+    CORRADE_ASSERT(destination.size() == field._size,
+        "Trade::SceneData::objectsInto(): expected a view with" << field._size << "elements but got" << destination.size(), );
+    const Containers::StridedArrayView1D<const void> objectData = fieldDataObjectViewInternal(field);
+    const auto destination1ui = Containers::arrayCast<2, UnsignedInt>(destination);
+
+    if(field._objectType == SceneObjectType::UnsignedInt)
+        Utility::copy(Containers::arrayCast<const UnsignedInt>(objectData), destination);
+    else if(field._objectType == SceneObjectType::UnsignedShort)
+        Math::castInto(Containers::arrayCast<2, const UnsignedShort>(objectData, 1), destination1ui);
+    else if(field._objectType == SceneObjectType::UnsignedByte)
+        Math::castInto(Containers::arrayCast<2, const UnsignedByte>(objectData, 1), destination1ui);
+    else if(field._objectType == SceneObjectType::UnsignedLong) {
+        CORRADE_ASSERT(_objectCount <= 0xffffffffull, "Trade::SceneData::objectsInto(): indices for up to" << _objectCount << "objects can't fit into a 32-bit type, access them directly via objects() instead", );
+        Math::castInto(Containers::arrayCast<2, const UnsignedLong>(objectData, 1), destination1ui);
+    } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+}
+
+Containers::Array<UnsignedInt> SceneData::objectsAsArray(const UnsignedInt fieldId) const {
+    CORRADE_ASSERT(fieldId < _fields.size(),
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::objectsInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+    Containers::Array<UnsignedInt> out{NoInit, std::size_t(_fields[fieldId]._size)};
+    objectsInto(fieldId, out);
+    return out;
+}
+
+void SceneData::objectsInto(const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        "Trade::SceneData::objectsInto(): field" << name << "not found", );
+    objectsInto(fieldId, destination);
+}
+
+Containers::Array<UnsignedInt> SceneData::objectsAsArray(const SceneField name) const {
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::objectsInto(): field" << name << "not found", {});
+    return objectsAsArray(fieldId);
+}
+
+void SceneData::parentsInto(const Containers::StridedArrayView1D<Int>& destination) const {
+    const UnsignedInt fieldId = fieldFor(SceneField::Parent);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        "Trade::SceneData::parentsInto(): field not found", );
+    const SceneFieldData& field = _fields[fieldId];
+    CORRADE_ASSERT(destination.size() == field._size,
+        "Trade::SceneData::parentsInto(): expected a view with" << field._size << "elements but got" << destination.size(), );
+    const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+    const auto destination1i = Containers::arrayCast<2, Int>(destination);
+
+    if(field._fieldType == SceneFieldType::Int)
+        Utility::copy(Containers::arrayCast<const Int>(fieldData), destination);
+    else if(field._fieldType == SceneFieldType::Short)
+        Math::castInto(Containers::arrayCast<2, const Short>(fieldData, 1), destination1i);
+    else if(field._fieldType == SceneFieldType::Byte)
+        Math::castInto(Containers::arrayCast<2, const Byte>(fieldData, 1), destination1i);
+    else if(field._fieldType == SceneFieldType::Long) {
+        CORRADE_ASSERT(field._size <= 0xffffffffull, "Trade::SceneData::parentsInto(): parent indices for up to"  << field._size << "objects can't fit into a 32-bit type, access them directly via field() instead", );
+        Math::castInto(Containers::arrayCast<2, const Long>(fieldData, 1), destination1i);
+    } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+}
+
+Containers::Array<Int> SceneData::parentsAsArray() const {
+    const UnsignedInt fieldId = fieldFor(SceneField::Parent);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::parentsInto(): field not found", {});
+    Containers::Array<Int> out{NoInit, std::size_t(_fields[fieldId]._size)};
+    parentsInto(out);
+    return out;
+}
+
+namespace {
+
+template<class Source, class Destination> void convertTransformation(const Containers::StridedArrayView1D<const void>& source, const Containers::StridedArrayView1D<Destination>& destination) {
+    CORRADE_INTERNAL_ASSERT(source.size() == destination.size());
+    const auto sourceT = Containers::arrayCast<const Source>(source);
+    for(std::size_t i = 0; i != sourceT.size(); ++i)
+        destination[i] = Destination{sourceT[i].toMatrix()};
+}
+
+/** @todo these (or the float variants at least) should eventually be replaced
+    with optimized batched APIs (applyTranslationsInto() updating just the
+    last matrix column etc.) */
+
+template<class Source, class Destination> void applyTranslation(const Containers::StridedArrayView1D<const void>& source, const Containers::StridedArrayView1D<Destination>& destination) {
+    CORRADE_INTERNAL_ASSERT(source.size() == destination.size());
+    const auto sourceT = Containers::arrayCast<const Source>(source);
+    for(std::size_t i = 0; i != sourceT.size(); ++i)
+        destination[i] = Destination::translation(Math::Vector<Destination::Size - 1, Float>{sourceT[i]})*destination[i];
+}
+
+template<class Source, class Destination> void applyRotation(const Containers::StridedArrayView1D<const void>& source, const Containers::StridedArrayView1D<Destination>& destination) {
+    CORRADE_INTERNAL_ASSERT(source.size() == destination.size());
+    const auto sourceT = Containers::arrayCast<const Source>(source);
+    for(std::size_t i = 0; i != sourceT.size(); ++i)
+        destination[i] = Destination{Math::Matrix<Destination::Size - 1, Float>{ sourceT[i].toMatrix()}}*destination[i];
+}
+
+template<class Source, class Destination> void applyScaling(const Containers::StridedArrayView1D<const void>& source, const Containers::StridedArrayView1D<Destination>& destination) {
+    CORRADE_INTERNAL_ASSERT(source.size() == destination.size());
+    const auto sourceT = Containers::arrayCast<const Source>(source);
+    for(std::size_t i = 0; i != sourceT.size(); ++i)
+        destination[i] = Destination::scaling(Math::Vector<Destination::Size - 1, Float>{sourceT[i]})*destination[i];
+}
+
+}
+
+std::size_t SceneData::findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const {
+    UnsignedInt fieldToCheckForSize = ~UnsignedInt{};
+    transformationFieldId = ~UnsignedInt{};
+    translationFieldId = ~UnsignedInt{};
+    rotationFieldId = ~UnsignedInt{};
+    scalingFieldId = ~UnsignedInt{};
+    for(std::size_t i = 0; i != _fields.size(); ++i) {
+        /* If we find a transformation field, we don't need to look any
+           further */
+        if(_fields[i]._name == SceneField::Transformation) {
+            fieldToCheckForSize = transformationFieldId = i;
+            break;
+        } else if(_fields[i]._name == SceneField::Translation) {
+            fieldToCheckForSize = translationFieldId = i;
+        } else if(_fields[i]._name == SceneField::Rotation) {
+            fieldToCheckForSize = rotationFieldId = i;
+        } else if(_fields[i]._name == SceneField::Scaling) {
+            fieldToCheckForSize = scalingFieldId = i;
+        }
+    }
+
+    /* Assuming the caller fires an appropriate assertion */
+    return fieldToCheckForSize == ~UnsignedInt{} ?
+        ~std::size_t{} : _fields[fieldToCheckForSize]._size;
+}
+
+void SceneData::transformations2DIntoInternal(const UnsignedInt transformationFieldId, const UnsignedInt translationFieldId, const UnsignedInt rotationFieldId, const UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix3>& destination) const {
+    /** @todo apply scalings as well if dual complex? */
+
+    /* Prefer the transformation field, if present */
+    if(transformationFieldId != ~UnsignedInt{}) {
+        const SceneFieldData& field = _fields[transformationFieldId];
+        const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+        const auto destination1f = Containers::arrayCast<2, Float>(destination);
+
+        if(field._fieldType == SceneFieldType::Matrix3x3) {
+            Utility::copy(Containers::arrayCast<const Matrix3>(fieldData), destination);
+        } else if(field._fieldType == SceneFieldType::Matrix3x3d) {
+            Math::castInto(Containers::arrayCast<2, const Double>(fieldData, 9), destination1f);
+        } else if(field._fieldType == SceneFieldType::DualComplex) {
+            convertTransformation<DualComplex>(fieldData, destination);
+        } else if(field._fieldType == SceneFieldType::DualComplexd) {
+            convertTransformation<DualComplexd>(fieldData, destination);
+        } else if(field._fieldType == SceneFieldType::Matrix4x4 ||
+                  field._fieldType == SceneFieldType::Matrix4x4d ||
+                  field._fieldType == SceneFieldType::DualQuaternion ||
+                  field._fieldType == SceneFieldType::DualQuaterniond) {
+            CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations2DInto(): field has a 3D transformation type" << field._fieldType, );
+        } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+
+    /* If not, combine from TRS components */
+    } else if(translationFieldId != ~UnsignedInt{} || rotationFieldId != ~UnsignedInt{} || scalingFieldId != ~UnsignedInt{}) {
+        /* First fill the destination with identity matrices */
+        const Matrix3 identity[1]{Matrix3{Math::IdentityInit}};
+        Utility::copy(Containers::stridedArrayView(identity).broadcasted<0>(destination.size()), destination);
+
+        /* Apply scaling first, if present */
+        if(scalingFieldId != ~UnsignedInt{}) {
+            const SceneFieldData& field = _fields[scalingFieldId];
+            const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+
+            if(field._fieldType == SceneFieldType::Vector2) {
+                applyScaling<Vector2>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector2d) {
+                applyScaling<Vector2d>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector3 ||
+                      field._fieldType == SceneFieldType::Vector3d) {
+                CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations2DInto(): field has a 3D scaling type" << field._fieldType, );
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+        }
+
+        /* Apply rotation second, if present */
+        if(rotationFieldId != ~UnsignedInt{}) {
+            const SceneFieldData& field = _fields[rotationFieldId];
+            const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+
+            if(field._fieldType == SceneFieldType::Complex) {
+                applyRotation<Complex>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Complexd) {
+                applyRotation<Complexd>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Quaternion ||
+                      field._fieldType == SceneFieldType::Quaterniond) {
+                CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations2DInto(): field has a 3D rotation type" << field._fieldType, );
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+        }
+
+        /* Apply translation last, if present */
+        if(translationFieldId != ~UnsignedInt{}) {
+            const SceneFieldData& field = _fields[translationFieldId];
+            const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+
+            if(field._fieldType == SceneFieldType::Vector2) {
+                applyTranslation<Vector2>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector2d) {
+                applyTranslation<Vector2d>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector3 ||
+                      field._fieldType == SceneFieldType::Vector3d) {
+                CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations2DInto(): field has a 3D translation type" << field._fieldType, );
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+        }
+
+    /* Checked in the caller */
+    } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+}
+
+void SceneData::transformations2DInto(const Containers::StridedArrayView1D<Matrix3>& destination) const {
+    UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
+    #ifndef CORRADE_NO_ASSERT
+    const std::size_t expectedSize =
+    #endif
+        findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
+    CORRADE_ASSERT(expectedSize != ~std::size_t{},
+        "Trade::SceneData::transformations2DInto(): no transformation-related field found", );
+    CORRADE_ASSERT(expectedSize == destination.size(),
+        "Trade::SceneData::transformations2DInto(): expected a view with" << expectedSize << "elements but got" << destination.size(), );
+    transformations2DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, destination);
+}
+
+Containers::Array<Matrix3> SceneData::transformations2DAsArray() const {
+    UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
+    const std::size_t expectedSize = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
+    CORRADE_ASSERT(expectedSize != ~std::size_t{},
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::transformations2DInto(): no transformation-related field found", {});
+    Containers::Array<Matrix3> out{NoInit, expectedSize};
+    transformations2DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, out);
+    return out;
+}
+
+void SceneData::transformations3DIntoInternal(const UnsignedInt transformationFieldId, const UnsignedInt translationFieldId, const UnsignedInt rotationFieldId, const UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix4>& destination) const {
+    /** @todo apply scalings as well if dual quat? */
+
+    /* Prefer the transformation field, if present */
+    if(transformationFieldId != ~UnsignedInt{}) {
+        const SceneFieldData& field = _fields[transformationFieldId];
+        const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+        const auto destination1f = Containers::arrayCast<2, Float>(destination);
+
+        if(field._fieldType == SceneFieldType::Matrix4x4) {
+            Utility::copy(Containers::arrayCast<const Matrix4>(fieldData), destination);
+        } else if(field._fieldType == SceneFieldType::Matrix4x4d) {
+            Math::castInto(Containers::arrayCast<2, const Double>(fieldData, 16), destination1f);
+        } else if(field._fieldType == SceneFieldType::DualQuaternion) {
+            convertTransformation<DualQuaternion>(fieldData, destination);
+        } else if(field._fieldType == SceneFieldType::DualQuaterniond) {
+            convertTransformation<DualQuaterniond>(fieldData, destination);
+        } else if(field._fieldType == SceneFieldType::Matrix3x3 ||
+                  field._fieldType == SceneFieldType::Matrix3x3d ||
+                  field._fieldType == SceneFieldType::DualComplex ||
+                  field._fieldType == SceneFieldType::DualComplexd) {
+            CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations3DInto(): field has a 2D transformation type" << field._fieldType, );
+        } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+
+    /* If not, combine from TRS components */
+    } else if(translationFieldId != ~UnsignedInt{} || rotationFieldId != ~UnsignedInt{} || scalingFieldId != ~UnsignedInt{}) {
+        /* First fill the destination with identity matrices */
+        const Matrix4 identity[1]{Matrix4{Math::IdentityInit}};
+        Utility::copy(Containers::stridedArrayView(identity).broadcasted<0>(destination.size()), destination);
+
+        /* Apply scaling first, if present */
+        if(scalingFieldId != ~UnsignedInt{}) {
+            const SceneFieldData& field = _fields[scalingFieldId];
+            const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+
+            if(field._fieldType == SceneFieldType::Vector3) {
+                applyScaling<Vector3>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector3d) {
+                applyScaling<Vector3d>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector2 ||
+                      field._fieldType == SceneFieldType::Vector2d) {
+                CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations3DInto(): field has a 2D scaling type" << field._fieldType, );
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+        }
+
+        /* Apply rotation second, if present */
+        if(rotationFieldId != ~UnsignedInt{}) {
+            const SceneFieldData& field = _fields[rotationFieldId];
+            const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+
+            if(field._fieldType == SceneFieldType::Quaternion) {
+                applyRotation<Quaternion>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Quaterniond) {
+                applyRotation<Quaterniond>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Complex ||
+                      field._fieldType == SceneFieldType::Complexd) {
+                CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations3DInto(): field has a 2D rotation type" << field._fieldType, );
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+        }
+
+        /* Apply translation last, if present */
+        if(translationFieldId != ~UnsignedInt{}) {
+            const SceneFieldData& field = _fields[translationFieldId];
+            const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+
+            if(field._fieldType == SceneFieldType::Vector3) {
+                applyTranslation<Vector3>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector3d) {
+                applyTranslation<Vector3d>(fieldData, destination);
+            } else if(field._fieldType == SceneFieldType::Vector2 ||
+                      field._fieldType == SceneFieldType::Vector2d) {
+                CORRADE_ASSERT_UNREACHABLE("Trade::SceneData::transformations3DInto(): field has a 2D translation type" << field._fieldType, );
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+        }
+
+    /* Checked in the caller */
+    } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+}
+
+void SceneData::transformations3DInto(const Containers::StridedArrayView1D<Matrix4>& destination) const {
+    UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
+    #ifndef CORRADE_NO_ASSERT
+    const std::size_t expectedSize =
+    #endif
+        findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
+    CORRADE_ASSERT(expectedSize != ~std::size_t{},
+        "Trade::SceneData::transformations3DInto(): no transformation-related field found", );
+    CORRADE_ASSERT(expectedSize == destination.size(),
+        "Trade::SceneData::transformations3DInto(): expected a view with" << expectedSize << "elements but got" << destination.size(), );
+    transformations3DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, destination);
+}
+
+Containers::Array<Matrix4> SceneData::transformations3DAsArray() const {
+    UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
+    const std::size_t expectedSize = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
+    CORRADE_ASSERT(expectedSize != ~std::size_t{},
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::transformations3DInto(): no transformation-related field found", {});
+    Containers::Array<Matrix4> out{NoInit, expectedSize};
+    transformations3DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, out);
+    return out;
+}
+
+void SceneData::indexFieldIntoInternal(
+    #ifndef CORRADE_NO_ASSERT
+    const char* const prefix,
+    #endif
+    const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const
+{
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{},
+        prefix << "field not found", );
+    const SceneFieldData& field = _fields[fieldId];
+    CORRADE_ASSERT(destination.size() == field._size,
+        prefix << "expected a view with" << field._size << "elements but got" << destination.size(), );
+    const Containers::StridedArrayView1D<const void> fieldData = fieldDataFieldViewInternal(field);
+    const auto destination1ui = Containers::arrayCast<2, UnsignedInt>(destination);
+
+    if(field._fieldType == SceneFieldType::UnsignedInt)
+        Utility::copy(Containers::arrayCast<const UnsignedInt>(fieldData), destination);
+    else if(field._fieldType == SceneFieldType::UnsignedShort)
+        Math::castInto(Containers::arrayCast<2, const UnsignedShort>(fieldData, 1), destination1ui);
+    else if(field._fieldType == SceneFieldType::UnsignedByte)
+        Math::castInto(Containers::arrayCast<2, const UnsignedByte>(fieldData, 1), destination1ui);
+    else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
+}
+
+Containers::Array<UnsignedInt> SceneData::indexFieldAsArrayInternal(
+    #ifndef CORRADE_NO_ASSERT
+    const char* const prefix,
+    #endif
+    const SceneField name) const
+{
+    const UnsignedInt fieldId = fieldFor(name);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, prefix << "field not found", {});
+    Containers::Array<UnsignedInt> out{NoInit, std::size_t(_fields[fieldId]._size)};
+    indexFieldIntoInternal(
+        #ifndef CORRADE_NO_ASSERT
+        prefix,
+        #endif
+        name, out);
+    return out;
+}
+
+void SceneData::meshesInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    indexFieldIntoInternal(
+        #ifndef CORRADE_NO_ASSERT
+        "Trade::SceneData::meshesInto():",
+        #endif
+        SceneField::Mesh, destination);
+}
+
+Containers::Array<UnsignedInt> SceneData::meshesAsArray() const {
+    return indexFieldAsArrayInternal(
+        #ifndef CORRADE_NO_ASSERT
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::meshesInto():",
+        #endif
+        SceneField::Mesh);
+}
+
+void SceneData::meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    indexFieldIntoInternal(
+        #ifndef CORRADE_NO_ASSERT
+        "Trade::SceneData::meshMaterialsInto():",
+        #endif
+        SceneField::MeshMaterial, destination);
+}
+
+Containers::Array<UnsignedInt> SceneData::meshMaterialsAsArray() const {
+    return indexFieldAsArrayInternal(
+        #ifndef CORRADE_NO_ASSERT
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::meshMaterialsInto():",
+        #endif
+        SceneField::MeshMaterial);
+}
+
+void SceneData::lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    indexFieldIntoInternal(
+        #ifndef CORRADE_NO_ASSERT
+        "Trade::SceneData::lightsInto():",
+        #endif
+        SceneField::Light, destination);
+}
+
+Containers::Array<UnsignedInt> SceneData::lightsAsArray() const {
+    return indexFieldAsArrayInternal(
+        #ifndef CORRADE_NO_ASSERT
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::lightsInto():",
+        #endif
+        SceneField::Light);
+}
+
+void SceneData::camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    indexFieldIntoInternal(
+        #ifndef CORRADE_NO_ASSERT
+        "Trade::SceneData::camerasInto():",
+        #endif
+        SceneField::Camera, destination);
+}
+
+Containers::Array<UnsignedInt> SceneData::camerasAsArray() const {
+    return indexFieldAsArrayInternal(
+        #ifndef CORRADE_NO_ASSERT
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::camerasInto():",
+        #endif
+        SceneField::Camera);
+}
+
+void SceneData::skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+    indexFieldIntoInternal(
+        #ifndef CORRADE_NO_ASSERT
+        "Trade::SceneData::skinsInto():",
+        #endif
+        SceneField::Skin, destination);
+}
+
+Containers::Array<UnsignedInt> SceneData::skinsAsArray() const {
+    return indexFieldAsArrayInternal(
+        #ifndef CORRADE_NO_ASSERT
+        /* Using the same message as in Into() to avoid too many redundant
+           strings in the binary */
+        "Trade::SceneData::skinsInto():",
+        #endif
+        SceneField::Skin);
+}
+
+Containers::Array<SceneFieldData> SceneData::releaseFieldData() {
+    Containers::Array<SceneFieldData> out = std::move(_fields);
+    _fields = {};
+    return out;
+}
+
+Containers::Array<char> SceneData::releaseData() {
+    _fields = {};
+    Containers::Array<char> out = std::move(_data);
+    _data = {};
+    return out;
+}
 
 }}

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -2210,12 +2210,24 @@ Containers::Optional<const void*> SceneData::importerStateFor(const UnsignedInt 
 #ifdef MAGNUM_BUILD_DEPRECATED
 std::vector<UnsignedInt> SceneData::children2D() const {
     if(_dimensions != 2) return {};
+
+    /* Even though (or exactly because?) this API is deprecated, it's better to
+       warn than to spend several hours debugging what's wrong */
+    if(!hasField(SceneField::Parent))
+        Warning{} << "Trade::SceneData::children2D(): no parent field present, returned array will be empty";
+
     const Containers::Array<UnsignedInt> children = childrenFor(-1);
     return {children.begin(), children.end()};
 }
 
 std::vector<UnsignedInt> SceneData::children3D() const {
     if(_dimensions != 3) return {};
+
+    /* Even though (or exactly because?) this API is deprecated, it's better to
+       warn than to spend several hours debugging what's wrong */
+    if(!hasField(SceneField::Parent))
+        Warning{} << "Trade::SceneData::children3D(): no parent field present, returned array will be empty";
+
     const Containers::Array<UnsignedInt> children = childrenFor(-1);
     return {children.begin(), children.end()};
 }

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -782,7 +782,7 @@ Containers::StridedArrayView1D<const void> SceneData::fieldDataObjectViewInterna
         /* We're *sure* the view is correct, so faking the view size */
         {static_cast<const char*>(field._isOffsetOnly ?
             _data.data() + field._objectData.offset : field._objectData.pointer)
-            + field._fieldStride*offset, ~std::size_t{}},
+            + field._objectStride*offset, ~std::size_t{}},
         size, field._objectStride};
 }
 

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -895,7 +895,7 @@ namespace {
 
 /* The `objects` view is already adjusted for `offset`, the offset is needed
    only to return the correct value for ImplicitMapping */
-template<class T> std::size_t findObject(const SceneFieldFlags flags, const Containers::StridedArrayView1D<const void>& mapping, const std::size_t offset, const UnsignedInt object) {
+template<class T> std::size_t findObject(const SceneFieldFlags flags, const Containers::StridedArrayView1D<const void>& mapping, const std::size_t offset, const UnsignedLong object) {
     const std::size_t max = mapping.size();
 
     /* Implicit mapping, position equals object ID (if in bounds) and thus an
@@ -926,7 +926,7 @@ template<class T> std::size_t findObject(const SceneFieldFlags flags, const Cont
 
 }
 
-std::size_t SceneData::findFieldObjectOffsetInternal(const SceneFieldData& field, const UnsignedInt object, const std::size_t offset) const {
+std::size_t SceneData::findFieldObjectOffsetInternal(const SceneFieldData& field, const UnsignedLong object, const std::size_t offset) const {
     const Containers::StridedArrayView1D<const void> mapping = fieldDataMappingViewInternal(field, offset, field._size - offset);
     if(field._mappingType == SceneMappingType::UnsignedInt)
         return offset + findObject<UnsignedInt>(field._flags, mapping, offset, object);
@@ -939,7 +939,7 @@ std::size_t SceneData::findFieldObjectOffsetInternal(const SceneFieldData& field
     else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
-Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const UnsignedInt fieldId, const UnsignedInt object, const std::size_t offset) const {
+Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const UnsignedInt fieldId, const UnsignedLong object, const std::size_t offset) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::findFieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
@@ -953,7 +953,7 @@ Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const Unsigne
     return found == field._size ? Containers::Optional<std::size_t>{} : found;
 }
 
-Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const SceneField fieldName, const UnsignedInt object, const std::size_t offset) const {
+Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const SceneField fieldName, const UnsignedLong object, const std::size_t offset) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::findFieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -969,7 +969,7 @@ Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const SceneFi
     return found == field._size ? Containers::Optional<std::size_t>{} : found;
 }
 
-std::size_t SceneData::fieldObjectOffset(const UnsignedInt fieldId, const UnsignedInt object, const std::size_t offset) const {
+std::size_t SceneData::fieldObjectOffset(const UnsignedInt fieldId, const UnsignedLong object, const std::size_t offset) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::fieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
@@ -985,7 +985,7 @@ std::size_t SceneData::fieldObjectOffset(const UnsignedInt fieldId, const Unsign
     return found;
 }
 
-std::size_t SceneData::fieldObjectOffset(const SceneField fieldName, const UnsignedInt object, const std::size_t offset) const {
+std::size_t SceneData::fieldObjectOffset(const SceneField fieldName, const UnsignedLong object, const std::size_t offset) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::fieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -1003,7 +1003,7 @@ std::size_t SceneData::fieldObjectOffset(const SceneField fieldName, const Unsig
     return found;
 }
 
-bool SceneData::hasFieldObject(const UnsignedInt fieldId, const UnsignedInt object) const {
+bool SceneData::hasFieldObject(const UnsignedInt fieldId, const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::hasFieldObject(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
@@ -1013,7 +1013,7 @@ bool SceneData::hasFieldObject(const UnsignedInt fieldId, const UnsignedInt obje
     return findFieldObjectOffsetInternal(field, object, 0) != field._size;
 }
 
-bool SceneData::hasFieldObject(const SceneField fieldName, const UnsignedInt object) const {
+bool SceneData::hasFieldObject(const SceneField fieldName, const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::hasFieldObject(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2122,7 +2122,7 @@ Containers::Array<Containers::Pair<UnsignedInt, const void*>> SceneData::importe
     return out;
 }
 
-Containers::Optional<Int> SceneData::parentFor(const UnsignedInt object) const {
+Containers::Optional<Long> SceneData::parentFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::parentFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2138,7 +2138,7 @@ Containers::Optional<Int> SceneData::parentFor(const UnsignedInt object) const {
     return *index;
 }
 
-Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
+Containers::Array<UnsignedLong> SceneData::childrenFor(const Long object) const {
     CORRADE_ASSERT(object >= -1 && object < Long(_mappingBound),
         "Trade::SceneData::childrenFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2148,11 +2148,15 @@ Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
     const SceneFieldData& parentField = _fields[parentFieldId];
 
     /* Collect IDs of all objects that reference this object */
-    Containers::Array<UnsignedInt> out;
+    Containers::Array<UnsignedLong> out;
     for(std::size_t offset = 0; offset != parentField.size(); ++offset) {
         Int parentIndex[1];
         parentsIntoInternal(parentFieldId, offset, parentIndex);
         if(*parentIndex == object) {
+            /** @todo this drops the upper 64 bits, might be a problem
+                eventually (at this point it's more important to have an API
+                that won't change the return types in the future, breaking
+                existing code) */
             UnsignedInt child[1];
             /** @todo bleh slow, use the children <-> parent field proxying
                 when implemented */
@@ -2164,7 +2168,7 @@ Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
     return out;
 }
 
-Containers::Optional<Matrix3> SceneData::transformation2DFor(const UnsignedInt object) const {
+Containers::Optional<Matrix3> SceneData::transformation2DFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::transformation2DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2185,7 +2189,7 @@ Containers::Optional<Matrix3> SceneData::transformation2DFor(const UnsignedInt o
     return *transformation;
 }
 
-Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> SceneData::translationRotationScaling2DFor(const UnsignedInt object) const {
+Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> SceneData::translationRotationScaling2DFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::translationRotationScaling2DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2208,7 +2212,7 @@ Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> SceneData::t
     return {InPlaceInit, *translation, *rotation, *scaling};
 }
 
-Containers::Optional<Matrix4> SceneData::transformation3DFor(const UnsignedInt object) const {
+Containers::Optional<Matrix4> SceneData::transformation3DFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::transformation3DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2229,7 +2233,7 @@ Containers::Optional<Matrix4> SceneData::transformation3DFor(const UnsignedInt o
     return *transformation;
 }
 
-Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> SceneData::translationRotationScaling3DFor(const UnsignedInt object) const {
+Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> SceneData::translationRotationScaling3DFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::translationRotationScaling3DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2252,7 +2256,7 @@ Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> SceneData
     return {InPlaceInit, *translation, *rotation, *scaling};
 }
 
-Containers::Array<Containers::Pair<UnsignedInt, Int>> SceneData::meshesMaterialsFor(const UnsignedInt object) const {
+Containers::Array<Containers::Pair<UnsignedInt, Int>> SceneData::meshesMaterialsFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::meshesMaterialsFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2276,7 +2280,7 @@ Containers::Array<Containers::Pair<UnsignedInt, Int>> SceneData::meshesMaterials
     return out;
 }
 
-Containers::Array<UnsignedInt> SceneData::lightsFor(const UnsignedInt object) const {
+Containers::Array<UnsignedInt> SceneData::lightsFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::lightsFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2299,7 +2303,7 @@ Containers::Array<UnsignedInt> SceneData::lightsFor(const UnsignedInt object) co
     return out;
 }
 
-Containers::Array<UnsignedInt> SceneData::camerasFor(const UnsignedInt object) const {
+Containers::Array<UnsignedInt> SceneData::camerasFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::camerasFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2322,7 +2326,7 @@ Containers::Array<UnsignedInt> SceneData::camerasFor(const UnsignedInt object) c
     return out;
 }
 
-Containers::Array<UnsignedInt> SceneData::skinsFor(const UnsignedInt object) const {
+Containers::Array<UnsignedInt> SceneData::skinsFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::skinsFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2345,7 +2349,7 @@ Containers::Array<UnsignedInt> SceneData::skinsFor(const UnsignedInt object) con
     return out;
 }
 
-Containers::Optional<const void*> SceneData::importerStateFor(const UnsignedInt object) const {
+Containers::Optional<const void*> SceneData::importerStateFor(const UnsignedLong object) const {
     CORRADE_ASSERT(object < _mappingBound,
         "Trade::SceneData::importerStateFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
@@ -2370,7 +2374,7 @@ std::vector<UnsignedInt> SceneData::children2D() const {
     if(!hasField(SceneField::Parent))
         Warning{} << "Trade::SceneData::children2D(): no parent field present, returned array will be empty";
 
-    const Containers::Array<UnsignedInt> children = childrenFor(-1);
+    const Containers::Array<UnsignedLong> children = childrenFor(-1);
     return {children.begin(), children.end()};
 }
 
@@ -2382,7 +2386,7 @@ std::vector<UnsignedInt> SceneData::children3D() const {
     if(!hasField(SceneField::Parent))
         Warning{} << "Trade::SceneData::children3D(): no parent field present, returned array will be empty";
 
-    const Containers::Array<UnsignedInt> children = childrenFor(-1);
+    const Containers::Array<UnsignedLong> children = childrenFor(-1);
     return {children.begin(), children.end()};
 }
 #endif

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -1588,7 +1588,27 @@ std::size_t SceneData::fieldFor(const SceneFieldData& field, const std::size_t o
     else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
-Containers::Array<UnsignedInt> SceneData::childrenFor(Int object) const {
+Containers::Optional<Int> SceneData::parentFor(const UnsignedInt object) const {
+    CORRADE_ASSERT(object < _objectCount,
+        "Trade::SceneData::parentFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+
+    const UnsignedInt fieldId = fieldFor(SceneField::Parent);
+    if(fieldId == ~UnsignedInt{}) return {};
+
+    const SceneFieldData& field = _fields[fieldId];
+    const std::size_t offset = fieldFor(field, 0, object);
+    if(offset == field._size) return {};
+
+    Int index[1];
+    parentsIntoInternal(fieldId, offset, index);
+    if(*index == -1) return -1;
+
+    UnsignedInt parent[1];
+    objectsIntoInternal(fieldId, *index, parent);
+    return Int(*parent);
+}
+
+Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
     CORRADE_ASSERT(object >= -1 && object < Long(_objectCount),
         "Trade::SceneData::childrenFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
 

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -47,12 +47,12 @@
 
 namespace Magnum { namespace Trade {
 
-Debug& operator<<(Debug& debug, const SceneObjectType value) {
-    debug << "Trade::SceneObjectType" << Debug::nospace;
+Debug& operator<<(Debug& debug, const SceneMappingType value) {
+    debug << "Trade::SceneMappingType" << Debug::nospace;
 
     switch(value) {
         /* LCOV_EXCL_START */
-        #define _c(value) case SceneObjectType::value: return debug << "::" #value;
+        #define _c(value) case SceneMappingType::value: return debug << "::" #value;
         _c(UnsignedByte)
         _c(UnsignedInt)
         _c(UnsignedShort)
@@ -64,40 +64,40 @@ Debug& operator<<(Debug& debug, const SceneObjectType value) {
     return debug << "(" << Debug::nospace << reinterpret_cast<void*>(UnsignedByte(value)) << Debug::nospace << ")";
 }
 
-UnsignedInt sceneObjectTypeSize(const SceneObjectType type) {
+UnsignedInt sceneMappingTypeSize(const SceneMappingType type) {
     #ifdef CORRADE_TARGET_GCC
     #pragma GCC diagnostic push
     #pragma GCC diagnostic error "-Wswitch"
     #endif
     switch(type) {
-        case SceneObjectType::UnsignedByte: return 1;
-        case SceneObjectType::UnsignedShort: return 2;
-        case SceneObjectType::UnsignedInt: return 4;
-        case SceneObjectType::UnsignedLong: return 8;
+        case SceneMappingType::UnsignedByte: return 1;
+        case SceneMappingType::UnsignedShort: return 2;
+        case SceneMappingType::UnsignedInt: return 4;
+        case SceneMappingType::UnsignedLong: return 8;
     }
     #ifdef CORRADE_TARGET_GCC
     #pragma GCC diagnostic pop
     #endif
 
-    CORRADE_ASSERT_UNREACHABLE("Trade::sceneObjectTypeSize(): invalid type" << type, {});
+    CORRADE_ASSERT_UNREACHABLE("Trade::sceneMappingTypeSize(): invalid type" << type, {});
 }
 
-UnsignedInt sceneObjectTypeAlignment(const SceneObjectType type) {
+UnsignedInt sceneMappingTypeAlignment(const SceneMappingType type) {
     #ifdef CORRADE_TARGET_GCC
     #pragma GCC diagnostic push
     #pragma GCC diagnostic error "-Wswitch"
     #endif
     switch(type) {
-        case SceneObjectType::UnsignedByte: return 1;
-        case SceneObjectType::UnsignedShort: return 2;
-        case SceneObjectType::UnsignedInt: return 4;
-        case SceneObjectType::UnsignedLong: return 8;
+        case SceneMappingType::UnsignedByte: return 1;
+        case SceneMappingType::UnsignedShort: return 2;
+        case SceneMappingType::UnsignedInt: return 4;
+        case SceneMappingType::UnsignedLong: return 8;
     }
     #ifdef CORRADE_TARGET_GCC
     #pragma GCC diagnostic pop
     #endif
 
-    CORRADE_ASSERT_UNREACHABLE("Trade::sceneObjectTypeAlignment(): invalid type" << type, {});
+    CORRADE_ASSERT_UNREACHABLE("Trade::sceneMappingTypeAlignment(): invalid type" << type, {});
 }
 
 Debug& operator<<(Debug& debug, const SceneField value) {
@@ -473,7 +473,7 @@ UnsignedInt sceneFieldTypeAlignment(const SceneFieldType type) {
     CORRADE_ASSERT_UNREACHABLE("Trade::sceneFieldTypeAlignment(): invalid type" << type, {});
 }
 
-SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView2D<const char>& objectData, const SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, const UnsignedShort fieldArraySize) noexcept: SceneFieldData{name, {}, Containers::StridedArrayView1D<const void>{{objectData.data(), ~std::size_t{}}, objectData.size()[0], objectData.stride()[0]}, fieldType, Containers::StridedArrayView1D<const void>{{fieldData.data(), ~std::size_t{}}, fieldData.size()[0], fieldData.stride()[0]}, fieldArraySize} {
+SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView2D<const char>& mappingData, const SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, const UnsignedShort fieldArraySize) noexcept: SceneFieldData{name, {}, Containers::StridedArrayView1D<const void>{{mappingData.data(), ~std::size_t{}}, mappingData.size()[0], mappingData.stride()[0]}, fieldType, Containers::StridedArrayView1D<const void>{{fieldData.data(), ~std::size_t{}}, fieldData.size()[0], fieldData.stride()[0]}, fieldArraySize} {
     /* Yes, this calls into a constexpr function defined in the header --
        because I feel that makes more sense than duplicating the full assert
        logic */
@@ -484,14 +484,14 @@ SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedA
         "Trade::SceneFieldData: second field view dimension size" << fieldData.size()[1] << "doesn't match" << fieldType, );
     #endif
 
-    if(objectData.size()[1] == 8) _objectType = SceneObjectType::UnsignedLong;
-    else if(objectData.size()[1] == 4) _objectType = SceneObjectType::UnsignedInt;
-    else if(objectData.size()[1] == 2) _objectType = SceneObjectType::UnsignedShort;
-    else if(objectData.size()[1] == 1) _objectType = SceneObjectType::UnsignedByte;
-    else CORRADE_ASSERT_UNREACHABLE("Trade::SceneFieldData: expected second object view dimension size 1, 2, 4 or 8 but got" << objectData.size()[1], );
+    if(mappingData.size()[1] == 8) _mappingType = SceneMappingType::UnsignedLong;
+    else if(mappingData.size()[1] == 4) _mappingType = SceneMappingType::UnsignedInt;
+    else if(mappingData.size()[1] == 2) _mappingType = SceneMappingType::UnsignedShort;
+    else if(mappingData.size()[1] == 1) _mappingType = SceneMappingType::UnsignedByte;
+    else CORRADE_ASSERT_UNREACHABLE("Trade::SceneFieldData: expected second mapping view dimension size 1, 2, 4 or 8 but got" << mappingData.size()[1], );
 
+    CORRADE_ASSERT(mappingData.isContiguous<1>(), "Trade::SceneFieldData: second mapping view dimension is not contiguous", );
     CORRADE_ASSERT(fieldData.isContiguous<1>(), "Trade::SceneFieldData: second field view dimension is not contiguous", );
-    CORRADE_ASSERT(objectData.isContiguous<1>(), "Trade::SceneFieldData: second object view dimension is not contiguous", );
 }
 
 Containers::Array<SceneFieldData> sceneFieldDataNonOwningArray(const Containers::ArrayView<const SceneFieldData> view) {
@@ -499,19 +499,19 @@ Containers::Array<SceneFieldData> sceneFieldDataNonOwningArray(const Containers:
     return Containers::Array<SceneFieldData>{const_cast<SceneFieldData*>(view.data()), view.size(), reinterpret_cast<void(*)(SceneFieldData*, std::size_t)>(Implementation::nonOwnedArrayDeleter)};
 }
 
-SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, Containers::Array<char>&& data, Containers::Array<SceneFieldData>&& fields, const void* const importerState) noexcept: _dataFlags{DataFlag::Owned|DataFlag::Mutable}, _objectType{objectType}, _dimensions{}, _objectCount{objectCount}, _importerState{importerState}, _fields{std::move(fields)}, _data{std::move(data)} {
-    /* Check that object type is large enough */
+SceneData::SceneData(const SceneMappingType mappingType, const UnsignedLong mappingBound, Containers::Array<char>&& data, Containers::Array<SceneFieldData>&& fields, const void* const importerState) noexcept: _dataFlags{DataFlag::Owned|DataFlag::Mutable}, _mappingType{mappingType}, _dimensions{}, _mappingBound{mappingBound}, _importerState{importerState}, _fields{std::move(fields)}, _data{std::move(data)} {
+    /* Check that mapping type is large enough */
     CORRADE_ASSERT(
-        (objectType == SceneObjectType::UnsignedByte && objectCount <= 0xffull) ||
-        (objectType == SceneObjectType::UnsignedShort && objectCount <= 0xffffull) ||
-        (objectType == SceneObjectType::UnsignedInt && objectCount <= 0xffffffffull) ||
-        objectType == SceneObjectType::UnsignedLong,
-        "Trade::SceneData:" << objectType << "is too small for" << objectCount << "objects", );
+        (mappingType == SceneMappingType::UnsignedByte && mappingBound <= 0xffull) ||
+        (mappingType == SceneMappingType::UnsignedShort && mappingBound <= 0xffffull) ||
+        (mappingType == SceneMappingType::UnsignedInt && mappingBound <= 0xffffffffull) ||
+        mappingType == SceneMappingType::UnsignedLong,
+        "Trade::SceneData:" << mappingType << "is too small for" << mappingBound << "objects", );
 
     #ifndef CORRADE_NO_ASSERT
     /* Check various assumptions about field data */
     Math::BoolVector<12> fieldsPresent; /** @todo some constant for this */
-    const UnsignedInt objectTypeSize = sceneObjectTypeSize(_objectType);
+    const UnsignedInt mappingTypeSize = sceneMappingTypeSize(_mappingType);
     #endif
     UnsignedInt transformationField = ~UnsignedInt{};
     UnsignedInt translationField = ~UnsignedInt{};
@@ -526,17 +526,17 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
         const SceneFieldData& field = _fields[i];
 
         #ifndef CORRADE_NO_ASSERT
-        /* The object type has to be the same among all fields. Technically it
+        /* The mapping type has to be the same among all fields. Technically it
            wouldn't need to be, but if there's 60k objects then using a 8bit
            type for certain fields would mean only the first 256 objects can be
            referenced, which makes no practical sense, and to improve the
            situation there would need to be some additional per-field object
-           offset and ... it's simpler to just require the object type to be
+           offset and ... it's simpler to just require the mapping type to be
            large enough to reference all objects (checked outside of the loop
            above) and that it's the same for all fields. This also makes it
            more convenient for the user. */
-        CORRADE_ASSERT(field._objectType == _objectType,
-            "Trade::SceneData: inconsistent object type, got" << field._objectType << "for field" << i << "but expected" << _objectType, );
+        CORRADE_ASSERT(field._mappingType == _mappingType,
+            "Trade::SceneData: inconsistent mapping type, got" << field._mappingType << "for field" << i << "but expected" << _mappingType, );
 
         /* We could check that object indices are in bounds, but that's rather
            expensive. OTOH it's fine if field size is larger than object count,
@@ -558,7 +558,7 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
                 "Trade::SceneData: duplicate field" << _fields[i]._name, );
         }
 
-        /* Check that both the object and field view fits into the provided
+        /* Check that both the mapping and field view fits into the provided
            data array. If the field is empty, we don't check anything --
            accessing the memory would be invalid anyway and enforcing this
            would lead to unnecessary friction with optional fields. */
@@ -566,19 +566,19 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
             const UnsignedInt fieldTypeSize = sceneFieldTypeSize(field._fieldType)*
                 (field._fieldArraySize ? field._fieldArraySize : 1);
             if(field._isOffsetOnly) {
-                const std::size_t objectSize = field._objectData.offset + (field._size - 1)*field._objectStride + objectTypeSize;
+                const std::size_t mappingSize = field._mappingData.offset + (field._size - 1)*field._mappingStride + mappingTypeSize;
                 const std::size_t fieldSize = field._fieldData.offset + (field._size - 1)*field._fieldStride + fieldTypeSize;
-                CORRADE_ASSERT(objectSize <= _data.size(),
-                    "Trade::SceneData: offset-only object data of field" << i << "span" << objectSize << "bytes but passed data array has only" << _data.size(), );
+                CORRADE_ASSERT(mappingSize <= _data.size(),
+                    "Trade::SceneData: offset-only mapping data of field" << i << "span" << mappingSize << "bytes but passed data array has only" << _data.size(), );
                 CORRADE_ASSERT(fieldSize <= _data.size(),
                     "Trade::SceneData: offset-only field data of field" << i << "span" << fieldSize << "bytes but passed data array has only" << _data.size(), );
             } else {
-                const void* const objectBegin = field._objectData.pointer;
+                const void* const mappingBegin = field._mappingData.pointer;
                 const void* const fieldBegin = field._fieldData.pointer;
-                const void* const objectEnd = static_cast<const char*>(field._objectData.pointer) + (field._size - 1)*field._objectStride + objectTypeSize;
+                const void* const mappingEnd = static_cast<const char*>(field._mappingData.pointer) + (field._size - 1)*field._mappingStride + mappingTypeSize;
                 const void* const fieldEnd = static_cast<const char*>(field._fieldData.pointer) + (field._size - 1)*field._fieldStride + fieldTypeSize;
-                CORRADE_ASSERT(objectBegin >= _data.begin() && objectEnd <= _data.end(),
-                    "Trade::SceneData: object data [" << Debug::nospace << objectBegin << Debug::nospace << ":" << Debug::nospace << objectEnd << Debug::nospace << "] of field" << i << "are not contained in passed data array [" << Debug::nospace << static_cast<const void*>(_data.begin()) << Debug::nospace << ":" << Debug::nospace << static_cast<const void*>(_data.end()) << Debug::nospace << "]", );
+                CORRADE_ASSERT(mappingBegin >= _data.begin() && mappingEnd <= _data.end(),
+                    "Trade::SceneData: mapping data [" << Debug::nospace << mappingBegin << Debug::nospace << ":" << Debug::nospace << mappingEnd << Debug::nospace << "] of field" << i << "are not contained in passed data array [" << Debug::nospace << static_cast<const void*>(_data.begin()) << Debug::nospace << ":" << Debug::nospace << static_cast<const void*>(_data.end()) << Debug::nospace << "]", );
                 CORRADE_ASSERT(fieldBegin >= _data.begin() && fieldEnd <= _data.end(),
                     "Trade::SceneData: field data [" << Debug::nospace << fieldBegin << Debug::nospace << ":" << Debug::nospace << fieldEnd << Debug::nospace << "] of field" << i << "are not contained in passed data array [" << Debug::nospace << static_cast<const void*>(_data.begin()) << Debug::nospace << ":" << Debug::nospace << static_cast<const void*>(_data.end()) << Debug::nospace << "]", );
             }
@@ -614,29 +614,29 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
        effort just for an assert message. Also, compared to above, where
        "begin" was always zero, here we're always comparing four values, so the
        message for offset-only wouldn't be simpler either. */
-    const auto checkFieldObjectDataMatch = [](const SceneFieldData& a, const SceneFieldData& b) {
-        const std::size_t objectTypeSize = sceneObjectTypeSize(a._objectType);
-        const void* const aBegin = a._objectData.pointer;
-        const void* const bBegin = b._objectData.pointer;
-        const void* const aEnd = static_cast<const char*>(a._objectData.pointer) + a._size*objectTypeSize;
-        const void* const bEnd = static_cast<const char*>(b._objectData.pointer) + b._size*objectTypeSize;
+    const auto checkFieldMappingDataMatch = [](const SceneFieldData& a, const SceneFieldData& b) {
+        const std::size_t mappingTypeSize = sceneMappingTypeSize(a._mappingType);
+        const void* const aBegin = a._mappingData.pointer;
+        const void* const bBegin = b._mappingData.pointer;
+        const void* const aEnd = static_cast<const char*>(a._mappingData.pointer) + a._size*mappingTypeSize;
+        const void* const bEnd = static_cast<const char*>(b._mappingData.pointer) + b._size*mappingTypeSize;
         CORRADE_ASSERT(aBegin == bBegin && aEnd == bEnd,
-            "Trade::SceneData:" << b._name << "object data [" << Debug::nospace << bBegin << Debug::nospace << ":" << Debug::nospace << bEnd << Debug::nospace << "] is different from" << a._name << "object data [" << Debug::nospace << aBegin << Debug::nospace << ":" << Debug::nospace << aEnd << Debug::nospace << "]", );
+            "Trade::SceneData:" << b._name << "mapping data [" << Debug::nospace << bBegin << Debug::nospace << ":" << Debug::nospace << bEnd << Debug::nospace << "] is different from" << a._name << "mapping data [" << Debug::nospace << aBegin << Debug::nospace << ":" << Debug::nospace << aEnd << Debug::nospace << "]", );
     };
 
     /* All present TRS fields should share the same object mapping */
     if(translationField != ~UnsignedInt{}) {
         if(rotationField != ~UnsignedInt{})
-            checkFieldObjectDataMatch(_fields[translationField], _fields[rotationField]);
+            checkFieldMappingDataMatch(_fields[translationField], _fields[rotationField]);
         if(scalingField != ~UnsignedInt{})
-            checkFieldObjectDataMatch(_fields[translationField], _fields[scalingField]);
+            checkFieldMappingDataMatch(_fields[translationField], _fields[scalingField]);
     }
     if(rotationField != ~UnsignedInt{} && scalingField != ~UnsignedInt{})
-        checkFieldObjectDataMatch(_fields[rotationField], _fields[scalingField]);
+        checkFieldMappingDataMatch(_fields[rotationField], _fields[scalingField]);
 
     /* Mesh and materials also */
     if(meshField != ~UnsignedInt{} && meshMaterialField != ~UnsignedInt{})
-        checkFieldObjectDataMatch(_fields[meshField], _fields[meshMaterialField]);
+        checkFieldMappingDataMatch(_fields[meshField], _fields[meshMaterialField]);
     #endif
 
     /* Decide about dimensionality based on transformation type, if present */
@@ -710,18 +710,18 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
         "Trade::SceneData: a skin field requires some transformation field to be present in order to disambiguate between 2D and 3D", );
 }
 
-SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, Containers::Array<char>&& data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{objectType, objectCount, std::move(data), Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}
+SceneData::SceneData(const SceneMappingType mappingType, const UnsignedLong mappingBound, Containers::Array<char>&& data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{mappingType, mappingBound, std::move(data), Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}
 
-SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, const DataFlags dataFlags, const Containers::ArrayView<const void> data, Containers::Array<SceneFieldData>&& fields, const void* const importerState) noexcept: SceneData{objectType, objectCount, Containers::Array<char>{const_cast<char*>(static_cast<const char*>(data.data())), data.size(), Implementation::nonOwnedArrayDeleter}, std::move(fields), importerState} {
+SceneData::SceneData(const SceneMappingType mappingType, const UnsignedLong mappingBound, const DataFlags dataFlags, const Containers::ArrayView<const void> data, Containers::Array<SceneFieldData>&& fields, const void* const importerState) noexcept: SceneData{mappingType, mappingBound, Containers::Array<char>{const_cast<char*>(static_cast<const char*>(data.data())), data.size(), Implementation::nonOwnedArrayDeleter}, std::move(fields), importerState} {
     CORRADE_ASSERT(!(dataFlags & DataFlag::Owned),
         "Trade::SceneData: can't construct with non-owned data but" << dataFlags, );
     _dataFlags = dataFlags;
 }
 
-SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, const DataFlags dataFlags, const Containers::ArrayView<const void> data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{objectType, objectCount, dataFlags, data, Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}
+SceneData::SceneData(const SceneMappingType mappingType, const UnsignedLong mappingBound, const DataFlags dataFlags, const Containers::ArrayView<const void> data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{mappingType, mappingBound, dataFlags, data, Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}
 
 #ifdef MAGNUM_BUILD_DEPRECATED
-SceneData::SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* const importerState): _dataFlags{DataFlag::Owned|DataFlag::Mutable}, _objectType{SceneObjectType::UnsignedInt}, _importerState{importerState} {
+SceneData::SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* const importerState): _dataFlags{DataFlag::Owned|DataFlag::Mutable}, _mappingType {SceneMappingType::UnsignedInt}, _importerState{importerState} {
     /* Assume nobody ever created a scene with both 2D and 3D children.
        (PrimitiveImporter did, but that's an exception and blame goes on me.)
        If this blows up for you, please complain. Or rather upgrade to the new
@@ -738,27 +738,27 @@ SceneData::SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedIn
         children = children3D;
     } else _dimensions = 0;
 
-    /* Set object count to the max found child index. It's not great as it
+    /* Set mapping bound to the max found child index. It's not great as it
        doesn't take any nested object into account but SceneData created this
        way is expected to be used only through the deprecated APIs anyway,
        which don't care about this value. */
-    _objectCount = children.empty() ? 0 : Math::max(children) + 1;
+    _mappingBound = children.empty() ? 0 : Math::max(children) + 1;
 
     /* Convert the vector with top-level object IDs to the parent field, where
        all have -1 as a parent. This way the (also deprecated) children2D() /
        children3D() will return the desired values. */
-    Containers::ArrayView<UnsignedInt> objects;
+    Containers::ArrayView<UnsignedInt> mapping;
     Containers::ArrayView<Int> parents;
     _data = Containers::ArrayTuple{
-        {NoInit, children.size(), objects},
+        {NoInit, children.size(), mapping},
         {NoInit, children.size(), parents},
     };
     /* Can't use InPlaceInit as that creates an Array with a non-default
        deleter, which then trips up on an assertion when such an instance gets
        returned from AbstractImporter */
     _fields = Containers::Array<SceneFieldData>{1};
-    _fields[0] = SceneFieldData{SceneField::Parent, objects, parents};
-    Utility::copy(children, objects);
+    _fields[0] = SceneFieldData{SceneField::Parent, mapping, parents};
+    Utility::copy(children, mapping);
     constexpr Int parent[]{-1};
     Utility::copy(Containers::stridedArrayView(parent).broadcasted<0>(parents.size()), parents);
 }
@@ -776,18 +776,19 @@ Containers::ArrayView<char> SceneData::mutableData() & {
     return _data;
 }
 
-Containers::StridedArrayView1D<const void> SceneData::fieldDataObjectViewInternal(const SceneFieldData& field, const std::size_t offset, const std::size_t size) const {
+Containers::StridedArrayView1D<const void> SceneData::fieldDataMappingViewInternal(const SceneFieldData& field, const std::size_t offset, const std::size_t size) const {
     CORRADE_INTERNAL_ASSERT(offset + size <= field._size);
     return Containers::StridedArrayView1D<const void>{
         /* We're *sure* the view is correct, so faking the view size */
         {static_cast<const char*>(field._isOffsetOnly ?
-            _data.data() + field._objectData.offset : field._objectData.pointer)
-            + field._objectStride*offset, ~std::size_t{}},
-        size, field._objectStride};
+            _data.data() + field._mappingData.offset : field._mappingData.pointer)
+            + field._mappingStride*offset, ~std::size_t{}},
+        size, field._mappingStride
+    };
 }
 
-Containers::StridedArrayView1D<const void> SceneData::fieldDataObjectViewInternal(const SceneFieldData& field) const {
-    return fieldDataObjectViewInternal(field, 0, field._size);
+Containers::StridedArrayView1D<const void> SceneData::fieldDataMappingViewInternal(const SceneFieldData& field) const {
+    return fieldDataMappingViewInternal(field, 0, field._size);
 }
 
 Containers::StridedArrayView1D<const void> SceneData::fieldDataFieldViewInternal(const SceneFieldData& field, const std::size_t offset, const std::size_t size) const {
@@ -808,7 +809,7 @@ SceneFieldData SceneData::fieldData(const UnsignedInt id) const {
     CORRADE_ASSERT(id < _fields.size(),
         "Trade::SceneData::fieldData(): index" << id << "out of range for" << _fields.size() << "fields", SceneFieldData{});
     const SceneFieldData& field = _fields[id];
-    return SceneFieldData{field._name, field._objectType, fieldDataObjectViewInternal(field), field._fieldType, fieldDataFieldViewInternal(field), field._fieldArraySize};
+    return SceneFieldData{field._name, field._mappingType, fieldDataMappingViewInternal(field), field._fieldType, fieldDataFieldViewInternal(field), field._fieldArraySize};
 }
 
 SceneField SceneData::fieldName(const UnsignedInt id) const {
@@ -858,34 +859,34 @@ bool SceneData::hasField(const SceneField name) const {
 
 namespace {
 
-template<class T> std::size_t findObject(const Containers::StridedArrayView1D<const void>& objects, const UnsignedInt object) {
-    const Containers::StridedArrayView1D<const T> objectsT = Containers::arrayCast<const T>(objects);
-    const std::size_t max = objectsT.size();
+template<class T> std::size_t findObject(const Containers::StridedArrayView1D<const void>& mapping, const UnsignedInt object) {
+    const Containers::StridedArrayView1D<const T> mappingT = Containers::arrayCast<const T>(mapping);
+    const std::size_t max = mappingT.size();
     /** @todo implement something faster than O(n) when field-specific flags
         can annotate how the object mapping is done */
     for(std::size_t i = 0; i != max; ++i)
-        if(objectsT[i] == object) return i;
+        if(mappingT[i] == object) return i;
     return max;
 }
 
 }
 
 std::size_t SceneData::findFieldObjectOffsetInternal(const SceneFieldData& field, const UnsignedInt object, const std::size_t offset) const {
-    const Containers::StridedArrayView1D<const void> objects = fieldDataObjectViewInternal(field, offset, field._size - offset);
-    if(field._objectType == SceneObjectType::UnsignedInt)
-        return offset + findObject<UnsignedInt>(objects, object);
-    else if(field._objectType == SceneObjectType::UnsignedShort)
-        return offset + findObject<UnsignedShort>(objects, object);
-    else if(field._objectType == SceneObjectType::UnsignedByte)
-        return offset + findObject<UnsignedByte>(objects, object);
-    else if(field._objectType == SceneObjectType::UnsignedLong)
-        return offset + findObject<UnsignedLong>(objects, object);
+    const Containers::StridedArrayView1D<const void> mapping = fieldDataMappingViewInternal(field, offset, field._size - offset);
+    if(field._mappingType == SceneMappingType::UnsignedInt)
+        return offset + findObject<UnsignedInt>(mapping, object);
+    else if(field._mappingType == SceneMappingType::UnsignedShort)
+        return offset + findObject<UnsignedShort>(mapping, object);
+    else if(field._mappingType == SceneMappingType::UnsignedByte)
+        return offset + findObject<UnsignedByte>(mapping, object);
+    else if(field._mappingType == SceneMappingType::UnsignedLong)
+        return offset + findObject<UnsignedLong>(mapping, object);
     else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
 Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const UnsignedInt fieldId, const UnsignedInt object, const std::size_t offset) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::findFieldObjectOffset(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::findFieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
         "Trade::SceneData::findFieldObjectOffset(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
 
@@ -898,8 +899,8 @@ Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const Unsigne
 }
 
 Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const SceneField fieldName, const UnsignedInt object, const std::size_t offset) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::findFieldObjectOffset(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::findFieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(fieldName);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
@@ -914,8 +915,8 @@ Containers::Optional<std::size_t> SceneData::findFieldObjectOffset(const SceneFi
 }
 
 std::size_t SceneData::fieldObjectOffset(const UnsignedInt fieldId, const UnsignedInt object, const std::size_t offset) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::fieldObjectOffset(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::fieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
         "Trade::SceneData::fieldObjectOffset(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
 
@@ -930,8 +931,8 @@ std::size_t SceneData::fieldObjectOffset(const UnsignedInt fieldId, const Unsign
 }
 
 std::size_t SceneData::fieldObjectOffset(const SceneField fieldName, const UnsignedInt object, const std::size_t offset) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::fieldObjectOffset(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::fieldObjectOffset(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(fieldName);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
@@ -948,8 +949,8 @@ std::size_t SceneData::fieldObjectOffset(const SceneField fieldName, const Unsig
 }
 
 bool SceneData::hasFieldObject(const UnsignedInt fieldId, const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::hasFieldObject(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::hasFieldObject(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
         "Trade::SceneData::hasFieldObject(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
 
@@ -958,8 +959,8 @@ bool SceneData::hasFieldObject(const UnsignedInt fieldId, const UnsignedInt obje
 }
 
 bool SceneData::hasFieldObject(const SceneField fieldName, const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::hasFieldObject(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::hasFieldObject(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(fieldName);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
@@ -987,26 +988,26 @@ UnsignedShort SceneData::fieldArraySize(const SceneField name) const {
     return _fields[fieldId]._fieldArraySize;
 }
 
-Containers::StridedArrayView2D<const char> SceneData::objects(const UnsignedInt fieldId) const {
+Containers::StridedArrayView2D<const char> SceneData::mapping(const UnsignedInt fieldId) const {
     CORRADE_ASSERT(fieldId < _fields.size(),
-        "Trade::SceneData::objects(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+        "Trade::SceneData::mapping(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
     const SceneFieldData& field = _fields[fieldId];
-    /* Build a 2D view using information about object type size */
+    /* Build a 2D view using information about mapping type size */
     return Containers::arrayCast<2, const char>(
-        fieldDataObjectViewInternal(field),
-        sceneObjectTypeSize(field._objectType));
+        fieldDataMappingViewInternal(field),
+        sceneMappingTypeSize(field._mappingType));
 }
 
-Containers::StridedArrayView2D<char> SceneData::mutableObjects(const UnsignedInt fieldId) {
+Containers::StridedArrayView2D<char> SceneData::mutableMapping(const UnsignedInt fieldId) {
     CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
-        "Trade::SceneData::mutableObjects(): data not mutable", {});
+        "Trade::SceneData::mutableMapping(): data not mutable", {});
     CORRADE_ASSERT(fieldId < _fields.size(),
-        "Trade::SceneData::mutableObjects(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+        "Trade::SceneData::mutableMapping(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
     const SceneFieldData& field = _fields[fieldId];
     /* Build a 2D view using information about attribute type size */
     const auto out = Containers::arrayCast<2, const char>(
-        fieldDataObjectViewInternal(field),
-        sceneObjectTypeSize(field._objectType));
+        fieldDataMappingViewInternal(field),
+        sceneMappingTypeSize(field._mappingType));
     /** @todo some arrayConstCast? UGH */
     return Containers::StridedArrayView2D<char>{
         /* The view size is there only for a size assert, we're pretty sure the
@@ -1015,25 +1016,25 @@ Containers::StridedArrayView2D<char> SceneData::mutableObjects(const UnsignedInt
         out.size(), out.stride()};
 }
 
-Containers::StridedArrayView2D<const char> SceneData::objects(const SceneField fieldName) const {
+Containers::StridedArrayView2D<const char> SceneData::mapping(const SceneField fieldName) const {
     const UnsignedInt fieldId = findFieldIdInternal(fieldName);
-    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::objects(): field" << fieldName << "not found", {});
-    return objects(fieldId);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::mapping(): field" << fieldName << "not found", {});
+    return mapping(fieldId);
 }
 
-Containers::StridedArrayView2D<char> SceneData::mutableObjects(const SceneField fieldName) {
+Containers::StridedArrayView2D<char> SceneData::mutableMapping(const SceneField fieldName) {
     CORRADE_ASSERT(_dataFlags & DataFlag::Mutable,
-        "Trade::SceneData::mutableObjects(): data not mutable", {});
+        "Trade::SceneData::mutableMapping(): data not mutable", {});
     const UnsignedInt fieldId = findFieldIdInternal(fieldName);
-    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::mutableObjects(): field" << fieldName << "not found", {});
-    return mutableObjects(fieldId);
+    CORRADE_ASSERT(fieldId != ~UnsignedInt{}, "Trade::SceneData::mutableMapping(): field" << fieldName << "not found", {});
+    return mutableMapping(fieldId);
 }
 
 Containers::StridedArrayView2D<const char> SceneData::field(const UnsignedInt id) const {
     CORRADE_ASSERT(id < _fields.size(),
         "Trade::SceneData::field(): index" << id << "out of range for" << _fields.size() << "fields", {});
     const SceneFieldData& field = _fields[id];
-    /* Build a 2D view using information about object type size */
+    /* Build a 2D view using information about mapping type size */
     return Containers::arrayCast<2, const char>(
         fieldDataFieldViewInternal(field),
         sceneFieldTypeSize(field._fieldType)*(field._fieldArraySize ? field._fieldArraySize : 1));
@@ -1073,74 +1074,74 @@ Containers::StridedArrayView2D<char> SceneData::mutableField(const SceneField na
     return mutableField(fieldId);
 }
 
-void SceneData::objectsIntoInternal(const UnsignedInt fieldId, const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+void SceneData::mappingIntoInternal(const UnsignedInt fieldId, const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
     /* fieldId, offset and destination.size() is assumed to be in bounds,
        checked by the callers */
 
     const SceneFieldData& field = _fields[fieldId];
-    const Containers::StridedArrayView1D<const void> objectData = fieldDataObjectViewInternal(field, offset, destination.size());
+    const Containers::StridedArrayView1D<const void> mappingData = fieldDataMappingViewInternal(field, offset, destination.size());
     const auto destination1ui = Containers::arrayCast<2, UnsignedInt>(destination);
 
-    if(field._objectType == SceneObjectType::UnsignedInt)
-        Utility::copy(Containers::arrayCast<const UnsignedInt>(objectData), destination);
-    else if(field._objectType == SceneObjectType::UnsignedShort)
-        Math::castInto(Containers::arrayCast<2, const UnsignedShort>(objectData, 1), destination1ui);
-    else if(field._objectType == SceneObjectType::UnsignedByte)
-        Math::castInto(Containers::arrayCast<2, const UnsignedByte>(objectData, 1), destination1ui);
-    else if(field._objectType == SceneObjectType::UnsignedLong) {
-        Math::castInto(Containers::arrayCast<2, const UnsignedLong>(objectData, 1), destination1ui);
+    if(field._mappingType == SceneMappingType::UnsignedInt)
+        Utility::copy(Containers::arrayCast<const UnsignedInt>(mappingData), destination);
+    else if(field._mappingType == SceneMappingType::UnsignedShort)
+        Math::castInto(Containers::arrayCast<2, const UnsignedShort>(mappingData, 1), destination1ui);
+    else if(field._mappingType == SceneMappingType::UnsignedByte)
+        Math::castInto(Containers::arrayCast<2, const UnsignedByte>(mappingData, 1), destination1ui);
+    else if(field._mappingType == SceneMappingType::UnsignedLong) {
+        Math::castInto(Containers::arrayCast<2, const UnsignedLong>(mappingData, 1), destination1ui);
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
-void SceneData::objectsInto(const UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+void SceneData::mappingInto(const UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
     CORRADE_ASSERT(fieldId < _fields.size(),
-        "Trade::SceneData::objectsInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", );
+        "Trade::SceneData::mappingInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", );
     CORRADE_ASSERT(destination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::objectsInto(): expected a view with" << _fields[fieldId]._size << "elements but got" << destination.size(), );
-    objectsIntoInternal(fieldId, 0, destination);
+        "Trade::SceneData::mappingInto(): expected a view with" << _fields[fieldId]._size << "elements but got" << destination.size(), );
+    mappingIntoInternal(fieldId, 0, destination);
 }
 
-std::size_t SceneData::objectsInto(const UnsignedInt fieldId, const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+std::size_t SceneData::mappingInto(const UnsignedInt fieldId, const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
     CORRADE_ASSERT(fieldId < _fields.size(),
-        "Trade::SceneData::objectsInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+        "Trade::SceneData::mappingInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
     CORRADE_ASSERT(offset <= _fields[fieldId]._size,
-        "Trade::SceneData::objectsInto(): offset" << offset << "out of bounds for a field of size" << _fields[fieldId]._size, {});
+        "Trade::SceneData::mappingInto(): offset" << offset << "out of bounds for a field of size" << _fields[fieldId]._size, {});
     const std::size_t size = Math::min(destination.size(), std::size_t(_fields[fieldId]._size) - offset);
-    objectsIntoInternal(fieldId, offset, destination.prefix(size));
+    mappingIntoInternal(fieldId, offset, destination.prefix(size));
     return size;
 }
 
-Containers::Array<UnsignedInt> SceneData::objectsAsArray(const UnsignedInt fieldId) const {
+Containers::Array<UnsignedInt> SceneData::mappingAsArray(const UnsignedInt fieldId) const {
     CORRADE_ASSERT(fieldId < _fields.size(),
         /* Using the same message as in Into() to avoid too many redundant
            strings in the binary */
-        "Trade::SceneData::objectsInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
+        "Trade::SceneData::mappingInto(): index" << fieldId << "out of range for" << _fields.size() << "fields", {});
     Containers::Array<UnsignedInt> out{NoInit, std::size_t(_fields[fieldId]._size)};
-    objectsIntoInternal(fieldId, 0, out);
+    mappingIntoInternal(fieldId, 0, out);
     return out;
 }
 
-void SceneData::objectsInto(const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+void SceneData::mappingInto(const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
     const UnsignedInt fieldId = findFieldIdInternal(name);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
-        "Trade::SceneData::objectsInto(): field" << name << "not found", );
-    objectsInto(fieldId, destination);
+        "Trade::SceneData::mappingInto(): field" << name << "not found", );
+    mappingInto(fieldId, destination);
 }
 
-std::size_t SceneData::objectsInto(const SceneField name, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
+std::size_t SceneData::mappingInto(const SceneField name, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const {
     const UnsignedInt fieldId = findFieldIdInternal(name);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
-        "Trade::SceneData::objectsInto(): field" << name << "not found", {});
-    return objectsInto(fieldId, offset, destination);
+        "Trade::SceneData::mappingInto(): field" << name << "not found", {});
+    return mappingInto(fieldId, offset, destination);
 }
 
-Containers::Array<UnsignedInt> SceneData::objectsAsArray(const SceneField name) const {
+Containers::Array<UnsignedInt> SceneData::mappingAsArray(const SceneField name) const {
     const UnsignedInt fieldId = findFieldIdInternal(name);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         /* Using the same message as in Into() to avoid too many redundant
            strings in the binary */
-        "Trade::SceneData::objectsInto(): field" << name << "not found", {});
-    return objectsAsArray(fieldId);
+        "Trade::SceneData::mappingInto(): field" << name << "not found", {});
+    return mappingAsArray(fieldId);
 }
 
 void SceneData::parentsIntoInternal(const UnsignedInt fieldId, const std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const {
@@ -1162,29 +1163,29 @@ void SceneData::parentsIntoInternal(const UnsignedInt fieldId, const std::size_t
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
-void SceneData::parentsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const {
+void SceneData::parentsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Parent);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::parentsInto(): field not found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::parentsInto(): expected object destination view either empty or with" << _fields[fieldId]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldId]._size,
+        "Trade::SceneData::parentsInto(): expected mapping destination view either empty or with" << _fields[fieldId]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::parentsInto(): expected field destination view either empty or with" << _fields[fieldId]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldId, 0, objectDestination);
+    mappingIntoInternal(fieldId, 0, mappingDestination);
     parentsIntoInternal(fieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::parentsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const {
+std::size_t SceneData::parentsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Parent);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::parentsInto(): field not found", {});
     const std::size_t fieldSize = _fields[fieldId]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::parentsInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::parentsInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldId, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::parentsInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldId, offset, mappingDestination.prefix(size));
     if(fieldDestination) parentsIntoInternal(fieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -1197,7 +1198,7 @@ Containers::Array<Containers::Pair<UnsignedInt, Int>> SceneData::parentsAsArray(
         "Trade::SceneData::parentsInto(): field not found", {});
     Containers::Array<Containers::Pair<UnsignedInt, Int>> out{NoInit, std::size_t(_fields[fieldId]._size)};
     /** @todo use slicing once Pair exposes members somehow */
-    objectsIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     parentsIntoInternal(fieldId, 0, {out, reinterpret_cast<Int*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)});
     return out;
 }
@@ -1368,20 +1369,20 @@ void SceneData::transformations2DIntoInternal(const UnsignedInt transformationFi
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
-void SceneData::transformations2DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const {
+void SceneData::transformations2DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const {
     UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
         "Trade::SceneData::transformations2DInto(): no transformation-related field found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldWithObjectMapping]._size,
-        "Trade::SceneData::transformations2DInto(): expected object destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldWithObjectMapping]._size,
+        "Trade::SceneData::transformations2DInto(): expected mapping destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::transformations2DInto(): expected field destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldWithObjectMapping, 0, objectDestination);
+    mappingIntoInternal(fieldWithObjectMapping, 0, mappingDestination);
     transformations2DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::transformations2DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const {
+std::size_t SceneData::transformations2DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const {
     UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
@@ -1389,10 +1390,10 @@ std::size_t SceneData::transformations2DInto(const std::size_t offset, const Con
     const std::size_t fieldSize = _fields[fieldWithObjectMapping]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::transformations2DInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::transformations2DInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldWithObjectMapping, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::transformations2DInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldWithObjectMapping, offset, mappingDestination.prefix(size));
     if(fieldDestination) transformations2DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -1406,7 +1407,7 @@ Containers::Array<Containers::Pair<UnsignedInt, Matrix3>> SceneData::transformat
         "Trade::SceneData::transformations2DInto(): no transformation-related field found", {});
     Containers::Array<Containers::Pair<UnsignedInt, Matrix3>> out{NoInit, std::size_t(_fields[fieldWithObjectMapping]._size)};
     /** @todo use slicing once Pair exposes members somehow */
-    objectsIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     transformations2DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, 0, {out, reinterpret_cast<Matrix3*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)});
     return out;
 }
@@ -1474,24 +1475,24 @@ void SceneData::translationsRotationsScalings2DIntoInternal(const UnsignedInt tr
     }
 }
 
-void SceneData::translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const {
+void SceneData::translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const {
     UnsignedInt translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTranslationRotationScalingFields(translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
         "Trade::SceneData::translationsRotationsScalings2DInto(): no transformation-related field found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldWithObjectMapping]._size,
-        "Trade::SceneData::translationsRotationsScalings2DInto(): expected object destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldWithObjectMapping]._size,
+        "Trade::SceneData::translationsRotationsScalings2DInto(): expected mapping destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!translationDestination || translationDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected translation destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << translationDestination.size(), );
     CORRADE_ASSERT(!rotationDestination || rotationDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected rotation destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << rotationDestination.size(), );
     CORRADE_ASSERT(!scalingDestination || scalingDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected scaling destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << scalingDestination.size(), );
-    objectsIntoInternal(fieldWithObjectMapping, 0, objectDestination);
+    mappingIntoInternal(fieldWithObjectMapping, 0, mappingDestination);
     translationsRotationsScalings2DIntoInternal(translationFieldId, rotationFieldId, scalingFieldId, 0, translationDestination, rotationDestination, scalingDestination);
 }
 
-std::size_t SceneData::translationsRotationsScalings2DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const {
+std::size_t SceneData::translationsRotationsScalings2DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const {
     UnsignedInt translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTranslationRotationScalingFields(translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
@@ -1499,20 +1500,20 @@ std::size_t SceneData::translationsRotationsScalings2DInto(const std::size_t off
     const std::size_t fieldSize = _fields[fieldWithObjectMapping]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::translationsRotationsScalings2DInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !translationDestination || objectDestination.size() == translationDestination.size(),
-        "Trade::SceneData::translationsRotationsScalings2DInto(): object and translation destination views have different size," << objectDestination.size() << "vs" << translationDestination.size(), {});
-    CORRADE_ASSERT(!objectDestination != !rotationDestination || objectDestination.size() == rotationDestination.size(),
-        "Trade::SceneData::translationsRotationsScalings2DInto(): object and rotation destination views have different size," << objectDestination.size() << "vs" << rotationDestination.size(), {});
-    CORRADE_ASSERT(!objectDestination != !scalingDestination || objectDestination.size() == scalingDestination.size(),
-        "Trade::SceneData::translationsRotationsScalings2DInto(): object and scaling destination views have different size," << objectDestination.size() << "vs" << scalingDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !translationDestination || mappingDestination.size() == translationDestination.size(),
+        "Trade::SceneData::translationsRotationsScalings2DInto(): mapping and translation destination views have different size," << mappingDestination.size() << "vs" << translationDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !rotationDestination || mappingDestination.size() == rotationDestination.size(),
+        "Trade::SceneData::translationsRotationsScalings2DInto(): mapping and rotation destination views have different size," << mappingDestination.size() << "vs" << rotationDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !scalingDestination || mappingDestination.size() == scalingDestination.size(),
+        "Trade::SceneData::translationsRotationsScalings2DInto(): mapping and scaling destination views have different size," << mappingDestination.size() << "vs" << scalingDestination.size(), {});
     CORRADE_ASSERT(!translationDestination != !rotationDestination || translationDestination.size() == rotationDestination.size(),
         "Trade::SceneData::translationsRotationsScalings2DInto(): translation and rotation destination views have different size," << translationDestination.size() << "vs" << rotationDestination.size(), {});
     CORRADE_ASSERT(!translationDestination != !scalingDestination || translationDestination.size() == scalingDestination.size(),
         "Trade::SceneData::translationsRotationsScalings2DInto(): translation and scaling destination views have different size," << translationDestination.size() << "vs" << scalingDestination.size(), {});
     CORRADE_ASSERT(!rotationDestination != !scalingDestination || rotationDestination.size() == scalingDestination.size(),
         "Trade::SceneData::translationsRotationsScalings2DInto(): rotation and scaling destination views have different size," << rotationDestination.size() << "vs" << scalingDestination.size(), {});
-    const std::size_t size = Math::min(Math::max({objectDestination.size(), translationDestination.size(), rotationDestination.size(), scalingDestination.size()}), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldWithObjectMapping, offset, objectDestination.prefix(size));
+    const std::size_t size = Math::min(Math::max({mappingDestination.size(), translationDestination.size(), rotationDestination.size(), scalingDestination.size()}), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldWithObjectMapping, offset, mappingDestination.prefix(size));
     translationsRotationsScalings2DIntoInternal(translationFieldId, rotationFieldId, scalingFieldId, offset,
         translationDestination ? translationDestination.prefix(size) : nullptr,
         rotationDestination ? rotationDestination.prefix(size) : nullptr,
@@ -1529,7 +1530,7 @@ Containers::Array<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Comp
         "Trade::SceneData::translationsRotationsScalings2DInto(): no transformation-related field found", {});
     Containers::Array<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>> out{NoInit, std::size_t(_fields[fieldWithObjectMapping]._size)};
     /** @todo use slicing once Triple exposes members somehow */
-    objectsIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     const Containers::StridedArrayView1D<Vector2> translationsOut{out, reinterpret_cast<Vector2*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)};
     const Containers::StridedArrayView1D<Complex> rotationsOut{out, reinterpret_cast<Complex*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt) + sizeof(Vector2)), out.size(), sizeof(decltype(out)::Type)};
     const Containers::StridedArrayView1D<Vector2> scalingsOut{out, reinterpret_cast<Vector2*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt) + sizeof(Vector2) + sizeof(Complex)), out.size(), sizeof(decltype(out)::Type)};
@@ -1613,20 +1614,20 @@ void SceneData::transformations3DIntoInternal(const UnsignedInt transformationFi
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
-void SceneData::transformations3DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix4>& fieldDestination) const {
+void SceneData::transformations3DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix4>& fieldDestination) const {
     UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
     const std::size_t fieldWithObjectMapping = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
         "Trade::SceneData::transformations3DInto(): no transformation-related field found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldWithObjectMapping]._size,
-        "Trade::SceneData::transformations3DInto(): expected object destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldWithObjectMapping]._size,
+        "Trade::SceneData::transformations3DInto(): expected mapping destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::transformations3DInto(): expected field destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldWithObjectMapping, 0, objectDestination);
+    mappingIntoInternal(fieldWithObjectMapping, 0, mappingDestination);
     transformations3DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::transformations3DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix4>& fieldDestination) const {
+std::size_t SceneData::transformations3DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix4>& fieldDestination) const {
     UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
@@ -1634,10 +1635,10 @@ std::size_t SceneData::transformations3DInto(const std::size_t offset, const Con
     const std::size_t fieldSize = _fields[fieldWithObjectMapping]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::transformations3DInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::transformations3DInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldWithObjectMapping, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::transformations3DInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldWithObjectMapping, offset, mappingDestination.prefix(size));
     if(fieldDestination) transformations3DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -1651,7 +1652,7 @@ Containers::Array<Containers::Pair<UnsignedInt, Matrix4>> SceneData::transformat
         "Trade::SceneData::transformations3DInto(): no transformation-related field found", {});
     Containers::Array<Containers::Pair<UnsignedInt, Matrix4>> out{NoInit, std::size_t(_fields[fieldWithObjectMapping]._size)};
     /** @todo use slicing once Pair exposes members somehow */
-    objectsIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     transformations3DIntoInternal(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId, 0, {out, reinterpret_cast<Matrix4*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)});
     return out;
 }
@@ -1719,24 +1720,24 @@ void SceneData::translationsRotationsScalings3DIntoInternal(const UnsignedInt tr
     }
 }
 
-void SceneData::translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const {
+void SceneData::translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const {
     UnsignedInt translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTranslationRotationScalingFields(translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
         "Trade::SceneData::translationsRotationsScalings3DInto(): no transformation-related field found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldWithObjectMapping]._size,
-        "Trade::SceneData::translationsRotationsScalings3DInto(): expected object destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldWithObjectMapping]._size,
+        "Trade::SceneData::translationsRotationsScalings3DInto(): expected mapping destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!translationDestination || translationDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected translation destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << translationDestination.size(), );
     CORRADE_ASSERT(!rotationDestination || rotationDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected rotation destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << rotationDestination.size(), );
     CORRADE_ASSERT(!scalingDestination || scalingDestination.size() == _fields[fieldWithObjectMapping]._size,
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected scaling destination view either empty or with" << _fields[fieldWithObjectMapping]._size << "elements but got" << scalingDestination.size(), );
-    objectsIntoInternal(fieldWithObjectMapping, 0, objectDestination);
+    mappingIntoInternal(fieldWithObjectMapping, 0, mappingDestination);
     translationsRotationsScalings3DIntoInternal(translationFieldId, rotationFieldId, scalingFieldId, 0, translationDestination, rotationDestination, scalingDestination);
 }
 
-std::size_t SceneData::translationsRotationsScalings3DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const {
+std::size_t SceneData::translationsRotationsScalings3DInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const {
     UnsignedInt translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTranslationRotationScalingFields(translationFieldId, rotationFieldId, scalingFieldId);
     CORRADE_ASSERT(fieldWithObjectMapping != ~UnsignedInt{},
@@ -1744,20 +1745,20 @@ std::size_t SceneData::translationsRotationsScalings3DInto(const std::size_t off
     const std::size_t fieldSize = _fields[fieldWithObjectMapping]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::translationsRotationsScalings3DInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !translationDestination || objectDestination.size() == translationDestination.size(),
-        "Trade::SceneData::translationsRotationsScalings3DInto(): object and translation destination views have different size," << objectDestination.size() << "vs" << translationDestination.size(), {});
-    CORRADE_ASSERT(!objectDestination != !rotationDestination || objectDestination.size() == rotationDestination.size(),
-        "Trade::SceneData::translationsRotationsScalings3DInto(): object and rotation destination views have different size," << objectDestination.size() << "vs" << rotationDestination.size(), {});
-    CORRADE_ASSERT(!objectDestination != !scalingDestination || objectDestination.size() == scalingDestination.size(),
-        "Trade::SceneData::translationsRotationsScalings3DInto(): object and scaling destination views have different size," << objectDestination.size() << "vs" << scalingDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !translationDestination || mappingDestination.size() == translationDestination.size(),
+        "Trade::SceneData::translationsRotationsScalings3DInto(): mapping and translation destination views have different size," << mappingDestination.size() << "vs" << translationDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !rotationDestination || mappingDestination.size() == rotationDestination.size(),
+        "Trade::SceneData::translationsRotationsScalings3DInto(): mapping and rotation destination views have different size," << mappingDestination.size() << "vs" << rotationDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !scalingDestination || mappingDestination.size() == scalingDestination.size(),
+        "Trade::SceneData::translationsRotationsScalings3DInto(): mapping and scaling destination views have different size," << mappingDestination.size() << "vs" << scalingDestination.size(), {});
     CORRADE_ASSERT(!translationDestination != !rotationDestination || translationDestination.size() == rotationDestination.size(),
         "Trade::SceneData::translationsRotationsScalings3DInto(): translation and rotation destination views have different size," << translationDestination.size() << "vs" << rotationDestination.size(), {});
     CORRADE_ASSERT(!translationDestination != !scalingDestination || translationDestination.size() == scalingDestination.size(),
         "Trade::SceneData::translationsRotationsScalings3DInto(): translation and scaling destination views have different size," << translationDestination.size() << "vs" << scalingDestination.size(), {});
     CORRADE_ASSERT(!rotationDestination != !scalingDestination || rotationDestination.size() == scalingDestination.size(),
         "Trade::SceneData::translationsRotationsScalings3DInto(): rotation and scaling destination views have different size," << rotationDestination.size() << "vs" << scalingDestination.size(), {});
-    const std::size_t size = Math::min(Math::max({objectDestination.size(), translationDestination.size(), rotationDestination.size(), scalingDestination.size()}), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldWithObjectMapping, offset, objectDestination.prefix(size));
+    const std::size_t size = Math::min(Math::max({mappingDestination.size(), translationDestination.size(), rotationDestination.size(), scalingDestination.size()}), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldWithObjectMapping, offset, mappingDestination.prefix(size));
     translationsRotationsScalings3DIntoInternal(translationFieldId, rotationFieldId, scalingFieldId, offset,
         translationDestination ? translationDestination.prefix(size) : nullptr,
         rotationDestination ? rotationDestination.prefix(size) : nullptr,
@@ -1774,7 +1775,7 @@ Containers::Array<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quat
         "Trade::SceneData::translationsRotationsScalings3DInto(): no transformation-related field found", {});
     Containers::Array<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>> out{NoInit, std::size_t(_fields[fieldWithObjectMapping]._size)};
     /** @todo use slicing once Triple exposes members somehow */
-    objectsIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldWithObjectMapping, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     const Containers::StridedArrayView1D<Vector3> translationsOut{out, reinterpret_cast<Vector3*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)};
     const Containers::StridedArrayView1D<Quaternion> rotationsOut{out, reinterpret_cast<Quaternion*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt) + sizeof(Vector3)), out.size(), sizeof(decltype(out)::Type)};
     const Containers::StridedArrayView1D<Vector3> scalingsOut{out, reinterpret_cast<Vector3*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt) + sizeof(Vector3) + sizeof(Quaternion)), out.size(), sizeof(decltype(out)::Type)};
@@ -1819,7 +1820,7 @@ void SceneData::indexFieldIntoInternal(const UnsignedInt fieldId, const std::siz
 Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> SceneData::unsignedIndexFieldAsArrayInternal(const UnsignedInt fieldId) const {
     Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> out{NoInit, std::size_t(_fields[fieldId]._size)};
     /** @todo use slicing once Pair exposes members somehow */
-    objectsIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     unsignedIndexFieldIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)});
     return out;
 }
@@ -1843,35 +1844,35 @@ void SceneData::meshesMaterialsIntoInternal(const UnsignedInt fieldId, const std
     }
 }
 
-void SceneData::meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const {
+void SceneData::meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Mesh);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::meshesMaterialsInto(): field" << SceneField::Mesh << "not found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::meshesMaterialsInto(): expected object destination view either empty or with" << _fields[fieldId]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldId]._size,
+        "Trade::SceneData::meshesMaterialsInto(): expected mapping destination view either empty or with" << _fields[fieldId]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!meshDestination || meshDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::meshesMaterialsInto(): expected mesh destination view either empty or with" << _fields[fieldId]._size << "elements but got" << meshDestination.size(), );
     CORRADE_ASSERT(!meshMaterialDestination || meshMaterialDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::meshesMaterialsInto(): expected mesh material destination view either empty or with" << _fields[fieldId]._size << "elements but got" << meshMaterialDestination.size(), );
-    objectsIntoInternal(fieldId, 0, objectDestination);
+    mappingIntoInternal(fieldId, 0, mappingDestination);
     meshesMaterialsIntoInternal(fieldId, 0, meshDestination, meshMaterialDestination);
 }
 
-std::size_t SceneData::meshesMaterialsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const {
+std::size_t SceneData::meshesMaterialsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Mesh);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::meshesMaterialsInto(): field" << SceneField::Mesh << "not found", {});
     const std::size_t fieldSize = _fields[fieldId]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::meshesMaterialsInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !meshDestination || objectDestination.size() == meshDestination.size(),
-        "Trade::SceneData::meshesMaterialsInto(): object and mesh destination views have different size," << objectDestination.size() << "vs" << meshDestination.size(), {});
-    CORRADE_ASSERT(!objectDestination != !meshMaterialDestination || objectDestination.size() == meshMaterialDestination.size(),
-        "Trade::SceneData::meshesMaterialsInto(): object and mesh material destination views have different size," << objectDestination.size() << "vs" << meshMaterialDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !meshDestination || mappingDestination.size() == meshDestination.size(),
+        "Trade::SceneData::meshesMaterialsInto(): mapping and mesh destination views have different size," << mappingDestination.size() << "vs" << meshDestination.size(), {});
+    CORRADE_ASSERT(!mappingDestination != !meshMaterialDestination || mappingDestination.size() == meshMaterialDestination.size(),
+        "Trade::SceneData::meshesMaterialsInto(): mapping and mesh material destination views have different size," << mappingDestination.size() << "vs" << meshMaterialDestination.size(), {});
     CORRADE_ASSERT(!meshDestination != !meshMaterialDestination || meshMaterialDestination.size() == meshDestination.size(),
         "Trade::SceneData::meshesMaterialsInto(): mesh and mesh material destination views have different size," << meshDestination.size() << "vs" << meshMaterialDestination.size(), {});
-    const std::size_t size = Math::min(Math::max({objectDestination.size(), meshDestination.size(), meshMaterialDestination.size()}), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldId, offset, objectDestination.prefix(size));
+    const std::size_t size = Math::min(Math::max({mappingDestination.size(), meshDestination.size(), meshMaterialDestination.size()}), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldId, offset, mappingDestination.prefix(size));
     meshesMaterialsIntoInternal(fieldId, offset,
         meshDestination ? meshDestination.prefix(size) : nullptr,
         meshMaterialDestination ? meshMaterialDestination.prefix(size) : nullptr);
@@ -1886,36 +1887,36 @@ Containers::Array<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, In
         "Trade::SceneData::meshesMaterialsInto(): field" << SceneField::Mesh << "not found", {});
     Containers::Array<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>> out{NoInit, std::size_t(_fields[fieldId]._size)};
     /** @todo use slicing once Pair exposes members somehow */
-    objectsIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     const Containers::StridedArrayView1D<UnsignedInt> meshesOut{out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)};
     const Containers::StridedArrayView1D<Int> meshMaterialsOut{out, reinterpret_cast<Int*>(reinterpret_cast<char*>(out.data()) + sizeof(UnsignedInt) + sizeof(UnsignedInt)), out.size(), sizeof(decltype(out)::Type)};
     meshesMaterialsIntoInternal(fieldId, 0, meshesOut, meshMaterialsOut);
     return out;
 }
 
-void SceneData::lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
+void SceneData::lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Light);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::lightsInto(): field not found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::lightsInto(): expected object destination view either empty or with" << _fields[fieldId]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldId]._size,
+        "Trade::SceneData::lightsInto(): expected mapping destination view either empty or with" << _fields[fieldId]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::lightsInto(): expected field destination view either empty or with" << _fields[fieldId]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldId, 0, objectDestination);
+    mappingIntoInternal(fieldId, 0, mappingDestination);
     unsignedIndexFieldIntoInternal(fieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::lightsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
+std::size_t SceneData::lightsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Light);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::lightsInto(): field not found", {});
     const std::size_t fieldSize = _fields[fieldId]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::lightsInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::lightsInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldId, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::lightsInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldId, offset, mappingDestination.prefix(size));
     if(fieldDestination) unsignedIndexFieldIntoInternal(fieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -1929,29 +1930,29 @@ Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> SceneData::lightsA
     return unsignedIndexFieldAsArrayInternal(fieldId);
 }
 
-void SceneData::camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
+void SceneData::camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Camera);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::camerasInto(): field not found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::camerasInto(): expected object destination view either empty or with" << _fields[fieldId]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldId]._size,
+        "Trade::SceneData::camerasInto(): expected mapping destination view either empty or with" << _fields[fieldId]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::camerasInto(): expected field destination view either empty or with" << _fields[fieldId]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldId, 0, objectDestination);
+    mappingIntoInternal(fieldId, 0, mappingDestination);
     unsignedIndexFieldIntoInternal(fieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::camerasInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
+std::size_t SceneData::camerasInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Camera);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::camerasInto(): field not found", {});
     const std::size_t fieldSize = _fields[fieldId]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::camerasInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::camerasInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldId, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::camerasInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldId, offset, mappingDestination.prefix(size));
     if(fieldDestination) unsignedIndexFieldIntoInternal(fieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -1965,29 +1966,29 @@ Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> SceneData::cameras
     return unsignedIndexFieldAsArrayInternal(fieldId);
 }
 
-void SceneData::skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
+void SceneData::skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Skin);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::skinsInto(): field not found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::skinsInto(): expected object destination view either empty or with" << _fields[fieldId]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldId]._size,
+        "Trade::SceneData::skinsInto(): expected mapping destination view either empty or with" << _fields[fieldId]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::skinsInto(): expected field destination view either empty or with" << _fields[fieldId]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldId, 0, objectDestination);
+    mappingIntoInternal(fieldId, 0, mappingDestination);
     unsignedIndexFieldIntoInternal(fieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::skinsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
+std::size_t SceneData::skinsInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Skin);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::skinsInto(): field not found", {});
     const std::size_t fieldSize = _fields[fieldId]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::skinsInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::skinsInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldId, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::skinsInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldId, offset, mappingDestination.prefix(size));
     if(fieldDestination) unsignedIndexFieldIntoInternal(fieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -2011,29 +2012,29 @@ void SceneData::importerStateIntoInternal(const UnsignedInt fieldId, const std::
     Utility::copy(Containers::arrayCast<const void* const>(fieldDataFieldViewInternal(field, offset, destination.size())), destination);
 }
 
-void SceneData::importerStateInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const {
+void SceneData::importerStateInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::ImporterState);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::importerStateInto(): field not found", );
-    CORRADE_ASSERT(!objectDestination || objectDestination.size() == _fields[fieldId]._size,
-        "Trade::SceneData::importerStateInto(): expected object destination view either empty or with" << _fields[fieldId]._size << "elements but got" << objectDestination.size(), );
+    CORRADE_ASSERT(!mappingDestination || mappingDestination.size() == _fields[fieldId]._size,
+        "Trade::SceneData::importerStateInto(): expected mapping destination view either empty or with" << _fields[fieldId]._size << "elements but got" << mappingDestination.size(), );
     CORRADE_ASSERT(!fieldDestination || fieldDestination.size() == _fields[fieldId]._size,
         "Trade::SceneData::importerStateInto(): expected field destination view either empty or with" << _fields[fieldId]._size << "elements but got" << fieldDestination.size(), );
-    objectsIntoInternal(fieldId, 0, objectDestination);
+    mappingIntoInternal(fieldId, 0, mappingDestination);
     importerStateIntoInternal(fieldId, 0, fieldDestination);
 }
 
-std::size_t SceneData::importerStateInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const {
+std::size_t SceneData::importerStateInto(const std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const {
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::ImporterState);
     CORRADE_ASSERT(fieldId != ~UnsignedInt{},
         "Trade::SceneData::importerStateInto(): field not found", {});
     const std::size_t fieldSize = _fields[fieldId]._size;
     CORRADE_ASSERT(offset <= fieldSize,
         "Trade::SceneData::importerStateInto(): offset" << offset << "out of bounds for a field of size" << fieldSize, {});
-    CORRADE_ASSERT(!objectDestination != !fieldDestination|| objectDestination.size() == fieldDestination.size(),
-        "Trade::SceneData::importerStateInto(): object and field destination views have different size," << objectDestination.size() << "vs" << fieldDestination.size(), {});
-    const std::size_t size = Math::min(Math::max(objectDestination.size(), fieldDestination.size()), fieldSize - offset);
-    if(objectDestination) objectsIntoInternal(fieldId, offset, objectDestination.prefix(size));
+    CORRADE_ASSERT(!mappingDestination != !fieldDestination|| mappingDestination.size() == fieldDestination.size(),
+        "Trade::SceneData::importerStateInto(): mapping and field destination views have different size," << mappingDestination.size() << "vs" << fieldDestination.size(), {});
+    const std::size_t size = Math::min(Math::max(mappingDestination.size(), fieldDestination.size()), fieldSize - offset);
+    if(mappingDestination) mappingIntoInternal(fieldId, offset, mappingDestination.prefix(size));
     if(fieldDestination) importerStateIntoInternal(fieldId, offset, fieldDestination.prefix(size));
     return size;
 }
@@ -2055,14 +2056,14 @@ Containers::Array<Containers::Pair<UnsignedInt, const void*>> SceneData::importe
     , std::size_t(_fields[fieldId]._size)};
     /** @todo use slicing once Pair exposes members somehow, especially because
         this is EXTREMELY prone to bugs due to the padding before the pointer */
-    objectsIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
+    mappingIntoInternal(fieldId, 0, {out, reinterpret_cast<UnsignedInt*>(reinterpret_cast<char*>(out.data())), out.size(), sizeof(decltype(out)::Type)});
     importerStateIntoInternal(fieldId, 0, {out, reinterpret_cast<const void**>(reinterpret_cast<char*>(out.data()) + sizeof(const void*)), out.size(), sizeof(decltype(out)::Type)});
     return out;
 }
 
 Containers::Optional<Int> SceneData::parentFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::parentFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::parentFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Parent);
     if(fieldId == ~UnsignedInt{}) return {};
@@ -2077,8 +2078,8 @@ Containers::Optional<Int> SceneData::parentFor(const UnsignedInt object) const {
 }
 
 Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
-    CORRADE_ASSERT(object >= -1 && object < Long(_objectCount),
-        "Trade::SceneData::childrenFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object >= -1 && object < Long(_mappingBound),
+        "Trade::SceneData::childrenFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt parentFieldId = findFieldIdInternal(SceneField::Parent);
     if(parentFieldId == ~UnsignedInt{}) return {};
@@ -2094,7 +2095,7 @@ Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
             UnsignedInt child[1];
             /** @todo bleh slow, use the children <-> parent field proxying
                 when implemented */
-            objectsIntoInternal(parentFieldId, offset, child);
+            mappingIntoInternal(parentFieldId, offset, child);
             arrayAppend(out, *child);
         }
     }
@@ -2103,8 +2104,8 @@ Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
 }
 
 Containers::Optional<Matrix3> SceneData::transformation2DFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::transformation2DFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::transformation2DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
@@ -2124,8 +2125,8 @@ Containers::Optional<Matrix3> SceneData::transformation2DFor(const UnsignedInt o
 }
 
 Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> SceneData::translationRotationScaling2DFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::translationRotationScaling2DFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::translationRotationScaling2DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     UnsignedInt translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTranslationRotationScalingFields(translationFieldId, rotationFieldId, scalingFieldId);
@@ -2147,8 +2148,8 @@ Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> SceneData::t
 }
 
 Containers::Optional<Matrix4> SceneData::transformation3DFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::transformation3DFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::transformation3DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     UnsignedInt transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTransformFields(transformationFieldId, translationFieldId, rotationFieldId, scalingFieldId);
@@ -2168,8 +2169,8 @@ Containers::Optional<Matrix4> SceneData::transformation3DFor(const UnsignedInt o
 }
 
 Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> SceneData::translationRotationScaling3DFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::translationRotationScaling3DFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::translationRotationScaling3DFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     UnsignedInt translationFieldId, rotationFieldId, scalingFieldId;
     const UnsignedInt fieldWithObjectMapping = findTranslationRotationScalingFields(translationFieldId, rotationFieldId, scalingFieldId);
@@ -2191,8 +2192,8 @@ Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> SceneData
 }
 
 Containers::Array<Containers::Pair<UnsignedInt, Int>> SceneData::meshesMaterialsFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::meshesMaterialsFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::meshesMaterialsFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt meshFieldId = findFieldIdInternal(SceneField::Mesh);
     if(meshFieldId == ~UnsignedInt{}) return {};
@@ -2215,8 +2216,8 @@ Containers::Array<Containers::Pair<UnsignedInt, Int>> SceneData::meshesMaterials
 }
 
 Containers::Array<UnsignedInt> SceneData::lightsFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::lightsFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::lightsFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Light);
     if(fieldId == ~UnsignedInt{}) return {};
@@ -2238,8 +2239,8 @@ Containers::Array<UnsignedInt> SceneData::lightsFor(const UnsignedInt object) co
 }
 
 Containers::Array<UnsignedInt> SceneData::camerasFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::camerasFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::camerasFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Camera);
     if(fieldId == ~UnsignedInt{}) return {};
@@ -2261,8 +2262,8 @@ Containers::Array<UnsignedInt> SceneData::camerasFor(const UnsignedInt object) c
 }
 
 Containers::Array<UnsignedInt> SceneData::skinsFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::skinsFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::skinsFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::Skin);
     if(fieldId == ~UnsignedInt{}) return {};
@@ -2284,8 +2285,8 @@ Containers::Array<UnsignedInt> SceneData::skinsFor(const UnsignedInt object) con
 }
 
 Containers::Optional<const void*> SceneData::importerStateFor(const UnsignedInt object) const {
-    CORRADE_ASSERT(object < _objectCount,
-        "Trade::SceneData::importerStateFor(): object" << object << "out of bounds for" << _objectCount << "objects", {});
+    CORRADE_ASSERT(object < _mappingBound,
+        "Trade::SceneData::importerStateFor(): object" << object << "out of bounds for" << _mappingBound << "objects", {});
 
     const UnsignedInt fieldId = findFieldIdInternal(SceneField::ImporterState);
     if(fieldId == ~UnsignedInt{}) return {};

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -1088,7 +1088,6 @@ void SceneData::objectsIntoInternal(const UnsignedInt fieldId, const std::size_t
     else if(field._objectType == SceneObjectType::UnsignedByte)
         Math::castInto(Containers::arrayCast<2, const UnsignedByte>(objectData, 1), destination1ui);
     else if(field._objectType == SceneObjectType::UnsignedLong) {
-        CORRADE_ASSERT(_objectCount <= 0xffffffffull, "Trade::SceneData::objectsInto(): indices for up to" << _objectCount << "objects can't fit into a 32-bit type, access them directly via objects() instead", );
         Math::castInto(Containers::arrayCast<2, const UnsignedLong>(objectData, 1), destination1ui);
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
@@ -1159,7 +1158,6 @@ void SceneData::parentsIntoInternal(const UnsignedInt fieldId, const std::size_t
     else if(field._fieldType == SceneFieldType::Byte)
         Math::castInto(Containers::arrayCast<2, const Byte>(fieldData, 1), destination1i);
     else if(field._fieldType == SceneFieldType::Long) {
-        CORRADE_ASSERT(field._size <= 0xffffffffull, "Trade::SceneData::parentsInto(): parent indices for up to"  << field._size << "objects can't fit into a 32-bit type, access them directly via field() instead", );
         Math::castInto(Containers::arrayCast<2, const Long>(fieldData, 1), destination1i);
     } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -2073,11 +2073,7 @@ Containers::Optional<Int> SceneData::parentFor(const UnsignedInt object) const {
 
     Int index[1];
     parentsIntoInternal(fieldId, offset, index);
-    if(*index == -1) return -1;
-
-    UnsignedInt parent[1];
-    objectsIntoInternal(fieldId, *index, parent);
-    return Int(*parent);
+    return *index;
 }
 
 Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
@@ -2089,22 +2085,12 @@ Containers::Array<UnsignedInt> SceneData::childrenFor(const Int object) const {
 
     const SceneFieldData& parentField = _fields[parentFieldId];
 
-    /* Figure out the parent object index to look for or -1 if we want
-       top-level objects */
-    Int parentIndexToLookFor;
-    if(object == -1) parentIndexToLookFor = -1;
-    else {
-        const std::size_t parentObjectIndex = findFieldObjectOffsetInternal(parentField, object, 0);
-        if(parentObjectIndex == parentField._size) return {};
-        parentIndexToLookFor = parentObjectIndex;
-    }
-
-    /* Collect IDs of all objects that reference this index */
+    /* Collect IDs of all objects that reference this object */
     Containers::Array<UnsignedInt> out;
     for(std::size_t offset = 0; offset != parentField.size(); ++offset) {
         Int parentIndex[1];
         parentsIntoInternal(parentFieldId, offset, parentIndex);
-        if(*parentIndex == parentIndexToLookFor) {
+        if(*parentIndex == object) {
             UnsignedInt child[1];
             /** @todo bleh slow, use the children <-> parent field proxying
                 when implemented */

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -384,6 +384,7 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
     #ifndef CORRADE_NO_ASSERT
     UnsignedInt meshField = ~UnsignedInt{};
     UnsignedInt meshMaterialField = ~UnsignedInt{};
+    UnsignedInt skinField = ~UnsignedInt{};
     #endif
     for(std::size_t i = 0; i != _fields.size(); ++i) {
         const SceneFieldData& field = _fields[i];
@@ -465,6 +466,8 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
             meshField = i;
         } else if(_fields[i]._name == SceneField::MeshMaterial) {
             meshMaterialField = i;
+        } else if(_fields[i]._name == SceneField::Skin) {
+            skinField = i;
         }
         #endif
     }
@@ -560,6 +563,11 @@ SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong object
             _dimensions = 3;
         } else CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
     }
+
+    /* A skin field requires some transformation field to exist in order to
+       disambiguate between 2D and 3D */
+    CORRADE_ASSERT(skinField == ~UnsignedInt{} || _dimensions,
+        "Trade::SceneData: a skin field requires some transformation field to be present in order to disambiguate between 2D and 3D", );
 }
 
 SceneData::SceneData(const SceneObjectType objectType, const UnsignedLong objectCount, Containers::Array<char>&& data, const std::initializer_list<SceneFieldData> fields, const void* const importerState): SceneData{objectType, objectCount, std::move(data), Implementation::initializerListToArrayWithDefaultDeleter(fields), importerState} {}

--- a/src/Magnum/Trade/SceneData.cpp
+++ b/src/Magnum/Trade/SceneData.cpp
@@ -749,9 +749,11 @@ SceneData::SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedIn
         {NoInit, children.size(), objects},
         {NoInit, children.size(), parents},
     };
-    _fields = {InPlaceInit, {
-        SceneFieldData{SceneField::Parent, objects, parents}
-    }};
+    /* Can't use InPlaceInit as that creates an Array with a non-default
+       deleter, which then trips up on an assertion when such an instance gets
+       returned from AbstractImporter */
+    _fields = Containers::Array<SceneFieldData>{1};
+    _fields[0] = SceneFieldData{SceneField::Parent, objects, parents};
     Utility::copy(children, objects);
     constexpr Int parent[]{-1};
     Utility::copy(Containers::stridedArrayView(parent).broadcasted<0>(parents.size()), parents);

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -273,12 +273,14 @@ enum class SceneField: UnsignedInt {
 
     /**
      * ID of a skin associated with this object, corresponding to the ID
-     * passed to @ref AbstractImporter::skin(). Type is usually
-     * @ref SceneFieldType::UnsignedInt, but can be also any of
-     * @relativeref{SceneFieldType,UnsignedByte} or
+     * passed to @ref AbstractImporter::skin2D() or
+     * @ref AbstractImporter::skin3D(), depending on whether the scene has a 2D
+     * or 3D transformation. Type is usually @ref SceneFieldType::UnsignedInt,
+     * but can be also any of @relativeref{SceneFieldType,UnsignedByte} or
      * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
      * skins associated.
-     * @see @ref SceneData::skinsAsArray(), @ref SceneData::skinsFor()
+     * @see @ref SceneData::is2D(), @ref SceneData::is3D(),
+     *      @ref SceneData::skinsAsArray(), @ref SceneData::skinsFor()
      */
     Skin,
 

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -83,7 +83,9 @@ MAGNUM_TRADE_EXPORT UnsignedInt sceneObjectTypeSize(SceneObjectType type);
 @m_since_latest
 
 See @ref SceneData for more information.
-@see @ref SceneFieldData, @ref SceneFieldType
+@see @ref SceneFieldData, @ref SceneFieldType,
+    @ref AbstractImporter::sceneFieldForName(),
+    @ref AbstractImporter::sceneFieldName()
 */
 enum class SceneField: UnsignedInt {
     /* Zero used for an invalid value */

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -208,10 +208,10 @@ enum class SceneField: UnsignedInt {
 
     /**
      * ID of a material for a @ref SceneField::Mesh, corresponding to the ID
-     * passed to @ref AbstractImporter::material(). Type is usually
-     * @ref SceneFieldType::UnsignedInt, but can be also any of
-     * @relativeref{SceneFieldType,UnsignedByte} or
-     * @relativeref{SceneFieldType,UnsignedShort}. Expected to share the
+     * passed to @ref AbstractImporter::material() or @cpp -1 @ce if the mesh
+     * has no material associated. Type is usually @ref SceneFieldType::Int,
+     * but can be also any of @relativeref{SceneFieldType,Byte} or
+     * @relativeref{SceneFieldType,Short}. Expected to share the
      * object mapping view with @ref SceneField::Mesh.
      * @see @ref SceneData::meshMaterialsAsArray()
      */
@@ -1492,7 +1492,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * newly-allocated array. The field is expected to exist.
          * @see @ref meshMaterialsInto(), @ref hasField()
          */
-        Containers::Array<UnsignedInt> meshMaterialsAsArray() const;
+        Containers::Array<Int> meshMaterialsAsArray() const;
 
         /**
          * @brief Mesh material IDs as 32-bit integers into a pre-allocated view
@@ -1503,20 +1503,20 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @p destination is sized to contain exactly all data.
          * @see @ref fieldSize(SceneField) const
          */
-        void meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        void meshMaterialsInto(const Containers::StridedArrayView1D<Int>& destination) const;
 
         /**
          * @brief A subrange of mesh material IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * Compared to @ref meshMaterialsInto(const Containers::StridedArrayView1D<Int>&) const
          * extracts only a subrange of the field defined by @p offset and size
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
          * @see @ref fieldSize(SceneField) const
          */
-        std::size_t meshMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        std::size_t meshMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
 
         /**
          * @brief Light IDs as 32-bit integers
@@ -1689,8 +1689,10 @@ class MAGNUM_TRADE_EXPORT SceneData {
         MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
         MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
         MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
-        MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
-        MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> indexFieldAsArrayInternal(const UnsignedInt fieldId) const;
+        MAGNUM_TRADE_LOCAL void unsignedIndexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
+        MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> unsignedIndexFieldAsArrayInternal(const UnsignedInt fieldId) const;
+        MAGNUM_TRADE_LOCAL Containers::Array<Int> indexFieldAsArrayInternal(const UnsignedInt fieldId) const;
 
         DataFlags _dataFlags;
         SceneObjectType _objectType;
@@ -1857,13 +1859,16 @@ namespace Implementation {
                  type == SceneFieldType::Quaternion ||
                  type == SceneFieldType::Quaterniond)) ||
            ((name == SceneField::Mesh ||
-             name == SceneField::MeshMaterial ||
              name == SceneField::Light ||
              name == SceneField::Camera ||
              name == SceneField::Skin) &&
                 (type == SceneFieldType::UnsignedByte ||
                  type == SceneFieldType::UnsignedShort ||
                  type == SceneFieldType::UnsignedInt)) ||
+            (name == SceneField::MeshMaterial &&
+                (type == SceneFieldType::Byte ||
+                 type == SceneFieldType::Short ||
+                 type == SceneFieldType::Int)) ||
             /* Custom fields can be anything */
             isSceneFieldCustom(name);
     }

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -60,16 +60,7 @@ enum class SceneObjectType: UnsignedByte {
     UnsignedByte = 1,   /**< @relativeref{Magnum,UnsignedByte} */
     UnsignedShort,      /**< @relativeref{Magnum,UnsignedShort} */
     UnsignedInt,        /**< @relativeref{Magnum,UnsignedInt} */
-
-    /**
-     * @relativeref{Magnum,UnsignedLong}. Meant to be used only in rare cases
-     * for *really huge* scenes. If this type is used and
-     * @ref SceneData::objectCount() is larger than the max representable
-     * 32-bit value, the indices can't be retrieved using
-     * @ref SceneData::objectsAsArray(), but only using appropriately typed
-     * @ref SceneData::objects().
-     */
-    UnsignedLong
+    UnsignedLong        /**< @relativeref{Magnum,UnsignedLong} */
 };
 
 /**
@@ -109,7 +100,7 @@ enum class SceneField: UnsignedInt {
     /**
      * Parent index. Type is usually @ref SceneFieldType::Int, but can be also
      * any of @relativeref{SceneFieldType,Byte},
-     * @relativeref{SceneFieldType,Short} or, rarely, a
+     * @relativeref{SceneFieldType,Short} or a
      * @relativeref{SceneFieldType,Long}. A value of @cpp -1 @ce means there's
      * no parent. An object should have only one parent, altough this isn't
      * enforced in any way, and which of the duplicate fields gets used is not
@@ -1483,11 +1474,6 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref objects(UnsignedInt) const that converts the field from an
          * arbitrary underlying type and returns it in a newly-allocated array.
          * The @p fieldId is expected to be smaller than @ref fieldCount().
-         * @attention In the rare case when @ref objectType() is
-         *      @ref SceneObjectType::UnsignedLong and @ref objectCount() is
-         *      larger than the max representable 32-bit value, this function
-         *      can't be used, only an appropriately typed
-         *      @ref objects(UnsignedInt) const.
          * @see @ref objectsInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
          */
         Containers::Array<UnsignedInt> objectsAsArray(UnsignedInt fieldId) const;
@@ -1525,11 +1511,6 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref objects(SceneField) const that converts the field from an
          * arbitrary underlying type and returns it in a newly-allocated array.
          * The @p fieldName is expected to exist.
-         * @attention In the rare case when @ref objectType() is
-         *      @ref SceneObjectType::UnsignedLong and @ref objectCount() is
-         *      larger than the max representable 32-bit value, this function
-         *      can't be used, only an appropriately typed
-         *      @ref objects(SceneField) const.
          * @see @ref objectsInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const,
          *      @ref hasField()
          */
@@ -1568,11 +1549,6 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref SceneField::Parent as the argument that converts the field from
          * an arbitrary underlying type and returns it in a newly-allocated
          * array. The field is expected to exist.
-         * @attention In the rare case when @ref fieldType(SceneField) const is
-         *      @ref SceneFieldType::Long and @ref fieldSize(SceneField) const
-         *      is larger than the max representable 32-bit value, this
-         *      function can't be used, only an appropriately typed
-         *      @ref field(SceneField) const.
          * @see @ref parentsInto(), @ref hasField(), @ref parentFor(),
          *      @ref childrenFor()
          */

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -102,7 +102,8 @@ enum class SceneField: UnsignedInt {
      * Note that the index points to the parent array itself and isn't the
      * actual object index --- the object mapping is stored in the
      * corresponding @ref SceneData::objects() array.
-     * @see @ref SceneData::parentsAsArray(), @ref SceneData::childrenFor()
+     * @see @ref SceneData::parentsAsArray(), @ref SceneData::parentFor(),
+     *      @ref SceneData::childrenFor()
      */
     Parent = 1,
 
@@ -1358,7 +1359,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *      is larger than the max representable 32-bit value, this
          *      function can't be used, only an appropriately typed
          *      @ref field(SceneField) const.
-         * @see @ref parentsInto(), @ref hasField(), @ref childrenFor()
+         * @see @ref parentsInto(), @ref hasField(), @ref parentFor(),
+         *      @ref childrenFor()
          */
         Containers::Array<Int> parentsAsArray() const;
 
@@ -1720,6 +1722,26 @@ class MAGNUM_TRADE_EXPORT SceneData {
         std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
+         * @brief Parent for given object
+         * @m_since_latest
+         *
+         * Looks up the @ref SceneField::Parent field for @p object. The lookup
+         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
+         * being the field count and @f$ n @f$ the size of the parent field,
+         * thus for retrieving parent info for many objects it's recommended to
+         * access the field data directly with @ref parentsAsArray() and
+         * related APIs.
+         *
+         * If the @ref SceneField::Parent field is not present or if there's no
+         * parent for @p object, returns @ref Containers::NullOpt. If @p object
+         * is top-level, returns @cpp -1 @ce.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         * @see @ref childrenFor()
+         */
+        Containers::Optional<Int> parentFor(UnsignedInt object) const;
+
+        /**
          * @brief Children for given object
          * @m_since_latest
          *
@@ -1737,6 +1759,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * an empty array. Pass @cpp -1 @ce to get a list of top-level objects.
          *
          * The @p object is expected to be less than @ref objectCount().
+         * @see @ref parentFor()
          */
         Containers::Array<UnsignedInt> childrenFor(Int object) const;
 

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -26,62 +26,1508 @@
 */
 
 /** @file
- * @brief Class @ref Magnum::Trade::SceneData
+ * @brief Class @ref Magnum::Trade::SceneData, @ref Magnum::Trade::SceneFieldData, enum @ref Magnum::Trade::SceneObjectType, @ref Magnum::Trade::SceneField, @ref Magnum::Trade::SceneFieldType, function @ref Magnum::sceneObjectTypeSize(), @ref Magnum::sceneFieldTypeSize(), @ref Magnum::Trade::isSceneFieldCustom(), @ref Magnum::sceneFieldCustom()
  */
 
-#include <vector>
+#include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/StridedArrayView.h>
 
-#include "Magnum/Types.h"
+#include "Magnum/Trade/Data.h"
+#include "Magnum/Trade/Trade.h"
 #include "Magnum/Trade/visibility.h"
 
 namespace Magnum { namespace Trade {
 
 /**
+@brief Scene object type
+@m_since_latest
+
+Type used for mapping fields to corresponding objects. Unlike
+@ref SceneFieldType that is different for different fields, the object type is
+the same for all fields, and is guaranteed to be large enough to fit all
+@ref SceneData::objectCount() objects.
+@see @ref SceneData::objectType(), @ref sceneObjectTypeSize()
+*/
+enum class SceneObjectType: UnsignedByte {
+    /* Zero used for an invalid value */
+
+    UnsignedByte = 1,   /**< @relativeref{Magnum,UnsignedByte} */
+    UnsignedShort,      /**< @relativeref{Magnum,UnsignedShort} */
+    UnsignedInt,        /**< @relativeref{Magnum,UnsignedInt} */
+
+    /**
+     * @relativeref{Magnum,UnsignedLong}. Meant to be used only in rare cases
+     * for *really huge* scenes. If this type is used and
+     * @ref SceneData::objectCount() is larger than the max representable
+     * 32-bit value, the indices can't be retrieved using
+     * @ref SceneData::objectsAsArray(), but only using appropriately typed
+     * @ref SceneData::objects().
+     */
+    UnsignedLong
+};
+
+/**
+@debugoperatorenum{SceneObjectType}
+@m_since_latest
+*/
+MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneObjectType value);
+
+/**
+@brief Size of given scene object type
+@m_since_latest
+*/
+MAGNUM_TRADE_EXPORT UnsignedInt sceneObjectTypeSize(SceneObjectType type);
+
+/**
+@brief Scene field name
+@m_since_latest
+
+See @ref SceneData for more information.
+@see @ref SceneFieldData, @ref SceneFieldType
+*/
+enum class SceneField: UnsignedInt {
+    /* Zero used for an invalid value */
+
+    /**
+     * Parent index. Type is usually @ref SceneFieldType::Int, but can be also
+     * any of @relativeref{SceneFieldType,Byte},
+     * @relativeref{SceneFieldType,Short} or, rarely, a
+     * @relativeref{SceneFieldType,Long}. A value of @cpp -1 @ce means there's
+     * no parent. An object should have only one parent, altough this isn't
+     * enforced in any way, and which of the duplicate fields gets used is not
+     * defined.
+     *
+     * Note that the index points to the parent array itself and isn't the
+     * actual object index --- the object mapping is stored in the
+     * corresponding @ref SceneData::objects() array.
+     * @see @ref SceneData::parentsAsArray()
+     */
+    Parent = 1,
+
+    /**
+     * Transformation. Type is usually @ref SceneFieldType::Matrix3x3 for 2D
+     * and @ref SceneFieldType::Matrix4x4 for 3D, but can be also any of
+     * @relativeref{SceneFieldType,Matrix3x3d},
+     * @relativeref{SceneFieldType,DualComplex} or
+     * @relativeref{SceneFieldType,DualComplexd} for 2D and
+     * @relativeref{SceneFieldType,Matrix4x4d},
+     * @relativeref{SceneFieldType,DualQuaternion} or
+     * @relativeref{SceneFieldType,DualQuaterniond} for 3D. An object should
+     * have only one transformation, altough this isn't enforced in any way,
+     * and which of the duplicate fields gets used is not defined.
+     *
+     * The transformation can be also represented by separate
+     * @ref SceneField::Translation, @ref SceneField::Rotation and
+     * @ref SceneField::Scaling fields. If both @ref SceneField::Transformation
+     * and TRS fields are specified, it's expected that all objects that have
+     * TRS fields have a combined transformation field as well, and
+     * @ref SceneData::transformations2DAsArray() /
+     * @ref SceneData::transformations3DAsArray() then takes into account only
+     * the combined transformation field. TRS fields can however be specified
+     * only for a subset of transformed objects, useful for example when only
+     * certain objects have these properties animated.
+     * @see @ref SceneData::transformations2DAsArray(),
+     *      @ref SceneData::transformations3DAsArray()
+     */
+    Transformation,
+
+    /**
+     * Translation. Type is usually @ref SceneFieldType::Vector2 for 2D and
+     * @ref SceneFieldType::Vector3 for 3D, but can be also any of
+     * @relativeref{SceneFieldType,Vector2d} for 2D and
+     * @relativeref{SceneFieldType,Vector3d} for 3D. An object should
+     * have only one translation, altough this isn't enforced in any way,
+     * and which of the duplicate fields gets used is not defined.
+     *
+     * The translation field usually is (but doesn't have to be) complemented
+     * by a @ref SceneField::Rotation and @ref SceneField::Scaling, which, if
+     * present, are expected to all share the same object mapping view. The TRS
+     * components can either completely replace @ref SceneField::Transformation
+     * or be provided just for a subset of it --- see its documentation for
+     * details.
+     * @see @ref SceneData::transformations2DAsArray(),
+     *      @ref SceneData::transformations3DAsArray()
+     */
+    Translation,
+
+    /**
+     * Rotation. Type is usually @ref SceneFieldType::Complex for 2D and
+     * @ref SceneFieldType::Quaternion for 3D, but can be also any of
+     * @relativeref{SceneFieldType,Complexd} for 2D and
+     * @relativeref{SceneFieldType,Quaterniond} for 3D. An object should have
+     * only one rotation, altough this isn't enforced in any way, and which of
+     * the duplicate fields gets used is not defined.
+     *
+     * The rotation field usually is (but doesn't have to be) complemented by a
+     * @ref SceneField::Translation and @ref SceneField::Scaling, which, if
+     * present, are expected to all share the same object mapping view. The TRS
+     * components can either completely replace @ref SceneField::Transformation
+     * or be provided just for a subset of it --- see its documentation for
+     * details.
+     * @see @ref SceneData::transformations2DAsArray(),
+     *      @ref SceneData::transformations3DAsArray()
+     */
+    Rotation,
+
+    /**
+     * Scaling. Type is usually @ref SceneFieldType::Vector2 for 2D and
+     * @ref SceneFieldType::Vector3 for 3D, but can be also any of
+     * @relativeref{SceneFieldType,Vector2d} for 2D and
+     * @relativeref{SceneFieldType,Vector3d} for 3D. An object should
+     * have only one scaling, altough this isn't enforced in any way, and which
+     * of the duplicate fields gets used is not defined.
+     *
+     * The scaling field usually is (but doesn't have to be) complemented by a
+     * @ref SceneField::Translation and @ref SceneField::Rotation, which, if
+     * present, are expected to all share the same object mapping view. The TRS
+     * components can either completely replace @ref SceneField::Transformation
+     * or be provided just for a subset of it --- see its documentation for
+     * details.
+     * @see @ref SceneData::transformations2DAsArray(),
+     *      @ref SceneData::transformations3DAsArray()
+     */
+    Scaling,
+
+    /**
+     * ID of a mesh associated with this object, corresponding to the ID passed
+     * to @ref AbstractImporter::mesh(). Type is usually
+     * @ref SceneFieldType::UnsignedInt, but can be also any of
+     * @relativeref{SceneFieldType,UnsignedByte} or
+     * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
+     * meshes associated.
+     *
+     * Usually complemented with a @ref SceneField::MeshMaterial, although not
+     * required. If present, both should share the same object mapping view.
+     * Objects with multiple meshes then have the Nth mesh associated with the
+     * Nth material.
+     * @see @ref SceneData::meshesAsArray()
+     */
+    Mesh,
+
+    /**
+     * ID of a material for a @ref SceneField::Mesh, corresponding to the ID
+     * passed to @ref AbstractImporter::material(). Type is usually
+     * @ref SceneFieldType::UnsignedInt, but can be also any of
+     * @relativeref{SceneFieldType,UnsignedByte} or
+     * @relativeref{SceneFieldType,UnsignedShort}. Expected to share the
+     * object mapping view with @ref SceneField::Mesh.
+     * @see @ref SceneData::meshMaterialsAsArray()
+     */
+    MeshMaterial,
+
+    /**
+     * ID of a light associated with this object, corresponding to the ID
+     * passed to @ref AbstractImporter::light(). Type is usually
+     * @ref SceneFieldType::UnsignedInt, but can be also any of
+     * @relativeref{SceneFieldType,UnsignedByte} or
+     * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
+     * lights associated.
+     * @see @ref SceneData::lightsAsArray()
+     */
+    Light,
+
+    /**
+     * ID of a camera associated with this object, corresponding to the ID
+     * passed to @ref AbstractImporter::camera(). Type is usually
+     * @ref SceneFieldType::UnsignedInt, but can be also any of
+     * @relativeref{SceneFieldType,UnsignedByte} or
+     * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
+     * cameras associated.
+     * @see @ref SceneData::camerasAsArray()
+     */
+    Camera,
+
+    /**
+     * ID of a skin associated with this object, corresponding to the ID
+     * passed to @ref AbstractImporter::skin(). Type is usually
+     * @ref SceneFieldType::UnsignedInt, but can be also any of
+     * @relativeref{SceneFieldType,UnsignedByte} or
+     * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
+     * skins associated.
+     * @see @ref SceneData::skinsAsArray()
+     */
+    Skin,
+
+    /**
+     * This and all higher values are for importer-specific fields. Can be
+     * of any type. See documentation of a particular importer for details.
+     *
+     * While it's unlikely to have billions of custom fields, the enum
+     * intentionally reserves a full 31-bit range to avoid the need to remap
+     * field identifiers coming from 3rd party ECS frameworks, for example.
+     * @see @ref isSceneFieldCustom(), @ref sceneFieldCustom(SceneField),
+     *      @ref sceneFieldCustom(UnsignedInt)
+     */
+    Custom = 0x80000000u
+};
+
+/**
+@debugoperatorenum{SceneField}
+@m_since_latest
+*/
+MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneField value);
+
+/**
+@brief Whether a scene field is custom
+@m_since_latest
+
+Returns @cpp true @ce if @p name has a value larger or equal to
+@ref SceneField::Custom, @cpp false @ce otherwise.
+@see @ref sceneFieldCustom(UnsignedInt), @ref sceneFieldCustom(SceneField)
+*/
+constexpr bool isSceneFieldCustom(SceneField name) {
+    return UnsignedInt(name) >= UnsignedInt(SceneField::Custom);
+}
+
+/**
+@brief Create a custom scene field
+@m_since_latest
+
+Returns a custom scene field with index @p id. The index is expected to be less
+than the value of @ref SceneField::Custom. Use @ref sceneFieldCustom(SceneField)
+to get the index back.
+*/
+/* Constexpr so it's usable for creating compile-time SceneFieldData
+   instances */
+constexpr SceneField sceneFieldCustom(UnsignedInt id) {
+    return CORRADE_CONSTEXPR_ASSERT(id < UnsignedInt(SceneField::Custom),
+        "Trade::sceneFieldCustom(): index" << id << "too large"),
+        SceneField(UnsignedInt(SceneField::Custom) + id);
+}
+
+/**
+@brief Get index of a custom scene field
+@m_since_latest
+
+Inverse to @ref sceneFieldCustom(UnsignedInt). Expects that the field is
+custom.
+@see @ref isSceneFieldCustom()
+*/
+constexpr UnsignedInt sceneFieldCustom(SceneField name) {
+    return CORRADE_CONSTEXPR_ASSERT(isSceneFieldCustom(name),
+        "Trade::sceneFieldCustom():" << name << "is not custom"),
+        UnsignedInt(name) - UnsignedInt(SceneField::Custom);
+}
+
+/**
+@brief Scene field type
+@m_since_latest
+
+A type in which a @ref SceneField is stored. See @ref SceneData for more
+information.
+@see @ref SceneFieldData, @ref sceneFieldTypeSize()
+*/
+enum class SceneFieldType: UnsignedShort {
+    /* Zero used for an invalid value */
+
+    /* 1 reserved for Bool (Bit?), which needs [Strided]BitArray[View] first */
+
+    Float = 2,      /**< @relativeref{Magnum,Float} */
+    Half,           /**< @relativeref{Magnum,Half} */
+    Double,         /**< @relativeref{Magnum,Double} */
+    UnsignedByte,   /**< @relativeref{Magnum,UnsignedByte} */
+    Byte,           /**< @relativeref{Magnum,Byte} */
+    UnsignedShort,  /**< @relativeref{Magnum,UnsignedShort} */
+    Short,          /**< @relativeref{Magnum,Short} */
+    UnsignedInt,    /**< @relativeref{Magnum,UnsignedInt} */
+    Int,            /**< @relativeref{Magnum,Int} */
+    UnsignedLong,   /**< @relativeref{Magnum,UnsignedLong} */
+    Long,           /**< @relativeref{Magnum,Long} */
+
+    Vector2,        /**< @relativeref{Magnum,Vector2} */
+    Vector2h,       /**< @relativeref{Magnum,Vector2h} */
+    Vector2d,       /**< @relativeref{Magnum,Vector2d} */
+    Vector2ub,      /**< @relativeref{Magnum,Vector2ub} */
+    Vector2b,       /**< @relativeref{Magnum,Vector2b} */
+    Vector2us,      /**< @relativeref{Magnum,Vector2us} */
+    Vector2s,       /**< @relativeref{Magnum,Vector2s} */
+    Vector2ui,      /**< @relativeref{Magnum,Vector2ui} */
+    Vector2i,       /**< @relativeref{Magnum,Vector2i} */
+
+    Vector3,        /**< @relativeref{Magnum,Vector3} */
+    Vector3h,       /**< @relativeref{Magnum,Vector3h} */
+    Vector3d,       /**< @relativeref{Magnum,Vector3d} */
+    Vector3ub,      /**< @relativeref{Magnum,Vector3ub} */
+    Vector3b,       /**< @relativeref{Magnum,Vector3b} */
+    Vector3us,      /**< @relativeref{Magnum,Vector3us} */
+    Vector3s,       /**< @relativeref{Magnum,Vector3s} */
+    Vector3ui,      /**< @relativeref{Magnum,Vector3ui} */
+    Vector3i,       /**< @relativeref{Magnum,Vector3i} */
+
+    Vector4,        /**< @relativeref{Magnum,Vector4} */
+    Vector4h,       /**< @relativeref{Magnum,Vector4h} */
+    Vector4d,       /**< @relativeref{Magnum,Vector4d} */
+    Vector4ub,      /**< @relativeref{Magnum,Vector4ub} */
+    Vector4b,       /**< @relativeref{Magnum,Vector4b} */
+    Vector4us,      /**< @relativeref{Magnum,Vector4us} */
+    Vector4s,       /**< @relativeref{Magnum,Vector4s} */
+    Vector4ui,      /**< @relativeref{Magnum,Vector4ui} */
+    Vector4i,       /**< @relativeref{Magnum,Vector4i} */
+
+    Matrix2x2,      /**< @relativeref{Magnum,Matrix2x2} */
+    Matrix2x2h,     /**< @relativeref{Magnum,Matrix2x2h} */
+    Matrix2x2d,     /**< @relativeref{Magnum,Matrix2x2d} */
+
+    Matrix2x3,      /**< @relativeref{Magnum,Matrix2x3} */
+    Matrix2x3h,     /**< @relativeref{Magnum,Matrix2x3h} */
+    Matrix2x3d,     /**< @relativeref{Magnum,Matrix2x3d} */
+
+    Matrix2x4,      /**< @relativeref{Magnum,Matrix2x4} */
+    Matrix2x4h,     /**< @relativeref{Magnum,Matrix2x4h} */
+    Matrix2x4d,     /**< @relativeref{Magnum,Matrix2x4d} */
+
+    Matrix3x2,      /**< @relativeref{Magnum,Matrix3x2} */
+    Matrix3x2h,     /**< @relativeref{Magnum,Matrix3x2h} */
+    Matrix3x2d,     /**< @relativeref{Magnum,Matrix3x2d} */
+
+    Matrix3x3,      /**< @relativeref{Magnum,Matrix3x3} */
+    Matrix3x3h,     /**< @relativeref{Magnum,Matrix3x3h} */
+    Matrix3x3d,     /**< @relativeref{Magnum,Matrix3x3d} */
+
+    Matrix3x4,      /**< @relativeref{Magnum,Matrix3x4} */
+    Matrix3x4h,     /**< @relativeref{Magnum,Matrix3x4h} */
+    Matrix3x4d,     /**< @relativeref{Magnum,Matrix3x4d} */
+
+    Matrix4x2,      /**< @relativeref{Magnum,Matrix4x2} */
+    Matrix4x2h,     /**< @relativeref{Magnum,Matrix4x2h} */
+    Matrix4x2d,     /**< @relativeref{Magnum,Matrix4x2d} */
+
+    Matrix4x3,      /**< @relativeref{Magnum,Matrix4x3} */
+    Matrix4x3h,     /**< @relativeref{Magnum,Matrix4x3h} */
+    Matrix4x3d,     /**< @relativeref{Magnum,Matrix4x3d} */
+
+    Matrix4x4,      /**< @relativeref{Magnum,Matrix4x4} */
+    Matrix4x4h,     /**< @relativeref{Magnum,Matrix4x4h} */
+    Matrix4x4d,     /**< @relativeref{Magnum,Matrix4x4d} */
+
+    Range1D,        /**< @relativeref{Magnum,Range1D} */
+    Range1Dh,       /**< @relativeref{Magnum,Range1Dh} */
+    Range1Dd,       /**< @relativeref{Magnum,Range1Dd} */
+    Range1Di,       /**< @relativeref{Magnum,Range1Di} */
+
+    Range2D,        /**< @relativeref{Magnum,Range2D} */
+    Range2Dh,       /**< @relativeref{Magnum,Range2Dh} */
+    Range2Dd,       /**< @relativeref{Magnum,Range2Dd} */
+    Range2Di,       /**< @relativeref{Magnum,Range2Di} */
+
+    Range3D,        /**< @relativeref{Magnum,Range3D} */
+    Range3Dh,       /**< @relativeref{Magnum,Range3Dh} */
+    Range3Dd,       /**< @relativeref{Magnum,Range3Dd} */
+    Range3Di,       /**< @relativeref{Magnum,Range3Di} */
+
+    Complex,        /**< @relativeref{Magnum,Complex} */
+    Complexd,       /**< @relativeref{Magnum,Complexd} */
+    DualComplex,    /**< @relativeref{Magnum,DualComplex} */
+    DualComplexd,   /**< @relativeref{Magnum,DualComplexd} */
+
+    Quaternion,     /**< @relativeref{Magnum,Quaternion} */
+    Quaterniond,    /**< @relativeref{Magnum,Quaterniond} */
+    DualQuaternion, /**< @relativeref{Magnum,DualQuaternion} */
+    DualQuaterniond,/**< @relativeref{Magnum,DualQuaterniond} */
+
+    Deg,            /**< @relativeref{Magnum,Deg} */
+    Degh,           /**< @relativeref{Magnum,Degh} */
+    Degd,           /**< @relativeref{Magnum,Degh} */
+    Rad,            /**< @relativeref{Magnum,Rad} */
+    Radh,           /**< @relativeref{Magnum,Radh} */
+    Radd            /**< @relativeref{Magnum,Radd} */
+};
+
+/**
+@debugoperatorenum{SceneFieldType}
+@m_since_latest
+*/
+MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneFieldType value);
+
+/**
+@brief Size of given scene field type
+@m_since_latest
+*/
+MAGNUM_TRADE_EXPORT UnsignedInt sceneFieldTypeSize(SceneFieldType type);
+
+/**
+@brief Scene field data
+@m_since_latest
+
+Convenience type for populating @ref SceneData, see its documentation for an
+introduction.
+*/
+class MAGNUM_TRADE_EXPORT SceneFieldData {
+    public:
+        /**
+         * @brief Default constructor
+         *
+         * Leaves contents at unspecified values. Provided as a convenience for
+         * initialization of the field array for @ref SceneData, expected to be
+         * replaced with concrete values later.
+         */
+        constexpr explicit SceneFieldData() noexcept: _size{}, _name{}, _isOffsetOnly{}, _objectType{}, _objectStride{}, _objectData{}, _fieldType{}, _fieldStride{}, _fieldArraySize{}, _fieldData{} {}
+
+        /**
+         * @brief Type-erased constructor
+         * @param name              Field name
+         * @param objectType        Object type
+         * @param objectData        Object data
+         * @param fieldType         Field type
+         * @param fieldData         Field data
+         * @param fieldArraySize    Field array size. Use @cpp 0 @ce for
+         *      non-array fields.
+         *
+         * Expects that @p objectData and @p fieldData have the same size,
+         * @p fieldType corresponds to @p name and @p fieldArraySize is zero
+         * for builtin fields.
+         */
+        constexpr explicit SceneFieldData(SceneField name, SceneObjectType objectType, const Containers::StridedArrayView1D<const void>& objectData, SceneFieldType fieldType, const Containers::StridedArrayView1D<const void>& fieldData, UnsignedShort fieldArraySize = 0) noexcept;
+
+        /**
+         * @brief Constructor
+         * @param name              Field name
+         * @param objectData        Object data
+         * @param fieldType         Field type
+         * @param fieldData         Field data
+         * @param fieldArraySize    Field array size. Use @cpp 0 @ce for
+         *      non-array fields.
+         *
+         * Expects that @p objectData and @p fieldData have the same size in
+         * the first dimension, that the second dimension of @p objectData is
+         * contiguous and its size is either 1, 2, 4 or 8, corresponding to one
+         * of the @ref SceneObjectType values, that the second dimension of
+         * @p fieldData is contiguous and its size matches @p fieldType and
+         * @p fieldArraySize and that @p fieldType corresponds to @p name and
+         * @p fieldArraySize is zero for builtin attributes.
+         */
+        explicit SceneFieldData(SceneField name, const Containers::StridedArrayView2D<const char>& objectData, SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, UnsignedShort fieldArraySize = 0) noexcept;
+
+        /**
+         * @brief Constructor
+         * @param name          Field name
+         * @param objectData    Object data
+         * @param fieldData     Field data
+         *
+         * Detects @ref SceneObjectType based on @p T and @ref SceneFieldType
+         * based on @p U and calls @ref SceneFieldData(SceneField, SceneObjectType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort).
+         * For all types known by Magnum, the detected @ref SceneFieldType is
+         * of the same name as the type (so e.g. @relativeref{Magnum,Vector3ui}
+         * gets recognized as @ref SceneFieldType::Vector3ui).
+         */
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView1D<U>& fieldData) noexcept;
+
+        /** @overload */
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::ArrayView<U>& fieldData) noexcept: SceneFieldData{name, objectData, Containers::stridedArrayView(fieldData)} {}
+
+        /** @overload */
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& objectData, const Containers::StridedArrayView1D<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(objectData), fieldData} {}
+
+        /** @overload */
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& objectData, const Containers::ArrayView<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(objectData), Containers::stridedArrayView(fieldData)} {}
+
+        /**
+         * @brief Construct an array field
+         * @param name          Field name
+         * @param objectData    Object data
+         * @param fieldData     Field data
+         *
+         * Detects @ref SceneObjectType based on @p T and @ref SceneFieldType
+         * based on @p U and calls @ref SceneFieldData(SceneField, SceneObjectType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort)
+         * with the @p fieldData second dimension size passed to
+         * @p fieldArraySize. Expects that the second dimension of @p fieldData
+         * is contiguous. At the moment only custom fields can be arrays, which
+         * means this function can't be used with a builtin @p name. See
+         * @ref SceneFieldData(SceneField, const Containers::StridedArrayView1D<T>&, const Containers::StridedArrayView1D<U>&)
+         * for details about @ref SceneObjectType and @ref SceneFieldType
+         * detection.
+         */
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView2D<U>& fieldData) noexcept;
+
+        /** @overload */
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& objectData, const Containers::StridedArrayView2D<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(objectData), fieldData} {}
+
+        /**
+         * @brief Construct an offset-only field
+         * @param name              Field name
+         * @param size              Number of entries
+         * @param objectType        Object type
+         * @param objectOffset      Object data offset
+         * @param objectStride      Object data stride
+         * @param fieldType         Field type
+         * @param fieldOffset       Field data offset
+         * @param fieldStride       Field data stride
+         * @param fieldArraySize    Field array size. Use @cpp 0 @ce for
+         *      non-array fields.
+         *
+         * Instances created this way refer to offsets in unspecified
+         * external scene data instead of containing the data views directly.
+         * Useful when the location of the scene data array is not known at
+         * field construction time. Expects that @p fieldType corresponds to
+         * @p name and @p fieldArraySize is zero for builtin attributes.
+         *
+         * Note that due to the @cpp constexpr @ce nature of this constructor,
+         * no @p objectType checks against @p objectStride or
+         * @p fieldType / @p fieldArraySize checks against @p fieldStride can
+         * be done. You're encouraged to use the @ref SceneFieldData(SceneField, SceneObjectType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort)
+         * constructor if you want additional safeguards.
+         * @see @ref isOffsetOnly(), @ref fieldArraySize(),
+         *      @ref objectData(Containers::ArrayView<const void>) const,
+         *      @ref fieldData(Containers::ArrayView<const void>) const
+         */
+        explicit constexpr SceneFieldData(SceneField name, std::size_t size, SceneObjectType objectType, std::size_t objectOffset, std::ptrdiff_t objectStride, SceneFieldType fieldType, std::size_t fieldOffset, std::ptrdiff_t fieldStride, UnsignedShort fieldArraySize = 0) noexcept;
+
+        /**
+         * @brief If the field is offset-only
+         *
+         * Returns @cpp true @ce if the field doesn't contain the data views
+         * directly, but instead refers to unspecified external data.
+         * @see @ref objectData(Containers::ArrayView<const void>) const,
+         *      @ref fieldData(Containers::ArrayView<const void>) const,
+         *      @ref SceneFieldData(SceneField, std::size_t, SceneObjectType, std::size_t, std::ptrdiff_t, SceneFieldType, std::size_t, std::ptrdiff_t, UnsignedShort)
+         */
+        constexpr bool isOffsetOnly() const { return _isOffsetOnly; }
+
+        /** @brief Field name */
+        constexpr SceneField name() const { return _name; }
+
+        /** @brief Number of entries */
+        constexpr UnsignedLong size() const { return _size; }
+
+        /** @brief Object type */
+        constexpr SceneObjectType objectType() const { return _objectType; }
+
+        /**
+         * @brief Type-erased object data
+         *
+         * Expects that the field is not offset-only, in that case use the
+         * @ref objectData(Containers::ArrayView<const void>) const overload
+         * instead.
+         * @see @ref isOffsetOnly()
+         */
+        constexpr Containers::StridedArrayView1D<const void> objectData() const {
+            return Containers::StridedArrayView1D<const void>{
+                /* We're *sure* the view is correct, so faking the view size */
+                /** @todo better ideas for the StridedArrayView API? */
+                {_objectData.pointer, ~std::size_t{}}, _size,
+                (CORRADE_CONSTEXPR_ASSERT(!_isOffsetOnly, "Trade::SceneFieldData::objectData(): the field is offset-only, supply a data array"), _objectStride)};
+        }
+
+        /**
+         * @brief Type-erased object data for an offset-only attribute
+         *
+         * If the field is not offset-only, the @p data parameter is ignored.
+         * @see @ref isOffsetOnly(), @ref objectData() const
+         */
+        Containers::StridedArrayView1D<const void> objectData(Containers::ArrayView<const void> data) const {
+            return Containers::StridedArrayView1D<const void>{
+                /* We're *sure* the view is correct, so faking the view size */
+                /** @todo better ideas for the StridedArrayView API? */
+                data, _isOffsetOnly ? reinterpret_cast<const char*>(data.data()) + _objectData.offset : _objectData.pointer, _size, _objectStride};
+        }
+
+        /** @brief Field type */
+        constexpr SceneFieldType fieldType() const { return _fieldType; }
+
+        /** @brief Field array size */
+        constexpr UnsignedShort fieldArraySize() const { return _fieldArraySize; }
+
+        /**
+         * @brief Type-erased field data
+         *
+         * Expects that the field is not offset-only, in that case use the
+         * @ref fieldData(Containers::ArrayView<const void>) const overload
+         * instead.
+         * @see @ref isOffsetOnly()
+         */
+        constexpr Containers::StridedArrayView1D<const void> fieldData() const {
+            return Containers::StridedArrayView1D<const void>{
+                /* We're *sure* the view is correct, so faking the view size */
+                /** @todo better ideas for the StridedArrayView API? */
+                {_fieldData.pointer, ~std::size_t{}}, _size,
+                (CORRADE_CONSTEXPR_ASSERT(!_isOffsetOnly, "Trade::SceneFieldData::fieldData(): the field is offset-only, supply a data array"), _fieldStride)};
+        }
+
+        /**
+         * @brief Type-erased field data for an offset-only attribute
+         *
+         * If the field is not offset-only, the @p data parameter is ignored.
+         * @see @ref isOffsetOnly(), @ref fieldData() const
+         */
+        Containers::StridedArrayView1D<const void> fieldData(Containers::ArrayView<const void> data) const {
+            return Containers::StridedArrayView1D<const void>{
+                /* We're *sure* the view is correct, so faking the view size */
+                /** @todo better ideas for the StridedArrayView API? */
+                data, _isOffsetOnly ? reinterpret_cast<const char*>(data.data()) + _fieldData.offset : _fieldData.pointer, _size, _fieldStride};
+        }
+
+    private:
+        friend SceneData;
+
+        union Data {
+            /* FFS C++ why this doesn't JUST WORK goddamit?! It's already past
+               the End Of Times AND YET this piece of complex shit can't do the
+               obvious! */
+            constexpr Data(const void* pointer = nullptr): pointer{pointer} {}
+            constexpr Data(std::size_t offset): offset{offset} {}
+
+            const void* pointer;
+            std::size_t offset;
+        };
+
+        UnsignedLong _size;
+        SceneField _name;
+        bool _isOffsetOnly;
+        SceneObjectType _objectType;
+        Short _objectStride;
+        Data _objectData;
+
+        SceneFieldType _fieldType;
+        Short _fieldStride;
+        UnsignedShort _fieldArraySize;
+        /* 2 bytes free */
+        Data _fieldData;
+};
+
+/** @relatesalso SceneFieldData
+@brief Create a non-owning array of @ref SceneFieldData items
+@m_since_latest
+
+Useful when you have the field definitions statically defined (for example when
+the data themselves are already defined at compile time) and don't want to
+allocate just to pass those to @ref SceneData.
+*/
+Containers::Array<SceneFieldData> MAGNUM_TRADE_EXPORT sceneFieldDataNonOwningArray(Containers::ArrayView<const SceneFieldData> view);
+
+/**
 @brief Scene data
+
+Contains scene hierarchy, object transformations and association of mesh,
+material, camera, light and other resources with particular objects.
 
 @see @ref AbstractImporter::scene()
 */
 class MAGNUM_TRADE_EXPORT SceneData {
     public:
         /**
-         * @brief Constructor
-         * @param children2D        Two-dimensional child objects
-         * @param children3D        Three-dimensional child objects
-         * @param importerState     Importer-specific state
+         * @brief Construct scene data
+         * @param objectType    Object type
+         * @param objectCount   Total count of all objects in the scene
+         * @param data          Data for all fields and objects
+         * @param fields        Description of all scene field data
+         * @param importerState Importer-specific state
+         * @m_since_latest
+         *
+         * The @p objectType is expected to be large enough to index all
+         * @p objectCount objects. The @p fields are expected to reference
+         * (sparse) sub-ranges of @p data, each having an unique
+         * @ref SceneField and @ref SceneObjectType equal to @p objectType.
+         * Particular fields can have additional restrictions, see
+         * documentation of @ref SceneField values for more information.
+         *
+         * The @ref dataFlags() are implicitly set to a combination of
+         * @ref DataFlag::Owned and @ref DataFlag::Mutable. For non-owned data
+         * use the @ref SceneData(SceneObjectType, UnsignedLong, DataFlags, Containers::ArrayView<const void>, Containers::Array<SceneFieldData>&&, const void*)
+         * constructor or its variants instead.
          */
-        explicit SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* importerState = nullptr);
+        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, Containers::Array<char>&& data, Containers::Array<SceneFieldData>&& fields, const void* importerState = nullptr) noexcept;
+
+        /**
+         * @overload
+         * @m_since_latest
+         */
+        /* Not noexcept because allocation happens inside */
+        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, Containers::Array<char>&& data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
+
+        /**
+         * @brief Construct non-owned scene data
+         * @param objectType    Object type
+         * @param objectCount   Total count of all objects in the scene
+         * @param dataFlags     Data flags
+         * @param data          View on data for all fields and objects
+         * @param fields        Description of all scene field data
+         * @param importerState Importer-specific state
+         * @m_since_latest
+         *
+         * Compared to @ref SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+         * creates an instance that doesn't own the passed data. The
+         * @p dataFlags parameter can contain @ref DataFlag::Mutable to
+         * indicate the external data can be modified, and is expected to *not*
+         * have @ref DataFlag::Owned set.
+         */
+        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, DataFlags dataFlags, Containers::ArrayView<const void> data, Containers::Array<SceneFieldData>&& fields, const void* importerState = nullptr) noexcept;
+
+        /**
+         * @overload
+         * @m_since_latest
+         */
+        /* Not noexcept because allocation happens inside */
+        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, DataFlags dataFlags, Containers::ArrayView<const void> data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
 
         /** @brief Copying is not allowed */
         SceneData(const SceneData&) = delete;
 
         /** @brief Move constructor */
-        SceneData(SceneData&&)
-            /* GCC 4.9.0 (the one from Android NDK) thinks this does not match
-               the implicit signature so it can't be defaulted. Works on 4.8,
-               5.0 and everywhere else, so I don't bother. */
-            #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
-            noexcept
-            #endif
-            ;
+        SceneData(SceneData&&) noexcept;
+
+        ~SceneData();
 
         /** @brief Copying is not allowed */
         SceneData& operator=(const SceneData&) = delete;
 
         /** @brief Move assignment */
-        SceneData& operator=(SceneData&&)
-            /* GCC 4.9.0 (the one from Android NDK) thinks this does not match
-               the implicit signature so it can't be defaulted. Works on 4.8,
-               5.0 and everywhere else, so I don't bother. */
-            #if !defined(__GNUC__) || __GNUC__*100 + __GNUC_MINOR__ != 409
-            noexcept
-            #endif
-            ;
+        SceneData& operator=(SceneData&&) noexcept;
 
-        /** @brief Two-dimensional child objects */
-        const std::vector<UnsignedInt>& children2D() const { return _children2D; }
+        /**
+         * @brief Data flags
+         * @m_since_latest
+         *
+         * @see @ref releaseData(), @ref mutableData(), @ref mutableField(),
+         *      @ref mutableObjects()
+         */
+        DataFlags dataFlags() const { return _dataFlags; }
 
-        /** @brief Three-dimensional child objects */
-        const std::vector<UnsignedInt>& children3D() const { return _children3D; }
+        /**
+         * @brief Raw data
+         * @m_since_latest
+         *
+         * Returns @cpp nullptr @ce if the scene has no data.
+         */
+        Containers::ArrayView<const char> data() const & { return _data; }
+
+        /**
+         * @brief Taking a view to a r-value instance is not allowed
+         * @m_since_latest
+         */
+        Containers::ArrayView<const char> data() const && = delete;
+
+        /**
+         * @brief Mutable raw data
+         * @m_since_latest
+         *
+         * Like @ref data(), but returns a non-const view. Expects that the
+         * scene is mutable.
+         * @see @ref dataFlags()
+         */
+        Containers::ArrayView<char> mutableData() &;
+
+        /**
+         * @brief Taking a view to a r-value instance is not allowed
+         * @m_since_latest
+         */
+        Containers::ArrayView<char> mutableData() && = delete;
+
+        /**
+         * @brief Type used for object mapping
+         * @m_since_latest
+         *
+         * Type returned from @ref objects() and @ref mutableObjects(). It's
+         * the same for all fields and is guaranteed to be large enough to fit
+         * all @ref objectCount() objects.
+         */
+        SceneObjectType objectType() const { return _objectType; }
+
+        /**
+         * @brief Total object count
+         * @m_since_latest
+         *
+         * Total number of objects contained in the scene.
+         * @see @ref fieldCount(), @ref fieldSize()
+         */
+        UnsignedLong objectCount() const { return _objectCount; }
+
+        /**
+         * @brief Field count
+         * @m_since_latest
+         *
+         * Count of different fields contained in the scene, or @cpp 0 @ce for
+         * a scene with no fields. Each @ref SceneField can be present only
+         * once, however an object can have a certain field associated with it
+         * multiple times with different values (for example an object having
+         * multiple meshes). See also @ref objectCount() which returns count of
+         * actual objects.
+         */
+        UnsignedInt fieldCount() const { return _fields.size(); }
+
+        /**
+         * @brief Raw field metadata
+         * @m_since_latest
+         *
+         * Returns the raw data that are used as a base for all `field*()`
+         * accessors, or @cpp nullptr @ce if the scene has no fields. In most
+         * cases you don't want to access those directly, but rather use the
+         * @ref objects(), @ref field(), @ref fieldName(), @ref fieldType(),
+         * @ref fieldSize() and @ref fieldArraySize() accessors. Compared to
+         * those and to @ref fieldData(UnsignedInt) const, the
+         * @ref SceneFieldData instances returned by this function may have
+         * different data pointers, and some of them might be offset-only ---
+         * use this function only if you *really* know what are you doing.
+         * @see @ref SceneFieldData::isOffsetOnly()
+         */
+        Containers::ArrayView<const SceneFieldData> fieldData() const & { return _fields; }
+
+        /**
+         * @brief Taking a view to a r-value instance is not allowed
+         * @m_since_latest
+         */
+        Containers::ArrayView<const SceneFieldData> fieldData() const && = delete;
+
+        /**
+         * @brief Raw field data
+         * @m_since_latest
+         *
+         * Returns the raw data that are used as a base for all `field*()`
+         * accessors. In most cases you don't want to access those directly,
+         * but rather use the @ref objects(), @ref field(), @ref fieldName(),
+         * @ref fieldType(), @ref fieldSize() and @ref fieldArraySize()
+         * accessors. This is also the reason why there's no overload taking a
+         * @ref SceneField, unlike the other accessors.
+         *
+         * Unlike with @ref fieldData() and @ref releaseFieldData(), returned
+         * instances are guaranteed to always have an absolute data pointer
+         * (i.e., @ref SceneFieldData::isOffsetOnly() always returning
+         * @cpp false @ce). The @p id is expected to be smaller than
+         * @ref fieldCount().
+         */
+        SceneFieldData fieldData(UnsignedInt id) const;
+
+        /**
+         * @brief Field name
+         * @m_since_latest
+         *
+         * The @p id is expected to be smaller than @ref fieldCount().
+         * @see @ref fieldType(), @ref isSceneFieldCustom(),
+         *      @ref AbstractImporter::sceneFieldForName(),
+         *      @ref AbstractImporter::sceneFieldName()
+         */
+        SceneField fieldName(UnsignedInt id) const;
+
+        /**
+         * @brief Field type
+         * @m_since_latest
+         *
+         * The @p id is expected to be smaller than @ref fieldCount(). You can
+         * also use @ref fieldType(SceneField) const to directly get a type of
+         * given named field.
+         * @see @ref fieldName(), @ref objectType()
+         */
+        SceneFieldType fieldType(UnsignedInt id) const;
+
+        /**
+         * @brief Size of given field
+         * @m_since_latest
+         *
+         * Size of the view returned by @ref field() / @ref mutableField() and
+         * also @ref objects() / @ref mutableObjects() for given @p id. Since
+         * an object can have multiple entries of the same field (for example
+         * multiple meshes associated with an object), the size doesn't
+         * necessarily match the number of objects having given field.
+         *
+         * The @p id is expected to be smaller than @ref fieldCount(). You can
+         * also use @ref fieldSize(SceneField) const to directly get a size of
+         * given named field.
+         */
+        std::size_t fieldSize(UnsignedInt id) const;
+
+        /**
+         * @brief Field array size
+         * @m_since_latest
+         *
+         * In case given field is an array (the euqivalent of e.g.
+         * @cpp int[30] @ce), returns array size, otherwise returns @cpp 0 @ce.
+         * At the moment only custom fields can be arrays, no builtin
+         * @ref SceneField is an array attribute. Note that this is different
+         * from the count of entries for given field, which is exposed through
+         * @ref fieldSize(). See @ref Trade-SceneData-populating-custom for an
+         * example.
+         *
+         * The @p id is expected to be smaller than @ref fieldCount(). You can
+         * also use @ref fieldArraySize(SceneField) const to directly get a
+         * type of given named field.
+         */
+        UnsignedShort fieldArraySize(UnsignedInt id) const;
+
+        /**
+         * @brief Whether the scene has given field
+         * @m_since_latest
+         */
+        bool hasField(SceneField name) const;
+
+        /**
+         * @brief Absolute ID of a named field
+         * @m_since_latest
+         *
+         * The @p name is expected to exist.
+         * @see @ref hasField(), @ref fieldName(UnsignedInt) const
+         */
+        UnsignedInt fieldId(SceneField name) const;
+
+        /**
+         * @brief Type of a named field
+         * @m_since_latest
+         *
+         * The @p name is expected to exist.
+         * @see @ref hasField(), @ref fieldType(UnsignedInt) const
+         */
+        SceneFieldType fieldType(SceneField name) const;
+
+        /**
+         * @brief Number of entries for given named field
+         * @m_since_latest
+         *
+         * The @p name is expected to exist.
+         * @see @ref hasField(), @ref fieldSize(UnsignedInt) const
+         */
+        std::size_t fieldSize(SceneField name) const;
+
+        /**
+         * @brief Array size of a named field
+         * @m_since_latest
+         *
+         * The @p name is expected to exist.
+         * @see @ref hasField(), @ref fieldArraySize(UnsignedInt) const
+         */
+        UnsignedShort fieldArraySize(SceneField name) const;
+
+        /**
+         * @brief Object mapping data for given field
+         * @m_since_latest
+         *
+         * The @p fieldId is expected to be smaller than @ref fieldCount(). The
+         * second dimension represents the actual data type (its size is equal
+         * to @ref SceneObjectType size) and is guaranteed to be contiguous.
+         * Use the templated overload below to get the objects in a concrete
+         * type.
+         * @see @ref mutableObjects(UnsignedInt),
+         *      @ref Corrade::Containers::StridedArrayView::isContiguous(),
+         *      @ref sceneObjectTypeSize()
+         */
+        Containers::StridedArrayView2D<const char> objects(UnsignedInt fieldId) const;
+
+        /**
+         * @brief Mutable object mapping data for given field
+         * @m_since_latest
+         *
+         * Like @ref objects(UnsignedInt) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        Containers::StridedArrayView2D<char> mutableObjects(UnsignedInt fieldId);
+
+        /**
+         * @brief Object mapping for given field
+         * @m_since_latest
+         *
+         * The @p fieldId is expected to be smaller than @ref fieldCount() and
+         * @p T is expected to correspond to @ref objectType(). You can also
+         * use the non-templated @ref objectsAsArray() accessor to get the
+         * object mapping converted to the usual type, but note that such
+         * operation involves extra allocation and data conversion.
+         * @see @ref mutableObjects(UnsignedInt)
+         */
+        template<class T> Containers::StridedArrayView1D<const T> objects(UnsignedInt fieldId) const;
+
+        /**
+         * @brief Mutable object mapping for given field
+         * @m_since_latest
+         *
+         * Like @ref objects(UnsignedInt) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        template<class T> Containers::StridedArrayView1D<T> mutableObjects(UnsignedInt fieldId);
+
+        /**
+         * @brief Object mapping data for given named field
+         * @m_since_latest
+         *
+         * The @p fieldName is expected to exist. The second dimension
+         * represents the actual data type (its size is equal to
+         * @ref SceneObjectType size) and is guaranteed to be contiguous. Use
+         * the templated overload below to get the objects in a concrete type.
+         * @see @ref hasField(), @ref objects(UnsignedInt) const,
+         *      @ref mutableObjects(SceneField),
+         *      @ref Corrade::Containers::StridedArrayView::isContiguous()
+         */
+        Containers::StridedArrayView2D<const char> objects(SceneField fieldName) const;
+
+        /**
+         * @brief Mutable object mapping data for given named field
+         * @m_since_latest
+         *
+         * Like @ref objects(SceneField) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        Containers::StridedArrayView2D<char> mutableObjects(SceneField fieldName);
+
+        /**
+         * @brief Object mapping for given named field
+         * @m_since_latest
+         *
+         * The @p fieldName is expected to exist and @p T is expected to
+         * correspond to @ref objectType(). You can also use the non-templated
+         * @ref objectsAsArray() accessor to get the object mapping converted
+         * to the usual type, but note that such operation involves extra
+         * allocation and data conversion.
+         * @see @ref hasField(), @ref objects(UnsignedInt) const,
+         *      @ref mutableObjects(UnsignedInt)
+         */
+        template<class T> Containers::StridedArrayView1D<const T> objects(SceneField fieldName) const;
+
+        /**
+         * @brief Mutable object mapping for given named field
+         * @m_since_latest
+         *
+         * Like @ref objects(SceneField) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        template<class T> Containers::StridedArrayView1D<T> mutableObjects(SceneField fieldName);
+
+        /**
+         * @brief Data for given field
+         * @m_since_latest
+         *
+         * The @p id is expected to be smaller than @ref fieldCount(). The
+         * second dimension represents the actual data type (its size is equal
+         * to @ref SceneFieldType size, possibly multiplied by array size) and
+         * is guaranteed to be contiguous. Use the templated overload below to
+         * get the field in a concrete type.
+         * @see @ref Corrade::Containers::StridedArrayView::isContiguous(),
+         *      @ref sceneFieldTypeSize(), @ref mutableField(UnsignedInt)
+         */
+        Containers::StridedArrayView2D<const char> field(UnsignedInt id) const;
+
+        /**
+         * @brief Mutable data for given field
+         * @m_since_latest
+         *
+         * Like @ref field(UnsignedInt) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        Containers::StridedArrayView2D<char> mutableField(UnsignedInt id);
+
+        /**
+         * @brief Data for given field in a concrete type
+         * @m_since_latest
+         *
+         * The @p id is expected to be smaller than @ref fieldCount() and @p T
+         * is expected to correspond to @ref fieldType(UnsignedInt) const. The
+         * field is also expected to not be an array, in that case you need to
+         * use the overload below by using @cpp T[] @ce instead of @cpp T @ce.
+         * You can also use the non-templated @ref parentsAsArray(),
+         * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
+         * @ref meshesAsArray(), @ref meshMaterialsAsArray(),
+         * @ref lightsAsArray(), @ref camerasAsArray(), @ref skinsAsArray()
+         * accessors to get common fields converted to usual types, but note
+         * that these operations involve extra allocation and data conversion.
+         * @see @ref field(SceneField) const, @ref mutableField(UnsignedInt),
+         *      @ref fieldArraySize()
+         */
+        template<class T, class = typename std::enable_if<!std::is_array<T>::value>::type> Containers::StridedArrayView1D<const T> field(UnsignedInt id) const;
+
+        /**
+         * @brief Data for given array field in a concrete type
+         * @m_since_latest
+         *
+         * Same as above, except that it works with array fields instead ---
+         * you're expected to select this overload by passing @cpp T[] @ce
+         * instead of @cpp T @ce. The second dimension is guaranteed to be
+         * contiguous and have the same size as reported by
+         * @ref fieldArraySize(UnsignedInt) const for given field.
+         */
+        template<class T, class = typename std::enable_if<std::is_array<T>::value>::type> Containers::StridedArrayView2D<const typename std::remove_extent<T>::type> field(UnsignedInt id) const;
+
+        /**
+         * @brief Mutable data for given field in a concrete type
+         * @m_since_latest
+         *
+         * Like @ref field(UnsignedInt) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        template<class T, class = typename std::enable_if<!std::is_array<T>::value>::type> Containers::StridedArrayView1D<T> mutableField(UnsignedInt id);
+
+        /**
+         * @brief Mutable data for given array field in a concrete type
+         * @m_since_latest
+         *
+         * Same as above, except that it works with array fields instead ---
+         * you're expected to select this overload by passing @cpp T[] @ce
+         * instead of @cpp T @ce. The second dimension is guaranteed to be
+         * contiguous and have the same size as reported by
+         * @ref fieldArraySize(UnsignedInt) const for given field.
+         */
+        template<class T, class = typename std::enable_if<std::is_array<T>::value>::type> Containers::StridedArrayView2D<typename std::remove_extent<T>::type> mutableField(UnsignedInt id);
+
+        /**
+         * @brief Data for given named field
+         * @m_since_latest
+         *
+         * The @p name is expected to exist. The second dimension represents
+         * the actual data type (its size is equal to @ref SceneFieldType size,
+         * possibly multiplied by array size) and is guaranteed to be
+         * contiguous. Use the templated overload below to get the field in a
+         * concrete type.
+         * @see @ref hasField(), @ref field(UnsignedInt) const,
+         *      @ref mutableField(SceneField),
+         *      @ref Corrade::Containers::StridedArrayView::isContiguous()
+         */
+        Containers::StridedArrayView2D<const char> field(SceneField name) const;
+
+        /**
+         * @brief Mutable data for given named field
+         * @m_since_latest
+         *
+         * Like @ref field(SceneField) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        Containers::StridedArrayView2D<char> mutableField(SceneField name);
+
+        /**
+         * @brief Data for given named field in a concrete type
+         * @m_since_latest
+         *
+         * The @p name is expected to exist and @p T is expected to correspond
+         * to @ref fieldType(SceneField) const. The field is also expected to
+         * not be an array, in that case you need to use the overload below by
+         * using @cpp T[] @ce instead of @cpp T @ce. You can also use the
+         * non-templated @ref parentsAsArray(), @ref transformations2DAsArray(),
+         * @ref transformations3DAsArray(), @ref meshesAsArray(),
+         * @ref meshMaterialsAsArray(), @ref lightsAsArray(),
+         * @ref camerasAsArray(), @ref skinsAsArray() accessors to get common
+         * fields converted to usual types, but note that these operations
+         * involve extra allocation and data conversion.
+         * @see @ref field(UnsignedInt) const, @ref mutableField(SceneField)
+         */
+        template<class T, class = typename std::enable_if<!std::is_array<T>::value>::type> Containers::StridedArrayView1D<const T> field(SceneField name) const;
+
+        /**
+         * @brief Data for given named array field in a concrete type
+         * @m_since_latest
+         *
+         * Same as above, except that it works with array fields instead ---
+         * you're expected to select this overload by passing @cpp T[] @ce
+         * instead of @cpp T @ce. The second dimension is guaranteed to be
+         * contiguous and have the same size as reported by
+         * @ref fieldArraySize(SceneField) const for given field.
+         */
+        template<class T, class = typename std::enable_if<std::is_array<T>::value>::type> Containers::StridedArrayView2D<const typename std::remove_extent<T>::type> field(SceneField name) const;
+
+        /**
+         * @brief Mutable data for given named field
+         * @m_since_latest
+         *
+         * Like @ref field(SceneField) const, but returns a mutable view.
+         * Expects that the scene is mutable.
+         * @see @ref dataFlags()
+         */
+        template<class T, class = typename std::enable_if<!std::is_array<T>::value>::type> Containers::StridedArrayView1D<T> mutableField(SceneField name);
+
+        /**
+         * @brief Mutable data for given named array field in a concrete type
+         * @m_since_latest
+         *
+         * Same as above, except that it works with array fields instead ---
+         * you're expected to select this overload by passing @cpp T[] @ce
+         * instead of @cpp T @ce. The second dimension is guaranteed to be
+         * contiguous and have the same size as reported by
+         * @ref fieldArraySize(SceneField) const for given field.
+         */
+        template<class T, class = typename std::enable_if<std::is_array<T>::value>::type> Containers::StridedArrayView2D<typename std::remove_extent<T>::type> mutableField(SceneField name);
+
+        /**
+         * @brief Object mapping for given field as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to the templated
+         * @ref objects(UnsignedInt) const that converts the field from an
+         * arbitrary underlying type and returns it in a newly-allocated array.
+         * The @p fieldId is expected to be smaller than @ref fieldCount().
+         * @attention In the rare case when @ref objectType() is
+         *      @ref SceneObjectType::UnsignedLong and @ref objectCount() is
+         *      larger than the max representable 32-bit value, this function
+         *      can't be used, only an appropriately typed
+         *      @ref objects(UnsignedInt) const.
+         * @see @ref objectsInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
+         */
+        Containers::Array<UnsignedInt> objectsAsArray(UnsignedInt fieldId) const;
+
+        /**
+         * @brief Object mapping for given field as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref objectsAsArray(UnsignedInt) const, but puts the result
+         * into @p destination instead of allocating a new array. Expects that
+         * @p destination is sized to contain exactly all data.
+         * @see @ref fieldSize(UnsignedInt) const
+         */
+        void objectsInto(UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Object mapping for given named field as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to the templated
+         * @ref objects(SceneField) const that converts the field from an
+         * arbitrary underlying type and returns it in a newly-allocated array.
+         * The @p fieldName is expected to exist.
+         * @attention In the rare case when @ref objectType() is
+         *      @ref SceneObjectType::UnsignedLong and @ref objectCount() is
+         *      larger than the max representable 32-bit value, this function
+         *      can't be used, only an appropriately typed
+         *      @ref objects(SceneField) const.
+         * @see @ref objectsInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const,
+         *      @ref hasField()
+         */
+        Containers::Array<UnsignedInt> objectsAsArray(SceneField fieldName) const;
+
+        /**
+         * @brief Object mapping for given named field as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref objectsAsArray(SceneField) const, but puts the result into
+         * @p destination instead of allocating a new array. Expects that
+         * @p destination is sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void objectsInto(SceneField fieldName, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Parent indices as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Parent as the argument that converts the field from
+         * an arbitrary underlying type and returns it in a newly-allocated
+         * array. The field is expected to exist.
+         * @attention In the rare case when @ref fieldType(SceneField) const is
+         *      @ref SceneFieldType::Long and @ref fieldSize(SceneField) const
+         *      is larger than the max representable 32-bit value, this
+         *      function can't be used, only an appropriately typed
+         *      @ref field(SceneField) const.
+         * @see @ref parentsInto(), @ref hasField()
+         */
+        Containers::Array<Int> parentsAsArray() const;
+
+        /**
+         * @brief Parent indices as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref parentsAsArray(), but puts the result into @p destination
+         * instead of allocating a new array. Expects that @p destination is
+         * sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void parentsInto(const Containers::StridedArrayView1D<Int>& destination) const;
+
+        /**
+         * @brief 2D transformations as 3x3 float matrices
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Transformation as the argument, or, if not present,
+         * to a matrix created out of a subset of the
+         * @ref SceneField::Translation, @ref SceneField::Rotation and
+         * @ref SceneField::Scaling fields that's present. The transformation
+         * is converted and composed from an arbitrary underlying type and
+         * returned in a newly-allocated array. At least one of the fields is
+         * expected to exist and they are expected to have a type corresponding
+         * to 2D, otherwise you're supposed to use
+         * @ref transformations3DAsArray().
+         * @see @ref transformations2DInto(), @ref hasField(),
+         *      @ref fieldType(SceneField) const
+         */
+        Containers::Array<Matrix3> transformations2DAsArray() const;
+
+        /**
+         * @brief 2D transformations as 3x3 float matrices into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref transformations2DAsArray(), but puts the result into
+         * @p destination instead of allocating a new array. Expects that
+         * @p destination is sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void transformations2DInto(const Containers::StridedArrayView1D<Matrix3>& destination) const;
+
+        /**
+         * @brief 3D transformations as 4x4 float matrices
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Transformation as the argument, or, if not present,
+         * to a matrix created out of a subset of the
+         * @ref SceneField::Translation, @ref SceneField::Rotation and
+         * @ref SceneField::Scaling fields that's present. The transformation
+         * is converted and composed from an arbitrary underlying type and
+         * returned in a newly-allocated array. At least one of the fields is
+         * expected to exist and they are expected to have a type corresponding
+         * to 3D, otherwise you're supposed to use
+         * @ref transformations2DAsArray().
+         * @see @ref transformations3DInto(), @ref hasField(),
+         *      @ref fieldType(SceneField) const
+         */
+        Containers::Array<Matrix4> transformations3DAsArray() const;
+
+        /**
+         * @brief 3D transformations as 4x4 float matrices into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref transformations3DAsArray(), but puts the result into
+         * @p destination instead of allocating a new array. Expects that
+         * @p destination is sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void transformations3DInto(const Containers::StridedArrayView1D<Matrix4>& destination) const;
+
+        /**
+         * @brief Mesh IDs as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Mesh as the argument that converts the field from
+         * an arbitrary underlying type and returns it in a newly-allocated
+         * array. The field is expected to exist.
+         * @see @ref meshesInto(), @ref hasField()
+         */
+        Containers::Array<UnsignedInt> meshesAsArray() const;
+
+        /**
+         * @brief Mesh IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref meshesAsArray(), but puts the result into @p destination
+         * instead of allocating a new array. Expects that @p destination is
+         * sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void meshesInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Mesh material IDs as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::MeshMaterial as the argument that converts the
+         * field from an arbitrary underlying type and returns it in a
+         * newly-allocated array. The field is expected to exist.
+         * @see @ref meshMaterialsInto(), @ref hasField()
+         */
+        Containers::Array<UnsignedInt> meshMaterialsAsArray() const;
+
+        /**
+         * @brief Mesh material IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref meshMaterialsAsArray(), but puts the result into
+         * @p destination instead of allocating a new array. Expects that
+         * @p destination is sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Light IDs as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Light as the argument that converts the field from
+         * an arbitrary underlying type and returns it in a newly-allocated
+         * array. The field is expected to exist.
+         * @see @ref lightsInto(), @ref hasField()
+         */
+        Containers::Array<UnsignedInt> lightsAsArray() const;
+
+        /**
+         * @brief Light IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref lightsAsArray(), but puts the result into @p destination
+         * instead of allocating a new array. Expects that @p destination is
+         * sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Camera IDs as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Camera as the argument that converts the field from
+         * an arbitrary underlying type and returns it in a newly-allocated
+         * array. The field is expected to exist.
+         * @see @ref camerasInto(), @ref hasField()
+         */
+        Containers::Array<UnsignedInt> camerasAsArray() const;
+
+        /**
+         * @brief Camera IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref camerasAsArray(), but puts the result into
+         * @p destination instead of allocating a new array. Expects that
+         * @p destination is sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Skin IDs as 32-bit integers
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Skin as the argument that converts the field from
+         * an arbitrary underlying type and returns it in a newly-allocated
+         * array. The field is expected to exist.
+         * @see @ref skinsInto(), @ref hasField()
+         */
+        Containers::Array<UnsignedInt> skinsAsArray() const;
+
+        /**
+         * @brief Skin IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref skinsAsArray(), but puts the result into @p destination
+         * instead of allocating a new array. Expects that @p destination is
+         * sized to contain exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Release field data storage
+         * @m_since_latest
+         *
+         * Releases the ownership of the field data array and resets internal
+         * field-related state to default. The scene then behaves like if it
+         * has no fields (but it can still have non-empty data). Note that the
+         * returned array has a custom no-op deleter when the data are not
+         * owned by the scene, and while the returned array type is mutable,
+         * the actual memory might be not. Additionally, the returned
+         * @ref SceneFieldData instances may have different data pointers and
+         * sizes than what's returned by the @ref field() and
+         * @ref fieldData(UnsignedInt) const accessors as some of them might be
+         * offset-only --- use this function only if you *really* know what are
+         * you doing.
+         * @see @ref fieldData(), @ref SceneFieldData::isOffsetOnly()
+         */
+        Containers::Array<SceneFieldData> releaseFieldData();
+
+        /**
+         * @brief Release data storage
+         * @m_since_latest
+         *
+         * Releases the ownership of the data array and resets internal
+         * field-related state to default. The scene then behaves like it has
+         * no fields and no data. If you want to release field data as well,
+         * first call @ref releaseFieldData() and then this function.
+         *
+         * Note that the returned array has a custom no-op deleter when the
+         * data are not owned by the scene, and while the returned array type
+         * is mutable, the actual memory might be not.
+         * @see @ref data(), @ref dataFlags()
+         */
+        Containers::Array<char> releaseData();
 
         /**
          * @brief Importer-specific state
@@ -91,10 +1537,396 @@ class MAGNUM_TRADE_EXPORT SceneData {
         const void* importerState() const { return _importerState; }
 
     private:
-        std::vector<UnsignedInt> _children2D,
-            _children3D;
+        /* Internal helper that doesn't assert, unlike fieldId() */
+        UnsignedInt fieldFor(SceneField name) const;
+
+        /* Like objects() / field(), but returning just a 1D view */
+        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataObjectViewInternal(const SceneFieldData& field) const;
+        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataFieldViewInternal(const SceneFieldData& field) const;
+
+        #ifndef CORRADE_NO_ASSERT
+        template<class T> bool checkFieldTypeCompatibility(const SceneFieldData& attribute, const char* prefix) const;
+        #endif
+
+        MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
+        MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix3>& destination) const;
+        MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(
+            #ifndef CORRADE_NO_ASSERT
+            const char* const prefix,
+            #endif
+            const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> indexFieldAsArrayInternal(
+            #ifndef CORRADE_NO_ASSERT
+            const char* const prefix,
+            #endif
+            const SceneField name) const;
+
+        DataFlags _dataFlags;
+        SceneObjectType _objectType;
+        /* 2/6 bytes free */
+        UnsignedLong _objectCount;
         const void* _importerState;
+        Containers::Array<SceneFieldData> _fields;
+        Containers::Array<char> _data;
 };
+
+namespace Implementation {
+    /* Making this a struct because there can't be partial specializations for
+       a function (which we may need for pointers, matrix/vector subclasses
+       etc) */
+    template<class T> struct SceneFieldTypeFor {
+        static_assert(sizeof(T) == 0, "unsupported field type");
+    };
+    #ifndef DOXYGEN_GENERATING_OUTPUT
+    #define _c(type_) template<> struct SceneFieldTypeFor<type_> {          \
+        constexpr static SceneFieldType type() {                            \
+            return SceneFieldType::type_;                                   \
+        }                                                                   \
+    };
+    /* Bool needs a special type */
+    _c(Float)
+    _c(Half)
+    _c(Double)
+    _c(UnsignedByte)
+    _c(Byte)
+    _c(UnsignedShort)
+    _c(Short)
+    _c(UnsignedInt)
+    _c(Int)
+    _c(UnsignedLong)
+    _c(Long)
+    _c(Vector2)
+    _c(Vector2h)
+    _c(Vector2d)
+    _c(Vector2ub)
+    _c(Vector2b)
+    _c(Vector2us)
+    _c(Vector2s)
+    _c(Vector2ui)
+    _c(Vector2i)
+    _c(Vector3)
+    _c(Vector3h)
+    _c(Vector3d)
+    _c(Vector3ub)
+    _c(Vector3b)
+    _c(Vector3us)
+    _c(Vector3s)
+    _c(Vector3ui)
+    _c(Vector3i)
+    _c(Vector4)
+    _c(Vector4h)
+    _c(Vector4d)
+    _c(Vector4ub)
+    _c(Vector4b)
+    _c(Vector4us)
+    _c(Vector4s)
+    _c(Vector4ui)
+    _c(Vector4i)
+    _c(Matrix2x2)
+    _c(Matrix2x2h)
+    _c(Matrix2x2d)
+    _c(Matrix2x3)
+    _c(Matrix2x3h)
+    _c(Matrix2x3d)
+    _c(Matrix2x4)
+    _c(Matrix2x4h)
+    _c(Matrix2x4d)
+    _c(Matrix3x2)
+    _c(Matrix3x2h)
+    _c(Matrix3x2d)
+    _c(Matrix3x3)
+    _c(Matrix3x3h)
+    _c(Matrix3x3d)
+    _c(Matrix3x4)
+    _c(Matrix3x4h)
+    _c(Matrix3x4d)
+    _c(Matrix4x2)
+    _c(Matrix4x2h)
+    _c(Matrix4x2d)
+    _c(Matrix4x3)
+    _c(Matrix4x3h)
+    _c(Matrix4x3d)
+    _c(Matrix4x4)
+    _c(Matrix4x4h)
+    _c(Matrix4x4d)
+    _c(Range1D)
+    _c(Range1Dh)
+    _c(Range1Dd)
+    _c(Range1Di)
+    _c(Range2D)
+    _c(Range2Dh)
+    _c(Range2Dd)
+    _c(Range2Di)
+    _c(Range3D)
+    _c(Range3Dh)
+    _c(Range3Dd)
+    _c(Range3Di)
+    _c(Complex)
+    _c(Complexd)
+    _c(DualComplex)
+    _c(DualComplexd)
+    _c(Quaternion)
+    _c(Quaterniond)
+    _c(DualQuaternion)
+    _c(DualQuaterniond)
+    _c(Deg)
+    _c(Degh)
+    _c(Degd)
+    _c(Rad)
+    _c(Radh)
+    _c(Radd)
+    #undef _c
+    #endif
+    /** @todo this doesn't handle RectangleMatrix<size, size, T> and Vector<size, T> at the moment, do we need those? */
+    template<class T> struct SceneFieldTypeFor<Math::Color3<T>>: SceneFieldTypeFor<Math::Vector3<T>> {};
+    template<class T> struct SceneFieldTypeFor<Math::Color4<T>>: SceneFieldTypeFor<Math::Vector4<T>> {};
+    template<class T> struct SceneFieldTypeFor<Math::Matrix3<T>>: SceneFieldTypeFor<Math::Matrix3x3<T>> {};
+    template<class T> struct SceneFieldTypeFor<Math::Matrix4<T>>: SceneFieldTypeFor<Math::Matrix4x4<T>> {};
+
+    template<class T> constexpr SceneObjectType sceneObjectTypeFor() {
+        static_assert(sizeof(T) == 0, "unsupported object type");
+        return {};
+    }
+    #ifndef DOXYGEN_GENERATING_OUTPUT
+    #define _c(type) \
+        template<> constexpr SceneObjectType sceneObjectTypeFor<type>() { return SceneObjectType::type; }
+    _c(UnsignedByte)
+    _c(UnsignedShort)
+    _c(UnsignedInt)
+    _c(UnsignedLong)
+    #undef _c
+    #endif
+
+    constexpr bool isSceneFieldTypeCompatibleWithField(SceneField name, SceneFieldType type) {
+        return
+            /* Named fields are restricted so we can decode them */
+            (name == SceneField::Parent &&
+                (type == SceneFieldType::Byte ||
+                 type == SceneFieldType::Short ||
+                 type == SceneFieldType::Int ||
+                 type == SceneFieldType::Long)) ||
+            (name == SceneField::Transformation &&
+                (type == SceneFieldType::Matrix3x3 ||
+                 type == SceneFieldType::Matrix3x3d ||
+                 type == SceneFieldType::Matrix4x4 ||
+                 type == SceneFieldType::Matrix4x4d ||
+                 type == SceneFieldType::DualComplex ||
+                 type == SceneFieldType::DualComplexd ||
+                 type == SceneFieldType::DualQuaternion ||
+                 type == SceneFieldType::DualQuaterniond)) ||
+           ((name == SceneField::Translation ||
+             name == SceneField::Scaling) &&
+                (type == SceneFieldType::Vector2 ||
+                 type == SceneFieldType::Vector2d ||
+                 type == SceneFieldType::Vector3 ||
+                 type == SceneFieldType::Vector3d)) ||
+            (name == SceneField::Rotation &&
+                (type == SceneFieldType::Complex ||
+                 type == SceneFieldType::Complexd ||
+                 type == SceneFieldType::Quaternion ||
+                 type == SceneFieldType::Quaterniond)) ||
+           ((name == SceneField::Mesh ||
+             name == SceneField::MeshMaterial ||
+             name == SceneField::Light ||
+             name == SceneField::Camera ||
+             name == SceneField::Skin) &&
+                (type == SceneFieldType::UnsignedByte ||
+                 type == SceneFieldType::UnsignedShort ||
+                 type == SceneFieldType::UnsignedInt)) ||
+            /* Custom fields can be anything */
+            isSceneFieldCustom(name);
+    }
+
+    constexpr bool isSceneFieldArrayAllowed(SceneField name) {
+        return isSceneFieldCustom(name);
+    }
+}
+
+constexpr SceneFieldData::SceneFieldData(const SceneField name, const SceneObjectType objectType, const Containers::StridedArrayView1D<const void>& objectData, const SceneFieldType fieldType, const Containers::StridedArrayView1D<const void>& fieldData, const UnsignedShort fieldArraySize) noexcept:
+    _size{(CORRADE_CONSTEXPR_ASSERT(objectData.size() == fieldData.size(),
+        "Trade::SceneFieldData: expected object and field view to have the same size but got" << objectData.size() << "and" << fieldData.size()), objectData.size())},
+    _name{(CORRADE_CONSTEXPR_ASSERT(Implementation::isSceneFieldTypeCompatibleWithField(name, fieldType),
+        "Trade::SceneFieldData:" << fieldType << "is not a valid type for" << name), name)},
+    _isOffsetOnly{false},
+    _objectType{objectType},
+    _objectStride{(CORRADE_CONSTEXPR_ASSERT(objectData.stride() >= -32768 && objectData.stride() <= 32767,
+        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got" << objectData.stride()), Short(objectData.stride()))},
+    _objectData{objectData.data()},
+    _fieldType{fieldType},
+    _fieldStride{(CORRADE_CONSTEXPR_ASSERT(fieldData.stride() >= -32768 && fieldData.stride() <= 32767,
+        "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got" << fieldData.stride()), Short(fieldData.stride()))},
+    _fieldArraySize{(CORRADE_CONSTEXPR_ASSERT(!fieldArraySize || Implementation::isSceneFieldArrayAllowed(name),
+        "Trade::SceneFieldData:" << name << "can't be an array field"), fieldArraySize)},
+    _fieldData{fieldData.data()} {}
+
+template<class T, class U> constexpr SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView1D<U>& fieldData) noexcept: SceneFieldData{name, Implementation::sceneObjectTypeFor<typename std::remove_const<T>::type>(), objectData, Implementation::SceneFieldTypeFor<typename std::remove_const<U>::type>::type(), fieldData, 0} {}
+
+template<class T, class U> constexpr SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView2D<U>& fieldData) noexcept: SceneFieldData{
+    name,
+    Implementation::sceneObjectTypeFor<typename std::remove_const<T>::type>(),
+    objectData,
+    Implementation::SceneFieldTypeFor<typename std::remove_const<U>::type>::type(),
+    Containers::StridedArrayView1D<const void>{{fieldData.data(), ~std::size_t{}}, fieldData.size()[0], fieldData.stride()[0]},
+    /* Not using isContiguous<1>() as that's not constexpr */
+    (CORRADE_CONSTEXPR_ASSERT(fieldData.stride()[1] == sizeof(U), "Trade::SceneFieldData: second field view dimension is not contiguous"), UnsignedShort(fieldData.size()[1]))
+} {}
+
+constexpr SceneFieldData::SceneFieldData(const SceneField name, const std::size_t size, const SceneObjectType objectType, const std::size_t objectOffset, const std::ptrdiff_t objectStride, const SceneFieldType fieldType, const std::size_t fieldOffset, const std::ptrdiff_t fieldStride, const UnsignedShort fieldArraySize) noexcept:
+    _size{size},
+    _name{(CORRADE_CONSTEXPR_ASSERT(Implementation::isSceneFieldTypeCompatibleWithField(name, fieldType),
+        "Trade::SceneFieldData:" << fieldType << "is not a valid type for" << name), name)},
+    _isOffsetOnly{true},
+    _objectType{objectType},
+    _objectStride{(CORRADE_CONSTEXPR_ASSERT(objectStride >= -32768 && objectStride <= 32767,
+        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got" << objectStride), Short(objectStride))},
+    _objectData{objectOffset},
+    _fieldType{fieldType},
+    _fieldStride{(CORRADE_CONSTEXPR_ASSERT(fieldStride >= -32768 && fieldStride <= 32767,
+        "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got" << fieldStride), Short(fieldStride))},
+    _fieldArraySize{(CORRADE_CONSTEXPR_ASSERT(!fieldArraySize || Implementation::isSceneFieldArrayAllowed(name),
+        "Trade::SceneFieldData:" << name << "can't be an array field"), fieldArraySize)},
+    _fieldData{fieldOffset} {}
+
+template<class T> Containers::StridedArrayView1D<const T> SceneData::objects(const UnsignedInt fieldId) const {
+    Containers::StridedArrayView2D<const char> data = objects(fieldId);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
+        "Trade::SceneData::objects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    return Containers::arrayCast<1, const T>(data);
+}
+
+template<class T> Containers::StridedArrayView1D<T> SceneData::mutableObjects(const UnsignedInt fieldId) {
+    Containers::StridedArrayView2D<char> data = mutableObjects(fieldId);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
+        "Trade::SceneData::mutableObjects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    return Containers::arrayCast<1, T>(data);
+}
+
+template<class T> Containers::StridedArrayView1D<const T> SceneData::objects(const SceneField fieldName) const {
+    Containers::StridedArrayView2D<const char> data = objects(fieldName);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
+        "Trade::SceneData::objects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    return Containers::arrayCast<1, const T>(data);
+}
+
+template<class T> Containers::StridedArrayView1D<T> SceneData::mutableObjects(const SceneField fieldName) {
+    Containers::StridedArrayView2D<char> data = mutableObjects(fieldName);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
+        "Trade::SceneData::mutableObjects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    return Containers::arrayCast<1, T>(data);
+}
+
+#ifndef CORRADE_NO_ASSERT
+template<class T> bool SceneData::checkFieldTypeCompatibility(const SceneFieldData& field, const char* const prefix) const {
+    CORRADE_ASSERT(Implementation::SceneFieldTypeFor<typename std::remove_extent<T>::type>::type() == field._fieldType,
+        prefix << field._name << "is" << field._fieldType << "but requested a type equivalent to" << Implementation::SceneFieldTypeFor<typename std::remove_extent<T>::type>::type(), false);
+    if(field._fieldArraySize) CORRADE_ASSERT(std::is_array<T>::value,
+        prefix << field._name << "is an array field, use T[] to access it", false);
+    else CORRADE_ASSERT(!std::is_array<T>::value,
+        prefix << field._name << "is not an array field, can't use T[] to access it", false);
+    return true;
+}
+#endif
+
+template<class T, class> Containers::StridedArrayView1D<const T> SceneData::field(const UnsignedInt id) const {
+    Containers::StridedArrayView2D<const char> data = field(id);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[id], "Trade::SceneData::field():")) return {};
+    #endif
+    return Containers::arrayCast<1, const T>(data);
+}
+
+template<class T, class> Containers::StridedArrayView2D<const typename std::remove_extent<T>::type> SceneData::field(const UnsignedInt id) const {
+    Containers::StridedArrayView2D<const char> data = field(id);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[id], "Trade::SceneData::field():")) return {};
+    #endif
+    return Containers::arrayCast<2, const typename std::remove_extent<T>::type>(data);
+}
+
+template<class T, class> Containers::StridedArrayView1D<T> SceneData::mutableField(const UnsignedInt id) {
+    Containers::StridedArrayView2D<char> data = mutableField(id);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[id], "Trade::SceneData::mutableField():")) return {};
+    #endif
+    return Containers::arrayCast<1, T>(data);
+}
+
+template<class T, class> Containers::StridedArrayView2D<typename std::remove_extent<T>::type> SceneData::mutableField(const UnsignedInt id) {
+    Containers::StridedArrayView2D<char> data = mutableField(id);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[id], "Trade::SceneData::mutableField():")) return {};
+    #endif
+    return Containers::arrayCast<2, typename std::remove_extent<T>::type>(data);
+}
+
+template<class T, class> Containers::StridedArrayView1D<const T> SceneData::field(const SceneField name) const {
+    Containers::StridedArrayView2D<const char> data = field(name);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::field():")) return {};
+    #endif
+    return Containers::arrayCast<1, const T>(data);
+}
+
+template<class T, class> Containers::StridedArrayView2D<const typename std::remove_extent<T>::type> SceneData::field(const SceneField name) const {
+    Containers::StridedArrayView2D<const char> data = field(name);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::field():")) return {};
+    #endif
+    return Containers::arrayCast<2, const typename std::remove_extent<T>::type>(data);
+}
+
+template<class T, class> Containers::StridedArrayView1D<T> SceneData::mutableField(const SceneField name) {
+    Containers::StridedArrayView2D<char> data = mutableField(name);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::mutableField():")) return {};
+    #endif
+    return Containers::arrayCast<1, T>(data);
+}
+
+template<class T, class> Containers::StridedArrayView2D<typename std::remove_extent<T>::type> SceneData::mutableField(const SceneField name) {
+    Containers::StridedArrayView2D<char> data = mutableField(name);
+    #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
+    if(!data.stride()[1]) return {};
+    #endif
+    #ifndef CORRADE_NO_ASSERT
+    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::mutableField():")) return {};
+    #endif
+    return Containers::arrayCast<2, typename std::remove_extent<T>::type>(data);
+}
 
 }}
 

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -1265,6 +1265,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
         void objectsInto(UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
+         * @brief A subrange of object mapping for given field as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref objectsInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the object mapping defined by @p offset
+         * and size of the @p destination view, returning the count of items
+         * actually extracted. The @p offset is expected to not be larger than
+         * the field size.
+         * @see @ref fieldSize(UnsignedInt) const
+         */
+        std::size_t objectsInto(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
          * @brief Object mapping for given named field as 32-bit integers
          * @m_since_latest
          *
@@ -1294,6 +1307,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
         void objectsInto(SceneField fieldName, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
+         * @brief A subrange of object mapping for given named field as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref objectsInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the object mapping defined by @p offset
+         * and size of the @p destination view, returning the count of items
+         * actually extracted. The @p offset is expected to not be larger than
+         * the field size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t objectsInto(SceneField fieldName, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
          * @brief Parent indices as 32-bit integers
          * @m_since_latest
          *
@@ -1320,6 +1346,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const
          */
         void parentsInto(const Containers::StridedArrayView1D<Int>& destination) const;
+
+        /**
+         * @brief A subrange of parent indices as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref parentsInto(const Containers::StridedArrayView1D<Int>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t parentsInto(std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
 
         /**
          * @brief 2D transformations as 3x3 float matrices
@@ -1352,6 +1391,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
         void transformations2DInto(const Containers::StridedArrayView1D<Matrix3>& destination) const;
 
         /**
+         * @brief A subrange of 2D transformations as 3x3 float matrices into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref transformations2DInto(const Containers::StridedArrayView1D<Matrix3>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
+
+        /**
          * @brief 3D transformations as 4x4 float matrices
          * @m_since_latest
          *
@@ -1382,6 +1434,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
         void transformations3DInto(const Containers::StridedArrayView1D<Matrix4>& destination) const;
 
         /**
+         * @brief A subrange of 3D transformations as 4x4 float matrices into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref transformations3DInto(const Containers::StridedArrayView1D<Matrix4>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+
+        /**
          * @brief Mesh IDs as 32-bit integers
          * @m_since_latest
          *
@@ -1403,6 +1468,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const
          */
         void meshesInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief A subrange of mesh IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref meshesInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t meshesInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief Mesh material IDs as 32-bit integers
@@ -1428,6 +1506,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
         void meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
+         * @brief A subrange of mesh material IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref meshMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t meshMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
          * @brief Light IDs as 32-bit integers
          * @m_since_latest
          *
@@ -1449,6 +1540,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const
          */
         void lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief A subrange of light IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref lightsInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t lightsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief Camera IDs as 32-bit integers
@@ -1474,6 +1578,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
         void camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
+         * @brief A subrange of camera IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref camerasInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t camerasInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
          * @brief Skin IDs as 32-bit integers
          * @m_since_latest
          *
@@ -1495,6 +1612,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const
          */
         void skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief A subrange of skin IDs as 32-bit integers into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref skinsInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the @p destination view, returning the count of items actually
+         * extracted. The @p offset is expected to not be larger than the field
+         * size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief Release field data storage
@@ -1542,28 +1672,25 @@ class MAGNUM_TRADE_EXPORT SceneData {
         /* Internal helper that doesn't assert, unlike fieldId() */
         UnsignedInt fieldFor(SceneField name) const;
 
-        /* Like objects() / field(), but returning just a 1D view */
+        /* Like objects() / field(), but returning just a 1D view, sliced from
+           offset to offset + size. The parameterless overloads are equal to
+           offset = 0 and size = field.size(). */
+        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataObjectViewInternal(const SceneFieldData& field, std::size_t offset, std::size_t size) const;
         MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataObjectViewInternal(const SceneFieldData& field) const;
+        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataFieldViewInternal(const SceneFieldData& field, std::size_t offset, std::size_t size) const;
         MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataFieldViewInternal(const SceneFieldData& field) const;
 
         #ifndef CORRADE_NO_ASSERT
         template<class T> bool checkFieldTypeCompatibility(const SceneFieldData& attribute, const char* prefix) const;
         #endif
 
-        MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, const Containers::StridedArrayView1D<Int>& destination) const;
+        MAGNUM_TRADE_LOCAL void objectsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
         MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
-        MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix3>& destination) const;
-        MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix4>& destination) const;
-        MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(
-            #ifndef CORRADE_NO_ASSERT
-            const char* const prefix,
-            #endif
-            const UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
-        MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> indexFieldAsArrayInternal(
-            #ifndef CORRADE_NO_ASSERT
-            const char* const prefix,
-            #endif
-            const SceneField name) const;
+        MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
+        MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> indexFieldAsArrayInternal(const UnsignedInt fieldId) const;
 
         DataFlags _dataFlags;
         SceneObjectType _objectType;

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -26,7 +26,7 @@
 */
 
 /** @file
- * @brief Class @ref Magnum::Trade::SceneData, @ref Magnum::Trade::SceneFieldData, enum @ref Magnum::Trade::SceneObjectType, @ref Magnum::Trade::SceneField, @ref Magnum::Trade::SceneFieldType, function @ref Magnum::sceneObjectTypeSize(), @ref Magnum::sceneFieldTypeSize(), @ref Magnum::Trade::isSceneFieldCustom(), @ref Magnum::sceneFieldCustom()
+ * @brief Class @ref Magnum::Trade::SceneData, @ref Magnum::Trade::SceneFieldData, enum @ref Magnum::Trade::SceneObjectType, @ref Magnum::Trade::SceneField, @ref Magnum::Trade::SceneFieldType, function @ref Magnum::sceneObjectTypeSize(), @ref Magnum::sceneObjectTypeAlignment(), @ref Magnum::sceneFieldTypeSize(), @ref Magnum::sceneFieldTypeAlignment(), @ref Magnum::Trade::isSceneFieldCustom(), @ref Magnum::sceneFieldCustom()
  */
 
 #include <Corrade/Containers/Array.h>
@@ -51,7 +51,8 @@ Type used for mapping fields to corresponding objects. Unlike
 @ref SceneFieldType that is different for different fields, the object type is
 the same for all fields, and is guaranteed to be large enough to fit all
 @ref SceneData::objectCount() objects.
-@see @ref SceneData::objectType(), @ref sceneObjectTypeSize()
+@see @ref SceneData::objectType(), @ref sceneObjectTypeSize(),
+    @ref sceneObjectTypeAlignment()
 */
 enum class SceneObjectType: UnsignedByte {
     /* Zero used for an invalid value */
@@ -80,8 +81,18 @@ MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneObjectType value);
 /**
 @brief Size of given scene object type
 @m_since_latest
+
+@see @ref sceneObjectTypeAlignment()
 */
 MAGNUM_TRADE_EXPORT UnsignedInt sceneObjectTypeSize(SceneObjectType type);
+
+/**
+@brief Alignment of given scene object type
+@m_since_latest
+
+Returns the same value as @ref sceneObjectTypeSize().
+*/
+MAGNUM_TRADE_EXPORT UnsignedInt sceneObjectTypeAlignment(SceneObjectType type);
 
 /**
 @brief Scene field name
@@ -368,7 +379,8 @@ constexpr UnsignedInt sceneFieldCustom(SceneField name) {
 
 A type in which a @ref SceneField is stored. See @ref SceneData for more
 information.
-@see @ref SceneFieldData, @ref sceneFieldTypeSize()
+@see @ref SceneFieldData, @ref sceneFieldTypeSize(),
+    @ref sceneFieldTypeAlignment()
 */
 enum class SceneFieldType: UnsignedShort {
     /* Zero used for an invalid value */
@@ -509,8 +521,18 @@ MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneFieldType value);
 /**
 @brief Size of given scene field type
 @m_since_latest
+
+@see @ref sceneFieldTypeAlignment()
 */
 MAGNUM_TRADE_EXPORT UnsignedInt sceneFieldTypeSize(SceneFieldType type);
+
+/**
+@brief Alignment of given scene field type
+@m_since_latest
+
+@see @ref sceneFieldTypeSize()
+*/
+MAGNUM_TRADE_EXPORT UnsignedInt sceneFieldTypeAlignment(SceneFieldType type);
 
 /**
 @brief Scene field data

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -148,7 +148,9 @@ enum class SceneField: UnsignedInt {
      * or be provided just for a subset of it --- see its documentation for
      * details.
      * @see @ref SceneData::transformations2DAsArray(),
-     *      @ref SceneData::transformations3DAsArray()
+     *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::translationsRotationsScalings2DAsArray(),
+     *      @ref SceneData::translationsRotationsScalings3DAsArray()
      */
     Translation,
 
@@ -167,7 +169,9 @@ enum class SceneField: UnsignedInt {
      * or be provided just for a subset of it --- see its documentation for
      * details.
      * @see @ref SceneData::transformations2DAsArray(),
-     *      @ref SceneData::transformations3DAsArray()
+     *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::translationsRotationsScalings2DAsArray(),
+     *      @ref SceneData::translationsRotationsScalings3DAsArray()
      */
     Rotation,
 
@@ -186,7 +190,9 @@ enum class SceneField: UnsignedInt {
      * or be provided just for a subset of it --- see its documentation for
      * details.
      * @see @ref SceneData::transformations2DAsArray(),
-     *      @ref SceneData::transformations3DAsArray()
+     *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::translationsRotationsScalings2DAsArray(),
+     *      @ref SceneData::translationsRotationsScalings3DAsArray()
      */
     Scaling,
 
@@ -1116,6 +1122,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * use the overload below by using @cpp T[] @ce instead of @cpp T @ce.
          * You can also use the non-templated @ref parentsAsArray(),
          * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
+         * @ref translationsRotationsScalings2DAsArray(),
+         * @ref translationsRotationsScalings3DAsArray(),
          * @ref meshesMaterialsAsArray(), @ref lightsAsArray(),
          * @ref camerasAsArray(), @ref skinsAsArray() accessors to get common
          * fields converted to usual types, but note that these operations
@@ -1192,11 +1200,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * to @ref fieldType(SceneField) const. The field is also expected to
          * not be an array, in that case you need to use the overload below by
          * using @cpp T[] @ce instead of @cpp T @ce. You can also use the
-         * non-templated @ref parentsAsArray(), @ref transformations2DAsArray(),
-         * @ref transformations3DAsArray(), @ref meshesMaterialsAsArray(),
-         * @ref lightsAsArray(), @ref camerasAsArray(), @ref skinsAsArray()
-         * accessors to get common fields converted to usual types, but note
-         * that these operations involve extra allocation and data conversion.
+         * non-templated @ref parentsAsArray(),
+         * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
+         * @ref translationsRotationsScalings2DAsArray(),
+         * @ref translationsRotationsScalings3DAsArray(),
+         * @ref meshesMaterialsAsArray(), @ref lightsAsArray(),
+         * @ref camerasAsArray(), @ref skinsAsArray() accessors to get common
+         * fields converted to usual types, but note that these operations
+         * involve extra allocation and data conversion.
          * @see @ref field(UnsignedInt) const, @ref mutableField(SceneField)
          */
         template<class T, class = typename std::enable_if<!std::is_array<T>::value>::type> Containers::StridedArrayView1D<const T> field(SceneField name) const;
@@ -1403,6 +1414,54 @@ class MAGNUM_TRADE_EXPORT SceneData {
         std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
 
         /**
+         * @brief 2D transformations as float translation, rotation and scaling components
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Translation, @ref SceneField::Rotation and
+         * @ref SceneField::Scaling as the arguments, as these are required to
+         * share the same object mapping. Converts the fields from an arbitrary
+         * underlying type and returns them in a newly-allocated array. At
+         * least one of the fields is expected to exist and they are expected
+         * to have a type corresponding to 2D, otherwise you're supposed to use
+         * @ref translationsRotationsScalings3DAsArray(). If the
+         * @ref SceneField::Translation field isn't present, the first returned
+         * value is a zero vector. If the @relativeref{SceneField,Rotation}
+         * field isn't present, the second value is an identity rotation. If
+         * the @relativeref{SceneField,Scaling} field isn't present, the third
+         * value is an identity scaling (@cpp 1.0f @ce in both dimensions).
+         * @see @ref translationsRotationsScalings2DInto(), @ref hasField(),
+         *      @ref fieldType(SceneField) const
+         */
+        Containers::Array<Containers::Triple<Vector2, Complex, Vector2>> translationsRotationsScalings2DAsArray() const;
+
+        /**
+         * @brief 2D transformations as float translation, rotation and scaling components into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref translationsRotationsScalings2DAsArray(), but puts the
+         * result into @p translationDestination, @p rotationDestination and
+         * @p scalingDestination instead of allocating a new array. Expects
+         * that each view is either @cpp nullptr @ce or sized to contain
+         * exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
+
+        /**
+         * @brief A subrange of 2D transformations as float translation, rotation and scaling components into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<Vector2>&, const Containers::StridedArrayView1D<Complex>&, const Containers::StridedArrayView1D<Vector2>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t translationsRotationsScalings2DInto(std::size_t offset, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
+
+        /**
          * @brief 3D transformations as 4x4 float matrices
          * @m_since_latest
          *
@@ -1444,6 +1503,54 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const
          */
         std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+
+        /**
+         * @brief 3D transformations as float translation, rotation and scaling components
+         * @m_since_latest
+         *
+         * Convenience alternative to @ref field(SceneField) const with
+         * @ref SceneField::Translation, @ref SceneField::Rotation and
+         * @ref SceneField::Scaling as the arguments, as these are required to
+         * share the same object mapping. Converts the fields from an arbitrary
+         * underlying type and returns them in a newly-allocated array. At
+         * least one of the fields is expected to exist and they are expected
+         * to have a type corresponding to 3D, otherwise you're supposed to use
+         * @ref translationsRotationsScalings2DAsArray(). If the
+         * @ref SceneField::Translation field isn't present, the first returned
+         * value is a zero vector. If the @relativeref{SceneField,Rotation}
+         * field isn't present, the second value is an identity rotation. If
+         * the @relativeref{SceneField,Scaling} field isn't present, the third
+         * value is an identity scaling (@cpp 1.0f @ce in all dimensions).
+         * @see @ref translationsRotationsScalings3DInto(), @ref hasField(),
+         *      @ref fieldType(SceneField) const
+         */
+        Containers::Array<Containers::Triple<Vector3, Quaternion, Vector3>> translationsRotationsScalings3DAsArray() const;
+
+        /**
+         * @brief 3D transformations as float translation, rotation and scaling components into a pre-allocated view
+         * @m_since_latest
+         *
+         * Like @ref translationsRotationsScalings3DAsArray(), but puts the
+         * result into @p translationDestination, @p rotationDestination and
+         * @p scalingDestination instead of allocating a new array. Expects
+         * that each view is either @cpp nullptr @ce or sized to contain
+         * exactly all data.
+         * @see @ref fieldSize(SceneField) const
+         */
+        void translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
+
+        /**
+         * @brief A subrange of 3D transformations as float translation, rotation and scaling components into a pre-allocated view
+         * @m_since_latest
+         *
+         * Compared to @ref translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<Vector3>&, const Containers::StridedArrayView1D<Quaternion>&, const Containers::StridedArrayView1D<Vector3>&) const
+         * extracts only a subrange of the field defined by @p offset and size
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
+         * @see @ref fieldSize(SceneField) const
+         */
+        std::size_t translationsRotationsScalings3DInto(std::size_t offset, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
 
         /**
          * @brief Mesh and material IDs as 32-bit integers
@@ -1654,8 +1761,11 @@ class MAGNUM_TRADE_EXPORT SceneData {
         MAGNUM_TRADE_LOCAL void objectsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
         MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
+        MAGNUM_TRADE_LOCAL std::size_t findTranslationRotationScalingFields(UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
         MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
+        MAGNUM_TRADE_LOCAL void translationsRotationsScalings2DIntoInternal(UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
         MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        MAGNUM_TRADE_LOCAL void translationsRotationsScalings3DIntoInternal(UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
         MAGNUM_TRADE_LOCAL void unsignedIndexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
         MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> unsignedIndexFieldAsArrayInternal(const UnsignedInt fieldId) const;

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -2182,6 +2182,11 @@ class MAGNUM_TRADE_EXPORT SceneData {
         const void* importerState() const { return _importerState; }
 
     private:
+        /* For custom deleter checks. Not done in the constructors here because
+           the restriction is pointless when used outside of plugin
+           implementations. */
+        friend AbstractImporter;
+
         /* Internal helper that doesn't assert, unlike fieldId() */
         UnsignedInt fieldFor(SceneField name) const;
 

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -98,17 +98,13 @@ enum class SceneField: UnsignedInt {
     /* Zero used for an invalid value */
 
     /**
-     * Parent index. Type is usually @ref SceneFieldType::Int, but can be also
+     * Parent object. Type is usually @ref SceneFieldType::Int, but can be also
      * any of @relativeref{SceneFieldType,Byte},
      * @relativeref{SceneFieldType,Short} or a
      * @relativeref{SceneFieldType,Long}. A value of @cpp -1 @ce means there's
      * no parent. An object should have only one parent, altough this isn't
      * enforced in any way, and which of the duplicate fields gets used is not
      * defined.
-     *
-     * Note that the index points to the parent array itself and isn't the
-     * actual object index --- the object mapping is stored in the
-     * corresponding @ref SceneData::objects() array.
      * @see @ref SceneData::parentsAsArray(), @ref SceneData::parentFor(),
      *      @ref SceneData::childrenFor()
      */

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -1240,10 +1240,18 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * The @p fieldId is expected to be smaller than @ref fieldCount() and
-         * @p T is expected to correspond to @ref objectType(). You can also
-         * use the non-templated @ref objectsAsArray() accessor to get the
-         * object mapping converted to the usual type, but note that such
-         * operation involves extra allocation and data conversion.
+         * @p T is expected to correspond to @ref objectType().
+         *
+         * You can also use the non-templated @ref objectsAsArray() accessor
+         * (or the combined @ref parentsAsArray(),
+         * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
+         * @ref translationsRotationsScalings2DAsArray(),
+         * @ref translationsRotationsScalings3DAsArray(),
+         * @ref meshesMaterialsAsArray(), @ref lightsAsArray(),
+         * @ref camerasAsArray(), @ref skinsAsArray(),
+         * @ref importerStateAsArray() accessors) to get the object mapping
+         * converted to the usual type, but note that these operations involve
+         * extra allocation and data conversion.
          * @see @ref mutableObjects(UnsignedInt)
          */
         template<class T> Containers::StridedArrayView1D<const T> objects(UnsignedInt fieldId) const;
@@ -1287,10 +1295,18 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * The @p fieldName is expected to exist and @p T is expected to
-         * correspond to @ref objectType(). You can also use the non-templated
-         * @ref objectsAsArray() accessor to get the object mapping converted
-         * to the usual type, but note that such operation involves extra
-         * allocation and data conversion.
+         * correspond to @ref objectType().
+         *
+         * You can also use the non-templated @ref objectsAsArray() accessor
+         * (or the combined @ref parentsAsArray(),
+         * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
+         * @ref translationsRotationsScalings2DAsArray(),
+         * @ref translationsRotationsScalings3DAsArray(),
+         * @ref meshesMaterialsAsArray(), @ref lightsAsArray(),
+         * @ref camerasAsArray(), @ref skinsAsArray(),
+         * @ref importerStateAsArray() accessors) to get the object mapping
+         * converted to the usual type, but note that these operations involve
+         * extra allocation and data conversion.
          * @see @ref hasField(), @ref objects(UnsignedInt) const,
          *      @ref mutableObjects(UnsignedInt)
          */
@@ -1338,6 +1354,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * is expected to correspond to @ref fieldType(UnsignedInt) const. The
          * field is also expected to not be an array, in that case you need to
          * use the overload below by using @cpp T[] @ce instead of @cpp T @ce.
+         *
          * You can also use the non-templated @ref parentsAsArray(),
          * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
          * @ref translationsRotationsScalings2DAsArray(),
@@ -1418,8 +1435,9 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p name is expected to exist and @p T is expected to correspond
          * to @ref fieldType(SceneField) const. The field is also expected to
          * not be an array, in that case you need to use the overload below by
-         * using @cpp T[] @ce instead of @cpp T @ce. You can also use the
-         * non-templated @ref parentsAsArray(),
+         * using @cpp T[] @ce instead of @cpp T @ce.
+         *
+         * You can also use the non-templated @ref parentsAsArray(),
          * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
          * @ref translationsRotationsScalings2DAsArray(),
          * @ref translationsRotationsScalings3DAsArray(),
@@ -1474,6 +1492,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref objects(UnsignedInt) const that converts the field from an
          * arbitrary underlying type and returns it in a newly-allocated array.
          * The @p fieldId is expected to be smaller than @ref fieldCount().
+         *
+         * Note that, for common fields, you can also use the
+         * @ref parentsAsArray(), @ref transformations2DAsArray(),
+         * @ref transformations3DAsArray(),
+         * @ref translationsRotationsScalings2DAsArray(),
+         * @ref translationsRotationsScalings3DAsArray(),
+         * @ref meshesMaterialsAsArray(), @ref lightsAsArray(),
+         * @ref camerasAsArray(), @ref skinsAsArray(),
+         * @ref importerStateAsArray() accessors, which give out the object
+         * mapping together with the field data.
          * @see @ref objectsInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
          */
         Containers::Array<UnsignedInt> objectsAsArray(UnsignedInt fieldId) const;
@@ -1485,6 +1513,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * Like @ref objectsAsArray(UnsignedInt) const, but puts the result
          * into @p destination instead of allocating a new array. Expects that
          * @p destination is sized to contain exactly all data.
+         *
+         * Note that, for common fields, you can also use the
+         * @ref parentsInto(), @ref transformations2DInto(),
+         * @ref transformations3DInto(),
+         * @ref translationsRotationsScalings2DInto(),
+         * @ref translationsRotationsScalings3DInto(),
+         * @ref meshesMaterialsInto(), @ref lightsInto(), @ref camerasInto(),
+         * @ref skinsInto(), @ref importerStateInto() accessors, which can give
+         * out the object mapping together with the field data.
+         *
          * @see @ref fieldSize(UnsignedInt) const
          */
         void objectsInto(UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
@@ -1498,6 +1536,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * and size of the @p destination view, returning the count of items
          * actually extracted. The @p offset is expected to not be larger than
          * the field size.
+         *
+         * Note that, for common fields, you can also use the
+         * @ref parentsInto(), @ref transformations2DInto(),
+         * @ref transformations3DInto(),
+         * @ref translationsRotationsScalings2DInto(),
+         * @ref translationsRotationsScalings3DInto(),
+         * @ref meshesMaterialsInto(), @ref lightsInto(), @ref camerasInto(),
+         * @ref skinsInto(), @ref importerStateInto() accessors, which can give
+         * out the object mapping together with the field data.
+         *
          * @see @ref fieldSize(UnsignedInt) const,
          *      @ref fieldObjectOffset(UnsignedInt, UnsignedInt, std::size_t) const
          */
@@ -1511,6 +1559,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref objects(SceneField) const that converts the field from an
          * arbitrary underlying type and returns it in a newly-allocated array.
          * The @p fieldName is expected to exist.
+         *
+         * Note that, for common fields, you can also use the
+         * @ref parentsAsArray(), @ref transformations2DAsArray(),
+         * @ref transformations3DAsArray(),
+         * @ref translationsRotationsScalings2DAsArray(),
+         * @ref translationsRotationsScalings3DAsArray(),
+         * @ref meshesMaterialsAsArray(), @ref lightsAsArray(),
+         * @ref camerasAsArray(), @ref skinsAsArray(),
+         * @ref importerStateAsArray() accessors, which give out the object
+         * mapping together with the field data.
          * @see @ref objectsInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const,
          *      @ref hasField()
          */
@@ -1523,6 +1581,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * Like @ref objectsAsArray(SceneField) const, but puts the result into
          * @p destination instead of allocating a new array. Expects that
          * @p destination is sized to contain exactly all data.
+         *
+         * Note that, for common fields, you can also use the
+         * @ref parentsInto(), @ref transformations2DInto(),
+         * @ref transformations3DInto(),
+         * @ref translationsRotationsScalings2DInto(),
+         * @ref translationsRotationsScalings3DInto(),
+         * @ref meshesMaterialsInto(), @ref lightsInto(), @ref camerasInto(),
+         * @ref skinsInto(), @ref importerStateInto() accessors, which can give
+         * out the object mapping together with the field data.
+         *
          * @see @ref fieldSize(SceneField) const
          */
         void objectsInto(SceneField fieldName, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
@@ -1536,6 +1604,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * and size of the @p destination view, returning the count of items
          * actually extracted. The @p offset is expected to not be larger than
          * the field size.
+         *
+         * Note that, for common fields, you can also use the
+         * @ref parentsInto(), @ref transformations2DInto(),
+         * @ref transformations3DInto(),
+         * @ref translationsRotationsScalings2DInto(),
+         * @ref translationsRotationsScalings3DInto(),
+         * @ref meshesMaterialsInto(), @ref lightsInto(), @ref camerasInto(),
+         * @ref skinsInto(), @ref importerStateInto() accessors, which can give
+         * out the object mapping together with the field data.
+         *
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
@@ -1545,95 +1623,107 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Parent indices as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Parent as the argument that converts the field from
-         * an arbitrary underlying type and returns it in a newly-allocated
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Parent as
+         * the argument. Converts the object mapping and the field from
+         * arbitrary underlying types and returns them in a newly-allocated
          * array. The field is expected to exist.
          * @see @ref parentsInto(), @ref hasField(), @ref parentFor(),
          *      @ref childrenFor()
          */
-        Containers::Array<Int> parentsAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, Int>> parentsAsArray() const;
 
         /**
          * @brief Parent indices as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Like @ref parentsAsArray(), but puts the result into @p destination
-         * instead of allocating a new array. Expects that @p destination is
-         * sized to contain exactly all data.
+         * Like @ref parentsAsArray(), but puts the result into
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that each view is either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref objectsInto() with @ref SceneField::Parent.
          * @see @ref fieldSize(SceneField) const
          */
-        void parentsInto(const Containers::StridedArrayView1D<Int>& destination) const;
+        void parentsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const;
 
         /**
          * @brief A subrange of parent indices as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref parentsInto(const Containers::StridedArrayView1D<Int>&) const
+         * Compared to @ref parentsInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Int>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t parentsInto(std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
+        std::size_t parentsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const;
 
         /**
          * @brief 2D transformations as 3x3 float matrices
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with
          * @ref SceneField::Transformation as the argument, or, if not present,
          * to a matrix created out of a subset of the
          * @ref SceneField::Translation, @ref SceneField::Rotation and
-         * @ref SceneField::Scaling fields that's present. The transformation
-         * is converted and composed from an arbitrary underlying type and
-         * returned in a newly-allocated array. At least one of the fields is
+         * @ref SceneField::Scaling fields that's present. Converts the object
+         * mapping and the fields from arbitrary underlying types and returns
+         * them in a newly-allocated array. At least one of the fields is
          * expected to exist and they are expected to have a type corresponding
          * to 2D, otherwise you're supposed to use
          * @ref transformations3DAsArray().
          * @see @ref is2D(), @ref transformations2DInto(), @ref hasField(),
          *      @ref fieldType(SceneField) const, @ref transformation2DFor()
          */
-        Containers::Array<Matrix3> transformations2DAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, Matrix3>> transformations2DAsArray() const;
 
         /**
          * @brief 2D transformations as 3x3 float matrices into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref transformations2DAsArray(), but puts the result into
-         * @p destination instead of allocating a new array. Expects that
-         * @p destination is sized to contain exactly all data.
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that each view is either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref objectsInto() with the first of the
+         * @ref SceneField::Transformation, @ref SceneField::Translation,
+         * @ref SceneField::Rotation and @ref SceneField::Scaling fields that's
+         * present.
          * @see @ref fieldSize(SceneField) const
          */
-        void transformations2DInto(const Containers::StridedArrayView1D<Matrix3>& destination) const;
+        void transformations2DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const;
 
         /**
          * @brief A subrange of 2D transformations as 3x3 float matrices into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref transformations2DInto(const Containers::StridedArrayView1D<Matrix3>&) const
+         * Compared to @ref transformations2DInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Matrix3>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
+        std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const;
 
         /**
          * @brief 2D transformations as float translation, rotation and scaling components
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Translation, @ref SceneField::Rotation and
-         * @ref SceneField::Scaling as the arguments, as these are required to
-         * share the same object mapping. Converts the fields from an arbitrary
-         * underlying type and returns them in a newly-allocated array. At
-         * least one of the fields is expected to exist and they are expected
-         * to have a type corresponding to 2D, otherwise you're supposed to use
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Translation,
+         * @ref SceneField::Rotation and @ref SceneField::Scaling as the
+         * arguments, as these are required to share the same object mapping.
+         * Converts the object mapping and the fields from arbitrary underlying
+         * types and returns them in a newly-allocated array. At least one of
+         * the fields is expected to exist and they are expected to have a type
+         * corresponding to 2D, otherwise you're supposed to use
          * @ref translationsRotationsScalings3DAsArray(). If the
          * @ref SceneField::Translation field isn't present, the first returned
          * value is a zero vector. If the @relativeref{SceneField,Rotation}
@@ -1644,26 +1734,31 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *      @ref hasField(), @ref fieldType(SceneField) const,
          *      @ref translationRotationScaling2DFor()
          */
-        Containers::Array<Containers::Triple<Vector2, Complex, Vector2>> translationsRotationsScalings2DAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>> translationsRotationsScalings2DAsArray() const;
 
         /**
          * @brief 2D transformations as float translation, rotation and scaling components into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref translationsRotationsScalings2DAsArray(), but puts the
-         * result into @p translationDestination, @p rotationDestination and
-         * @p scalingDestination instead of allocating a new array. Expects
-         * that each view is either @cpp nullptr @ce or sized to contain
-         * exactly all data.
+         * result into @p objectDestination, @p translationDestination,
+         * @p rotationDestination and @p scalingDestination instead of
+         * allocating a new array. Expects that each view is either
+         * @cpp nullptr @ce or sized to contain exactly all data. If
+         * @p translationDestination, @p rotationDestination and
+         * @p scalingDestination are all @cpp nullptr @ce, the effect is the
+         * same as calling @ref objectsInto() with one of the
+         * @ref SceneField::Translation, @ref SceneField::Rotation and
+         * @ref SceneField::Scaling fields that's present.
          * @see @ref fieldSize(SceneField) const
          */
-        void translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
+        void translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
 
         /**
          * @brief A subrange of 2D transformations as float translation, rotation and scaling components into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<Vector2>&, const Containers::StridedArrayView1D<Complex>&, const Containers::StridedArrayView1D<Vector2>&) const
+         * Compared to @ref translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Vector2>&, const Containers::StridedArrayView1D<Complex>&, const Containers::StridedArrayView1D<Vector2>&) const
          * extracts only a subrange of the field defined by @p offset and size
          * of the views, returning the count of items actually extracted. The
          * @p offset is expected to not be larger than the field size, views
@@ -1671,63 +1766,71 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t translationsRotationsScalings2DInto(std::size_t offset, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
+        std::size_t translationsRotationsScalings2DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
 
         /**
          * @brief 3D transformations as 4x4 float matrices
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with
          * @ref SceneField::Transformation as the argument, or, if not present,
          * to a matrix created out of a subset of the
          * @ref SceneField::Translation, @ref SceneField::Rotation and
-         * @ref SceneField::Scaling fields that's present. The transformation
-         * is converted and composed from an arbitrary underlying type and
-         * returned in a newly-allocated array. At least one of the fields is
+         * @ref SceneField::Scaling fields that's present. Converts the object
+         * mapping and the fields from arbitrary underlying types and returns
+         * them in a newly-allocated array. At least one of the fields is
          * expected to exist and they are expected to have a type corresponding
          * to 3D, otherwise you're supposed to use
          * @ref transformations2DAsArray().
          * @see @ref is3D(), @ref transformations3DInto(), @ref hasField(),
          *      @ref fieldType(SceneField) const, @ref transformation3DFor()
          */
-        Containers::Array<Matrix4> transformations3DAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, Matrix4>> transformations3DAsArray() const;
 
         /**
          * @brief 3D transformations as 4x4 float matrices into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref transformations3DAsArray(), but puts the result into
-         * @p destination instead of allocating a new array. Expects that
-         * @p destination is sized to contain exactly all data.
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that the two views are either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref objectsInto() with the first of the
+         * @ref SceneField::Transformation, @ref SceneField::Translation,
+         * @ref SceneField::Rotation and @ref SceneField::Scaling fields that's
+         * present.
          * @see @ref fieldSize(SceneField) const
          */
-        void transformations3DInto(const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        void transformations3DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix4>& destination) const;
 
         /**
          * @brief A subrange of 3D transformations as 4x4 float matrices into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref transformations3DInto(const Containers::StridedArrayView1D<Matrix4>&) const
+         * Compared to @ref transformations3DInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Matrix4>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix4>& destination) const;
 
         /**
          * @brief 3D transformations as float translation, rotation and scaling components
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Translation, @ref SceneField::Rotation and
-         * @ref SceneField::Scaling as the arguments, as these are required to
-         * share the same object mapping. Converts the fields from an arbitrary
-         * underlying type and returns them in a newly-allocated array. At
-         * least one of the fields is expected to exist and they are expected
-         * to have a type corresponding to 3D, otherwise you're supposed to use
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Translation,
+         * @ref SceneField::Rotation and @ref SceneField::Scaling as the
+         * arguments, as these are required to share the same object mapping.
+         * Converts the object mapping and the fields from arbitrary underlying
+         * types and returns them in a newly-allocated array. At least one of
+         * the fields is expected to exist and they are expected to have a type
+         * corresponding to 3D, otherwise you're supposed to use
          * @ref translationsRotationsScalings2DAsArray(). If the
          * @ref SceneField::Translation field isn't present, the first returned
          * value is a zero vector. If the @relativeref{SceneField,Rotation}
@@ -1738,26 +1841,31 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *      @ref hasField(), @ref fieldType(SceneField) const,
          *      @ref translationRotationScaling3DFor()
          */
-        Containers::Array<Containers::Triple<Vector3, Quaternion, Vector3>> translationsRotationsScalings3DAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>> translationsRotationsScalings3DAsArray() const;
 
         /**
          * @brief 3D transformations as float translation, rotation and scaling components into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref translationsRotationsScalings3DAsArray(), but puts the
-         * result into @p translationDestination, @p rotationDestination and
-         * @p scalingDestination instead of allocating a new array. Expects
-         * that each view is either @cpp nullptr @ce or sized to contain
-         * exactly all data.
+         * result into @p objectDestination, @p translationDestination,
+         * @p rotationDestination and @p scalingDestination instead of
+         * allocating a new array. Expects that each view is either
+         * @cpp nullptr @ce or sized to contain exactly all data. If
+         * @p translationDestination, @p rotationDestination and
+         * @p scalingDestination are all @cpp nullptr @ce, the effect is the
+         * same as calling @ref objectsInto() with one of the
+         * @ref SceneField::Translation, @ref SceneField::Rotation and
+         * @ref SceneField::Scaling fields that's present.
          * @see @ref fieldSize(SceneField) const
          */
-        void translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
+        void translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
 
         /**
          * @brief A subrange of 3D transformations as float translation, rotation and scaling components into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<Vector3>&, const Containers::StridedArrayView1D<Quaternion>&, const Containers::StridedArrayView1D<Vector3>&) const
+         * Compared to @ref translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Vector3>&, const Containers::StridedArrayView1D<Quaternion>&, const Containers::StridedArrayView1D<Vector3>&) const
          * extracts only a subrange of the field defined by @p offset and size
          * of the views, returning the count of items actually extracted. The
          * @p offset is expected to not be larger than the field size, views
@@ -1765,41 +1873,45 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t translationsRotationsScalings3DInto(std::size_t offset, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
+        std::size_t translationsRotationsScalings3DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
 
         /**
          * @brief Mesh and material IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Mesh and @ref SceneField::MeshMaterial as the
-         * argument, as the two are required to share the same object mapping.
-         * Converts the fields from an arbitrary underlying type and returns it
-         * in a newly-allocated array. The @ref SceneField::Mesh field is
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Mesh and
+         * @ref SceneField::MeshMaterial as the argument, as the two are
+         * required to share the same object mapping. Converts the object
+         * mapping and the fields from arbitrary underlying types and returns
+         * them in a newly-allocated array. The @ref SceneField::Mesh field is
          * expected to exist, if @ref SceneField::MeshMaterial isn't present,
          * the second returned values are all @cpp -1 @ce.
          * @see @ref meshesMaterialsInto(), @ref hasField(),
          *      @ref meshesMaterialsFor()
          */
-        Containers::Array<Containers::Pair<UnsignedInt, Int>> meshesMaterialsAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>> meshesMaterialsAsArray() const;
 
         /**
          * @brief Mesh and material IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref meshesMaterialsAsArray(), but puts the results into
-         * @p meshDestination and @p meshMaterialDestination instead of
-         * allocating a new array. Expects that each view is either
-         * @cpp nullptr @ce or sized to contain exactly all data.
+         * @p objectDestination, @p meshDestination and
+         * @p meshMaterialDestination instead of allocating a new array.
+         * Expects that each view is either @cpp nullptr @ce or sized to
+         * contain exactly all data. If @p meshDestination and
+         * @p meshMaterialDestination are both @cpp nullptr @ce, the effect is
+         * the same as calling @ref objectsInto() with @ref SceneField::Mesh.
          * @see @ref fieldSize(SceneField) const
          */
-        void meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const;
+        void meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const;
 
         /**
          * @brief A subrange of mesh and material IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Int>&) const
+         * Compared to @ref meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<Int>&) const
          * extracts only a subrange of the field defined by @p offset and size
          * of the views, returning the count of items actually extracted. The
          * @p offset is expected to not be larger than the field size, views
@@ -1807,158 +1919,174 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t meshesMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialsDestination) const;
+        std::size_t meshesMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialsDestination) const;
 
         /**
          * @brief Light IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Light as the argument that converts the field from
-         * an arbitrary underlying type and returns it in a newly-allocated
-         * array. The field is expected to exist.
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Light as the
+         * argument. Converts the object mapping and the field from arbitrary
+         * underlying types and returns them in a newly-allocated array. The
+         * field is expected to exist.
          * @see @ref lightsInto(), @ref hasField(), @ref lightsFor()
          */
-        Containers::Array<UnsignedInt> lightsAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> lightsAsArray() const;
 
         /**
          * @brief Light IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Like @ref lightsAsArray(), but puts the result into @p destination
-         * instead of allocating a new array. Expects that @p destination is
-         * sized to contain exactly all data.
+         * Like @ref lightsAsArray(), but puts the result into
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that each view is either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref lightsInto() with @ref SceneField::Light.
          * @see @ref fieldSize(SceneField) const
          */
-        void lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        void lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief A subrange of light IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref lightsInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * Compared to @ref lightsInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<UnsignedInt>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t lightsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        std::size_t lightsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief Camera IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Camera as the argument that converts the field from
-         * an arbitrary underlying type and returns it in a newly-allocated
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Camera as
+         * the argument. Converts the object mapping and the field from
+         * arbitrary underlying types and returns them in a newly-allocated
          * array. The field is expected to exist.
          * @see @ref camerasInto(), @ref hasField(), @ref camerasFor()
          */
-        Containers::Array<UnsignedInt> camerasAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> camerasAsArray() const;
 
         /**
          * @brief Camera IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref camerasAsArray(), but puts the result into
-         * @p destination instead of allocating a new array. Expects that
-         * @p destination is sized to contain exactly all data.
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that each view is either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref objectsInto() with @ref SceneField::Camera.
          * @see @ref fieldSize(SceneField) const
          */
-        void camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        void camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief A subrange of camera IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref camerasInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * Compared to @ref camerasInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<UnsignedInt>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t camerasInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        std::size_t camerasInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief Skin IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::Skin as the argument that converts the field from
-         * an arbitrary underlying type and returns it in a newly-allocated
-         * array. The field is expected to exist.
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::Skin as the
+         * argument. Converts the object mapping and the field from arbitrary
+         * underlying types and returns them in a newly-allocated array. The
+         * field is expected to exist.
          * @see @ref skinsInto(), @ref hasField(), @ref skinsFor()
          */
-        Containers::Array<UnsignedInt> skinsAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> skinsAsArray() const;
 
         /**
          * @brief Skin IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Like @ref skinsAsArray(), but puts the result into @p destination
-         * instead of allocating a new array. Expects that @p destination is
-         * sized to contain exactly all data.
+         * Like @ref skinsAsArray(), but puts the result into
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that each view is either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref objectsInto() with @ref SceneField::Skin.
          * @see @ref fieldSize(SceneField) const
          */
-        void skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        void skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief A subrange of skin IDs as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref skinsInto(const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * Compared to @ref skinsInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<UnsignedInt>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief Per-object importer state as `void` pointers
          * @m_since_latest
          *
-         * Convenience alternative to @ref field(SceneField) const with
-         * @ref SceneField::ImporterState as the argument that converts the
-         * field from an arbitrary underlying type and returns it in a
-         * newly-allocated array. The field is expected to exist.
+         * Convenience alternative to @ref objects(SceneField) const together
+         * with @ref field(SceneField) const with @ref SceneField::ImporterState
+         * as the argument. Converts the object mapping and the field from
+         * arbitrary underlying types and returns them in a newly-allocated
+         * array. The field is expected to exist.
          *
          * This is different from @ref importerState(), which returns importer
          * state for the scene itself, not particular objects.
          * @see @ref importerStateInto(), @ref hasField(), @ref importerStateFor()
          */
-        Containers::Array<const void*> importerStateAsArray() const;
+        Containers::Array<Containers::Pair<UnsignedInt, const void*>> importerStateAsArray() const;
 
         /**
          * @brief Per-object importer state as `void` pointers into a pre-allocated view
          * @m_since_latest
          *
          * Like @ref importerStateAsArray(), but puts the result into
-         * @p destination instead of allocating a new array. Expects that
-         * @p destination is sized to contain exactly all data.
+         * @p objectDestination and @p fieldDestination instead of allocating a
+         * new array. Expects that each view is either @cpp nullptr @ce or
+         * sized to contain exactly all data. If @p fieldDestination is
+         * @cpp nullptr @ce, the effect is the same as calling
+         * @ref objectsInto() with @ref SceneField::ImporterState.
          * @see @ref fieldSize(SceneField) const
          */
-        void importerStateInto(const Containers::StridedArrayView1D<const void*>& destination) const;
+        void importerStateInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const;
 
         /**
          * @brief A subrange of per-object importer state as `void` pointers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref importerStateInto(const Containers::StridedArrayView1D<const void*>&) const
+         * Compared to @ref importerStateInto(const Containers::StridedArrayView1D<UnsignedInt>&, const Containers::StridedArrayView1D<const void*>&) const
          * extracts only a subrange of the field defined by @p offset and size
-         * of the @p destination view, returning the count of items actually
-         * extracted. The @p offset is expected to not be larger than the field
-         * size.
+         * of the views, returning the count of items actually extracted. The
+         * @p offset is expected to not be larger than the field size, views
+         * that are not @cpp nullptr @ce are expected to have the same size.
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t importerStateInto(std::size_t offset, const Containers::StridedArrayView1D<const void*>& destination) const;
+        std::size_t importerStateInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const;
 
         /**
          * @brief Parent for given object
@@ -2300,15 +2428,15 @@ class MAGNUM_TRADE_EXPORT SceneData {
 
         MAGNUM_TRADE_LOCAL void objectsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
-        MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId, UnsignedInt* fieldWithObjectMappingDestination = nullptr) const;
-        MAGNUM_TRADE_LOCAL std::size_t findTranslationRotationScalingFields(UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId, UnsignedInt* fieldWithObjectMappingDestination = nullptr) const;
+        MAGNUM_TRADE_LOCAL UnsignedInt findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
+        MAGNUM_TRADE_LOCAL UnsignedInt findTranslationRotationScalingFields(UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
         MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
         MAGNUM_TRADE_LOCAL void translationsRotationsScalings2DIntoInternal(UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
         MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
         MAGNUM_TRADE_LOCAL void translationsRotationsScalings3DIntoInternal(UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
         MAGNUM_TRADE_LOCAL void unsignedIndexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL void indexFieldIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
-        MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> unsignedIndexFieldAsArrayInternal(const UnsignedInt fieldId) const;
+        MAGNUM_TRADE_LOCAL Containers::Array<Containers::Pair<UnsignedInt, UnsignedInt>> unsignedIndexFieldAsArrayInternal(const UnsignedInt fieldId) const;
         MAGNUM_TRADE_LOCAL void meshesMaterialsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const;
         MAGNUM_TRADE_LOCAL void importerStateIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<const void*>& destination) const;
 

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -1080,6 +1080,26 @@ class MAGNUM_TRADE_EXPORT SceneData {
         bool is3D() const { return _dimensions == 3; }
 
         /**
+         * @brief Find an absolute ID of a named field
+         * @m_since_latest
+         *
+         * If @p name doesn't exist, returns @ref Containers::NullOpt. The
+         * lookup is done in an @f$ \mathcal{O}(n) @f$ complexity with
+         * @f$ n @f$ being the field count.
+         * @see @ref hasField(), @ref fieldId()
+         */
+        Containers::Optional<UnsignedInt> findFieldId(SceneField name) const;
+
+        /**
+         * @brief Absolute ID of a named field
+         * @m_since_latest
+         *
+         * Like @ref findFieldId(), but the @p name is expected to exist.
+         * @see @ref hasField(), @ref fieldName(UnsignedInt) const
+         */
+        UnsignedInt fieldId(SceneField name) const;
+
+        /**
          * @brief Whether the scene has given field
          * @m_since_latest
          *
@@ -1088,13 +1108,83 @@ class MAGNUM_TRADE_EXPORT SceneData {
         bool hasField(SceneField name) const;
 
         /**
-         * @brief Absolute ID of a named field
+         * @brief Find offset of an object in given field
          * @m_since_latest
          *
-         * The @p name is expected to exist.
-         * @see @ref hasField(), @ref fieldName(UnsignedInt) const
+         * If @p object isn't present in @p fieldId starting at @p offset,
+         * returns @ref Containers::NullOpt. The @p fieldId is expected to be
+         * smaller than @ref fieldCount(), @p object smaller than
+         * @ref objectCount() and @p offset not larger than
+         * @ref fieldSize(UnsignedInt) const.
+         *
+         * The lookup is done in an @f$ \mathcal{O}(n) @f$ complexity with
+         * @f$ n @f$ being the size of the field.
+         *
+         * You can also use @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * to directly find offset of an object in given named field.
+         * @see @ref hasFieldObject(UnsignedInt, UnsignedInt) const,
+         *      @ref fieldObjectOffset(UnsignedInt, UnsignedInt, std::size_t) const
          */
-        UnsignedInt fieldId(SceneField name) const;
+        Containers::Optional<std::size_t> findFieldObjectOffset(UnsignedInt fieldId, UnsignedInt object, std::size_t offset = 0) const;
+
+        /**
+         * @brief Find offset of an object in given named field
+         * @m_since_latest
+         *
+         * If @p object isn't present in @p fieldName starting at @p offset,
+         * returns @ref Containers::NullOpt. The @p fieldName is expected to
+         * exist, @p object is expected to be smaller than @ref objectCount()
+         * and @p offset not be larger than @ref fieldSize(SceneField) const.
+         *
+         * The lookup is done in an @f$ \mathcal{O}(m + n) @f$ complexity with
+         * @f$ m @f$ being the field count and @f$ n @f$ the size of the field.
+         *
+         * @see @ref hasField(), @ref hasFieldObject(SceneField, UnsignedInt) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         */
+        Containers::Optional<std::size_t> findFieldObjectOffset(SceneField fieldName, UnsignedInt object, std::size_t offset = 0) const;
+
+        /**
+         * @brief Offset of an object in given field
+         * @m_since_latest
+         *
+         * Like @ref findFieldObjectOffset(UnsignedInt, UnsignedInt, std::size_t) const,
+         * but @p object is additionally expected to be present in @p fieldId
+         * starting at @p offset.
+         *
+         * You can also use @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * to directly get offset of an object in given named field.
+         */
+        std::size_t fieldObjectOffset(UnsignedInt fieldId, UnsignedInt object, std::size_t offset = 0) const;
+
+        /**
+         * @brief Offset of an object in given named field
+         * @m_since_latest
+         *
+         * Like @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const,
+         * but @p object is additionally expected to be present in @p fieldName
+         * starting at @p offset.
+         */
+        std::size_t fieldObjectOffset(SceneField fieldName, UnsignedInt object, std::size_t offset = 0) const;
+
+        /**
+         * @brief Whether a scene field has given object
+         * @m_since_latest
+         *
+         * The @p fieldId is expected to be smaller than @ref fieldCount() and
+         * @p object smaller than @ref objectCount().
+         */
+        bool hasFieldObject(UnsignedInt fieldId, UnsignedInt object) const;
+
+        /**
+         * @brief Whether a named scene field has given object
+         * @m_since_latest
+         *
+         * The @p fieldName is expected to exist and @p object is expected to
+         * be smaller than @ref objectCount().
+         * @see @ref hasField()
+         */
+        bool hasFieldObject(SceneField fieldName, UnsignedInt object) const;
 
         /**
          * @brief Type of a named field
@@ -1416,7 +1506,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * and size of the @p destination view, returning the count of items
          * actually extracted. The @p offset is expected to not be larger than
          * the field size.
-         * @see @ref fieldSize(UnsignedInt) const
+         * @see @ref fieldSize(UnsignedInt) const,
+         *      @ref fieldObjectOffset(UnsignedInt, UnsignedInt, std::size_t) const
          */
         std::size_t objectsInto(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
@@ -1458,7 +1549,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * and size of the @p destination view, returning the count of items
          * actually extracted. The @p offset is expected to not be larger than
          * the field size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t objectsInto(SceneField fieldName, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
@@ -1500,7 +1592,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t parentsInto(std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
 
@@ -1543,7 +1636,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
 
@@ -1592,7 +1686,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the views, returning the count of items actually extracted. The
          * @p offset is expected to not be larger than the field size, views
          * that are not @cpp nullptr @ce are expected to have the same size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t translationsRotationsScalings2DInto(std::size_t offset, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
 
@@ -1635,7 +1730,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;
 
@@ -1684,7 +1780,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the views, returning the count of items actually extracted. The
          * @p offset is expected to not be larger than the field size, views
          * that are not @cpp nullptr @ce are expected to have the same size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t translationsRotationsScalings3DInto(std::size_t offset, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
 
@@ -1725,7 +1822,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the views, returning the count of items actually extracted. The
          * @p offset is expected to not be larger than the field size, views
          * that are not @cpp nullptr @ce are expected to have the same size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t meshesMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialsDestination) const;
 
@@ -1761,7 +1859,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t lightsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
@@ -1797,7 +1896,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t camerasInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
@@ -1833,7 +1933,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
@@ -1872,7 +1973,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * of the @p destination view, returning the count of items actually
          * extracted. The @p offset is expected to not be larger than the field
          * size.
-         * @see @ref fieldSize(SceneField) const
+         * @see @ref fieldSize(SceneField) const,
+         *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
         std::size_t importerStateInto(std::size_t offset, const Containers::StridedArrayView1D<const void*>& destination) const;
 
@@ -1880,12 +1982,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Parent for given object
          * @m_since_latest
          *
-         * Looks up the @ref SceneField::Parent field for @p object. The lookup
-         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
-         * being the field count and @f$ n @f$ the size of the parent field,
-         * thus for retrieving parent info for many objects it's recommended to
-         * access the field data directly with @ref parentsAsArray() and
-         * related APIs.
+         * Looks up the @ref SceneField::Parent field for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the field from an arbitrary underlying type the
+         * same way as @ref parentsAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving parent
+         * info for many objects it's recommended to access the field data
+         * directly.
          *
          * If the @ref SceneField::Parent field is not present or if there's no
          * parent for @p object, returns @ref Containers::NullOpt. If @p object
@@ -1901,13 +2004,12 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Looks up @p object in the object mapping array for
-         * @ref SceneField::Parent and returns a list of all object IDs that
-         * have it listed as the parent. The lookup is done in an
-         * @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$ being the field
-         * count and @f$ n @f$ the size of the parent field, thus for
-         * retrieving parent/child info for many objects it's recommended to
-         * access the field data directly with @ref parentsAsArray() and
-         * related APIs.
+         * @ref SceneField::Parent equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const,
+         * converts the fields from an arbitrary underlying type the same way
+         * as @ref parentsAsArray(), returning a list of all object IDs that
+         * have it listed as the parent. See the lookup function documentation
+         * for operation complexity --- for retrieving parent/child info for
+         * many objects it's recommended to access the field data directly.
          *
          * If the @ref SceneField::Parent field doesn't exist or there are no
          * objects which would have @p object listed as their parent, returns
@@ -1922,16 +2024,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief 2D transformation for given object
          * @m_since_latest
          *
-         * Looks up the @ref SceneField::Transformation field for @p object or
-         * combines it from a @ref SceneField::Translation,
+         * Looks up the @ref SceneField::Transformation field for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * or combines it from a @ref SceneField::Translation,
          * @relativeref{SceneField,Rotation} and
-         * @relativeref{SceneField,Scaling} in the same way as
-         * @ref transformations2DAsArray(). The lookup is done in an
-         * @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$ being the field
-         * count and @f$ n @f$ the size of the transformation field, thus for
-         * retrieving transformation info for many objects it's recommended to
-         * access the field data directly with @ref transformations2DAsArray()
-         * and related APIs.
+         * @relativeref{SceneField,Scaling}, converting the fields from
+         * arbitrary underlying types the same way as
+         * @ref transformations2DAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving
+         * transformation info for many objects it's recommended to access the
+         * field data directly.
          *
          * If neither @ref SceneField::Transformation nor any of
          * @ref SceneField::Translation, @relativeref{SceneField,Rotation} or
@@ -1950,12 +2052,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * Looks up the @ref SceneField::Translation,
          * @relativeref{SceneField,Rotation} and
-         * @relativeref{SceneField,Scaling} fields for @p object. The lookup
-         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
-         * being the field count and @f$ n @f$ the size of the transformation
-         * field, thus for retrieving transformation info for many objects it's
-         * recommended to access the field data directly with
-         * @ref translationsRotationsScalings2DAsArray() and related APIs.
+         * @relativeref{SceneField,Scaling} fields for @p object equivalently
+         * to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the fields from arbitrary underlying types the
+         * same way as @ref translationsRotationsScalings2DAsArray(). See the
+         * lookup function documentation for operation complexity --- for
+         * retrieving transformation info for many objects it's recommended to
+         * access the field data directly.
          *
          * If the @ref SceneField::Translation field isn't present, the first
          * returned value is a zero vector. If the
@@ -1976,16 +2079,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief 3D transformation for given object
          * @m_since_latest
          *
-         * Looks up the @ref SceneField::Transformation field for @p object or
-         * combines it from a @ref SceneField::Translation,
+         * Looks up the @ref SceneField::Transformation field for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * or combines it from a @ref SceneField::Translation,
          * @relativeref{SceneField,Rotation} and
-         * @relativeref{SceneField,Scaling} in the same way as
-         * @ref transformations3DAsArray(). The lookup is done in an
-         * @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$ being the field
-         * count and @f$ n @f$ the size of the transformation field, thus for
-         * retrieving transformation info for many objects it's recommended to
-         * access the field data directly with @ref transformations3DAsArray()
-         * and related APIs.
+         * @relativeref{SceneField,Scaling}, converting the fields from
+         * arbitrary underlying types the same way as
+         * @ref transformations3DAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving
+         * transformation info for many objects it's recommended to access the
+         * field data directly.
          *
          * If neither @ref SceneField::Transformation nor any of
          * @ref SceneField::Translation, @relativeref{SceneField,Rotation} or
@@ -2004,12 +2107,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * Looks up the @ref SceneField::Translation,
          * @relativeref{SceneField,Rotation} and
-         * @relativeref{SceneField,Scaling} fields for @p object. The lookup
-         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
-         * being the field count and @f$ n @f$ the size of the transformation
-         * field, thus for retrieving transformation info for many objects it's
-         * recommended to access the field data directly with
-         * @ref translationsRotationsScalings3DAsArray() and related APIs.
+         * @relativeref{SceneField,Scaling} fields for @p object equivalently
+         * to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the fields from arbitrary underlying types the
+         * same way as @ref translationsRotationsScalings2DAsArray(). See the
+         * lookup function documentation for operation complexity --- for
+         * retrieving transformation info for many objects it's recommended to
+         * access the field data directly.
          *
          * If the @ref SceneField::Translation field isn't present, the first
          * returned value is a zero vector. If the
@@ -2031,12 +2135,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Looks up all @ref SceneField::Mesh and @ref SceneField::MeshMaterial
-         * @relativeref{SceneField,Scaling} fields for @p object. The lookup
-         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
-         * being the field count and @f$ n @f$ the size of the mesh field, thus
-         * for retrieving mesh info for many objects it's recommended to access
-         * the field data directly with @ref meshesMaterialsAsArray() and
-         * related APIs.
+         * @relativeref{SceneField,Scaling} fields for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the field from an arbitrary underlying type the
+         * same way as @ref meshesMaterialsAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving mesh and
+         * material info for many objects it's recommended to access the field
+         * data directly.
          *
          * If the @ref SceneField::MeshMaterial field is not present, the
          * second returned value is always @cpp -1 @ce. If
@@ -2051,12 +2156,12 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Lights for given object
          * @m_since_latest
          *
-         * Looks up all @ref SceneField::Light fields for @p object. The lookup
-         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
-         * being the field count and @f$ n @f$ the size of the light field,
-         * thus for retrieving light info for many objects it's recommended to
-         * access the field data directly with @ref lightsAsArray() and related
-         * APIs.
+         * Looks up all @ref SceneField::Light fields for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the field from an arbitrary underlying type the
+         * same way as @ref lightsAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving light info
+         * for many objects it's recommended to access the field data directly.
          *
          * If the @ref SceneField::Light field is not present or if there's no
          * light for @p object, returns an empty array.
@@ -2069,12 +2174,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Cameras for given object
          * @m_since_latest
          *
-         * Looks up all @ref SceneField::Camera fields for @p object. The
-         * lookup is done in an @f$ \mathcal{O}(m + n) @f$ complexity with
-         * @f$ m @f$ being the field count and @f$ n @f$ the size of the camera
-         * field, thus for retrieving camera info for many objects it's
-         * recommended to access the field data directly with
-         * @ref camerasAsArray() and related APIs.
+         * Looks up all @ref SceneField::Camera fields for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the field from an arbitrary underlying type the
+         * same way as @ref camerasAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving camera
+         * info for many objects it's recommended to access the field data
+         * directly.
          *
          * If the @ref SceneField::Camera field is not present or if there's no
          * camera for @p object, returns an empty array.
@@ -2087,11 +2193,12 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Skins for given object
          * @m_since_latest
          *
-         * Looks up all @ref SceneField::Skin fields for @p object. The lookup
-         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
-         * being the field count and @f$ n @f$ the size of the skin field, thus
-         * for retrieving skin info for many objects it's recommended to access
-         * the field data directly with @ref skinsAsArray() and related APIs.
+         * Looks up all @ref SceneField::Skin fields for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the field from an arbitrary underlying type the
+         * same way as @ref skinsAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving skin info
+         * for many objects it's recommended to access the field data directly.
          *
          * If the @ref SceneField::Skin field is not present or if there's no
          * skin for @p object, returns an empty array.
@@ -2104,12 +2211,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Importer state for given object
          * @m_since_latest
          *
-         * Looks up the @ref SceneField::ImporterState field for @p object. The
-         * lookup is done in a @f$ \mathcal{O}(m + n) @f$ complexity with
-         * @f$ m @f$ being the field count and @f$ n @f$ the size of the
-         * importer state field, thus for retrieving importer state info for
-         * many objects it's recommended to access the field data directly with
-         * @ref importerStateAsArray() and related APIs.
+         * Looks up the @ref SceneField::ImporterState field for @p object
+         * equivalently to @ref findFieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
+         * and then converts the field from an arbitrary underlying type the
+         * same way as @ref importerStateAsArray(). See the lookup function
+         * documentation for operation complexity --- for retrieving importer
+         * state info for many objects it's recommended to access the field
+         * data directly.
          *
          * If the @ref SceneField::ImporterState field is not present or if
          * there's no importer state for @p object, returns
@@ -2187,13 +2295,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
            implementations. */
         friend AbstractImporter;
 
-        /* Internal helper that doesn't assert, unlike fieldId() */
-        UnsignedInt fieldFor(SceneField name) const;
+        /* Internal helper without the extra overhead from Optional, returns
+           ~UnsignedInt{} on failure */
+        UnsignedInt findFieldIdInternal(SceneField name) const;
 
         /* Returns the offset at which `object` is for field at index `id`, or
            the end offset if the object is not found. The returned offset can
            be then passed to fieldData{Object,Field}ViewInternal(). */
-        std::size_t fieldFor(const SceneFieldData& field, std::size_t offset, UnsignedInt object) const;
+        std::size_t findFieldObjectOffsetInternal(const SceneFieldData& field, UnsignedInt object, std::size_t offset) const;
 
         /* Like objects() / field(), but returning just a 1D view, sliced from
            offset to offset + size. The parameterless overloads are equal to
@@ -2566,7 +2675,7 @@ template<class T, class> Containers::StridedArrayView1D<const T> SceneData::fiel
     if(!data.stride()[1]) return {};
     #endif
     #ifndef CORRADE_NO_ASSERT
-    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::field():")) return {};
+    if(!checkFieldTypeCompatibility<T>(_fields[findFieldIdInternal(name)], "Trade::SceneData::field():")) return {};
     #endif
     return Containers::arrayCast<1, const T>(data);
 }
@@ -2577,7 +2686,7 @@ template<class T, class> Containers::StridedArrayView2D<const typename std::remo
     if(!data.stride()[1]) return {};
     #endif
     #ifndef CORRADE_NO_ASSERT
-    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::field():")) return {};
+    if(!checkFieldTypeCompatibility<T>(_fields[findFieldIdInternal(name)], "Trade::SceneData::field():")) return {};
     #endif
     return Containers::arrayCast<2, const typename std::remove_extent<T>::type>(data);
 }
@@ -2588,7 +2697,7 @@ template<class T, class> Containers::StridedArrayView1D<T> SceneData::mutableFie
     if(!data.stride()[1]) return {};
     #endif
     #ifndef CORRADE_NO_ASSERT
-    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::mutableField():")) return {};
+    if(!checkFieldTypeCompatibility<T>(_fields[findFieldIdInternal(name)], "Trade::SceneData::mutableField():")) return {};
     #endif
     return Containers::arrayCast<1, T>(data);
 }
@@ -2599,7 +2708,7 @@ template<class T, class> Containers::StridedArrayView2D<typename std::remove_ext
     if(!data.stride()[1]) return {};
     #endif
     #ifndef CORRADE_NO_ASSERT
-    if(!checkFieldTypeCompatibility<T>(_fields[fieldFor(name)], "Trade::SceneData::mutableField():")) return {};
+    if(!checkFieldTypeCompatibility<T>(_fields[findFieldIdInternal(name)], "Trade::SceneData::mutableField():")) return {};
     #endif
     return Containers::arrayCast<2, typename std::remove_extent<T>::type>(data);
 }

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -36,6 +36,11 @@
 #include "Magnum/Trade/Trade.h"
 #include "Magnum/Trade/visibility.h"
 
+#ifdef MAGNUM_BUILD_DEPRECATED
+#include <Corrade/Utility/StlForwardVector.h>
+#include <Corrade/Utility/Macros.h>
+#endif
+
 namespace Magnum { namespace Trade {
 
 /**
@@ -820,6 +825,18 @@ class MAGNUM_TRADE_EXPORT SceneData {
          */
         /* Not noexcept because allocation happens inside */
         explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, DataFlags dataFlags, Containers::ArrayView<const void> data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
+
+        #ifdef MAGNUM_BUILD_DEPRECATED
+         /**
+         * @brief Constructor
+         * @param children2D        Two-dimensional child objects
+         * @param children3D        Three-dimensional child objects
+         * @param importerState     Importer-specific state
+         * @m_deprecated_since_latest Use @ref SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+         *      instead.
+         */
+        explicit CORRADE_DEPRECATED("use SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*) instead") SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* importerState = nullptr);
+        #endif
 
         /** @brief Copying is not allowed */
         SceneData(const SceneData&) = delete;
@@ -2079,6 +2096,22 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref objectCount().
          */
         Containers::Optional<const void*> importerStateFor(UnsignedInt object) const;
+
+        #ifdef MAGNUM_BUILD_DEPRECATED
+        /**
+         * @brief Two-dimensional root scene objects
+         * @m_deprecated_since_latest Use @ref childrenFor() with `-1` passed
+         *      as the @p object argument.
+         */
+        CORRADE_DEPRECATED("use childrenFor() instead") std::vector<UnsignedInt> children2D() const;
+
+        /**
+         * @brief Three-dimensional root scene objects
+         * @m_deprecated_since_latest Use @ref childrenFor() with `-1` passed
+         *      as the @p object argument.
+         */
+        CORRADE_DEPRECATED("use childrenFor() instead") std::vector<UnsignedInt> children3D() const;
+        #endif
 
         /**
          * @brief Release field data storage

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -1550,6 +1550,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
         template<class T> bool checkFieldTypeCompatibility(const SceneFieldData& attribute, const char* prefix) const;
         #endif
 
+        MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, const Containers::StridedArrayView1D<Int>& destination) const;
         MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
         MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix3>& destination) const;
         MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, const Containers::StridedArrayView1D<Matrix4>& destination) const;
@@ -1557,7 +1558,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
             #ifndef CORRADE_NO_ASSERT
             const char* const prefix,
             #endif
-            const SceneField name, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+            const UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL Containers::Array<UnsignedInt> indexFieldAsArrayInternal(
             #ifndef CORRADE_NO_ASSERT
             const char* const prefix,

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -2302,7 +2302,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
         /* Returns the offset at which `object` is for field at index `id`, or
            the end offset if the object is not found. The returned offset can
            be then passed to fieldData{Object,Field}ViewInternal(). */
-        std::size_t findFieldObjectOffsetInternal(const SceneFieldData& field, UnsignedInt object, std::size_t offset) const;
+        MAGNUM_TRADE_LOCAL std::size_t findFieldObjectOffsetInternal(const SceneFieldData& field, UnsignedInt object, std::size_t offset) const;
 
         /* Like objects() / field(), but returning just a 1D view, sliced from
            offset to offset + size. The parameterless overloads are equal to

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -26,7 +26,7 @@
 */
 
 /** @file
- * @brief Class @ref Magnum::Trade::SceneData, @ref Magnum::Trade::SceneFieldData, enum @ref Magnum::Trade::SceneObjectType, @ref Magnum::Trade::SceneField, @ref Magnum::Trade::SceneFieldType, function @ref Magnum::sceneObjectTypeSize(), @ref Magnum::sceneObjectTypeAlignment(), @ref Magnum::sceneFieldTypeSize(), @ref Magnum::sceneFieldTypeAlignment(), @ref Magnum::Trade::isSceneFieldCustom(), @ref Magnum::sceneFieldCustom()
+ * @brief Class @ref Magnum::Trade::SceneData, @ref Magnum::Trade::SceneFieldData, enum @ref Magnum::Trade::SceneMappingType, @ref Magnum::Trade::SceneField, @ref Magnum::Trade::SceneFieldType, function @ref Magnum::sceneMappingTypeSize(), @ref Magnum::sceneMappingTypeAlignment(), @ref Magnum::sceneFieldTypeSize(), @ref Magnum::sceneFieldTypeAlignment(), @ref Magnum::Trade::isSceneFieldCustom(), @ref Magnum::sceneFieldCustom()
  */
 
 #include <Corrade/Containers/Array.h>
@@ -44,17 +44,17 @@
 namespace Magnum { namespace Trade {
 
 /**
-@brief Scene object type
+@brief Scene object mapping type
 @m_since_latest
 
 Type used for mapping fields to corresponding objects. Unlike
-@ref SceneFieldType that is different for different fields, the object type is
-the same for all fields, and is guaranteed to be large enough to fit all
-@ref SceneData::objectCount() objects.
-@see @ref SceneData::objectType(), @ref sceneObjectTypeSize(),
-    @ref sceneObjectTypeAlignment()
+@ref SceneFieldType that is different for different fields, the object mapping
+type is the same for all fields, and is guaranteed to be large enough to fit
+@ref SceneData::mappingBound() objects.
+@see @ref SceneData::mappingType(), @ref sceneMappingTypeSize(),
+    @ref sceneMappingTypeAlignment()
 */
-enum class SceneObjectType: UnsignedByte {
+enum class SceneMappingType: UnsignedByte {
     /* Zero used for an invalid value */
 
     UnsignedByte = 1,   /**< @relativeref{Magnum,UnsignedByte} */
@@ -64,26 +64,26 @@ enum class SceneObjectType: UnsignedByte {
 };
 
 /**
-@debugoperatorenum{SceneObjectType}
+@debugoperatorenum{SceneMappingType}
 @m_since_latest
 */
-MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneObjectType value);
+MAGNUM_TRADE_EXPORT Debug& operator<<(Debug& debug, SceneMappingType value);
 
 /**
-@brief Size of given scene object type
+@brief Size of given scene object mapping type
 @m_since_latest
 
-@see @ref sceneObjectTypeAlignment()
+@see @ref sceneMappingTypeAlignment()
 */
-MAGNUM_TRADE_EXPORT UnsignedInt sceneObjectTypeSize(SceneObjectType type);
+MAGNUM_TRADE_EXPORT UnsignedInt sceneMappingTypeSize(SceneMappingType type);
 
 /**
-@brief Alignment of given scene object type
+@brief Alignment of given scene object mapping type
 @m_since_latest
 
-Returns the same value as @ref sceneObjectTypeSize().
+Returns the same value as @ref sceneMappingTypeSize().
 */
-MAGNUM_TRADE_EXPORT UnsignedInt sceneObjectTypeAlignment(SceneObjectType type);
+MAGNUM_TRADE_EXPORT UnsignedInt sceneMappingTypeAlignment(SceneMappingType type);
 
 /**
 @brief Scene field name
@@ -543,94 +543,94 @@ class MAGNUM_TRADE_EXPORT SceneFieldData {
          * initialization of the field array for @ref SceneData, expected to be
          * replaced with concrete values later.
          */
-        constexpr explicit SceneFieldData() noexcept: _size{}, _name{}, _isOffsetOnly{}, _objectType{}, _objectStride{}, _objectData{}, _fieldType{}, _fieldStride{}, _fieldArraySize{}, _fieldData{} {}
+        constexpr explicit SceneFieldData() noexcept: _size{}, _name{}, _isOffsetOnly{}, _mappingType{}, _mappingStride{}, _mappingData{}, _fieldType{}, _fieldStride{}, _fieldArraySize{}, _fieldData{} {}
 
         /**
          * @brief Type-erased constructor
          * @param name              Field name
-         * @param objectType        Object type
-         * @param objectData        Object data
+         * @param mappingType       Object mapping type
+         * @param mappingData       Object mapping data
          * @param fieldType         Field type
          * @param fieldData         Field data
          * @param fieldArraySize    Field array size. Use @cpp 0 @ce for
          *      non-array fields.
          *
-         * Expects that @p objectData and @p fieldData have the same size,
+         * Expects that @p mappingData and @p fieldData have the same size,
          * @p fieldType corresponds to @p name and @p fieldArraySize is zero
          * for builtin fields.
          */
-        constexpr explicit SceneFieldData(SceneField name, SceneObjectType objectType, const Containers::StridedArrayView1D<const void>& objectData, SceneFieldType fieldType, const Containers::StridedArrayView1D<const void>& fieldData, UnsignedShort fieldArraySize = 0) noexcept;
+        constexpr explicit SceneFieldData(SceneField name, SceneMappingType mappingType, const Containers::StridedArrayView1D<const void>& mappingData, SceneFieldType fieldType, const Containers::StridedArrayView1D<const void>& fieldData, UnsignedShort fieldArraySize = 0) noexcept;
 
         /**
          * @brief Constructor
          * @param name              Field name
-         * @param objectData        Object data
+         * @param mappingData       Object mapping data
          * @param fieldType         Field type
          * @param fieldData         Field data
          * @param fieldArraySize    Field array size. Use @cpp 0 @ce for
          *      non-array fields.
          *
-         * Expects that @p objectData and @p fieldData have the same size in
-         * the first dimension, that the second dimension of @p objectData is
+         * Expects that @p mappingData and @p fieldData have the same size in
+         * the first dimension, that the second dimension of @p mappingData is
          * contiguous and its size is either 1, 2, 4 or 8, corresponding to one
-         * of the @ref SceneObjectType values, that the second dimension of
+         * of the @ref SceneMappingType values, that the second dimension of
          * @p fieldData is contiguous and its size matches @p fieldType and
          * @p fieldArraySize and that @p fieldType corresponds to @p name and
          * @p fieldArraySize is zero for builtin attributes.
          */
-        explicit SceneFieldData(SceneField name, const Containers::StridedArrayView2D<const char>& objectData, SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, UnsignedShort fieldArraySize = 0) noexcept;
+        explicit SceneFieldData(SceneField name, const Containers::StridedArrayView2D<const char>& mappingData, SceneFieldType fieldType, const Containers::StridedArrayView2D<const char>& fieldData, UnsignedShort fieldArraySize = 0) noexcept;
 
         /**
          * @brief Constructor
          * @param name          Field name
-         * @param objectData    Object data
+         * @param mappingData   Object mapping data
          * @param fieldData     Field data
          *
-         * Detects @ref SceneObjectType based on @p T and @ref SceneFieldType
-         * based on @p U and calls @ref SceneFieldData(SceneField, SceneObjectType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort).
+         * Detects @ref SceneMappingType based on @p T and @ref SceneFieldType
+         * based on @p U and calls @ref SceneFieldData(SceneField, SceneMappingType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort).
          * For all types known by Magnum, the detected @ref SceneFieldType is
          * of the same name as the type (so e.g. @relativeref{Magnum,Vector3ui}
          * gets recognized as @ref SceneFieldType::Vector3ui).
          */
-        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView1D<U>& fieldData) noexcept;
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& mappingData, const Containers::StridedArrayView1D<U>& fieldData) noexcept;
 
         /** @overload */
-        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::ArrayView<U>& fieldData) noexcept: SceneFieldData{name, objectData, Containers::stridedArrayView(fieldData)} {}
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& mappingData, const Containers::ArrayView<U>& fieldData) noexcept: SceneFieldData{name, mappingData, Containers::stridedArrayView(fieldData)} {}
 
         /** @overload */
-        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& objectData, const Containers::StridedArrayView1D<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(objectData), fieldData} {}
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& mappingData, const Containers::StridedArrayView1D<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(mappingData), fieldData} {}
 
         /** @overload */
-        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& objectData, const Containers::ArrayView<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(objectData), Containers::stridedArrayView(fieldData)} {}
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& mappingData, const Containers::ArrayView<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(mappingData), Containers::stridedArrayView(fieldData)} {}
 
         /**
          * @brief Construct an array field
          * @param name          Field name
-         * @param objectData    Object data
+         * @param mappingData   Object mapping data
          * @param fieldData     Field data
          *
-         * Detects @ref SceneObjectType based on @p T and @ref SceneFieldType
-         * based on @p U and calls @ref SceneFieldData(SceneField, SceneObjectType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort)
+         * Detects @ref SceneMappingType based on @p T and @ref SceneFieldType
+         * based on @p U and calls @ref SceneFieldData(SceneField, SceneMappingType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort)
          * with the @p fieldData second dimension size passed to
          * @p fieldArraySize. Expects that the second dimension of @p fieldData
          * is contiguous. At the moment only custom fields can be arrays, which
          * means this function can't be used with a builtin @p name. See
          * @ref SceneFieldData(SceneField, const Containers::StridedArrayView1D<T>&, const Containers::StridedArrayView1D<U>&)
-         * for details about @ref SceneObjectType and @ref SceneFieldType
+         * for details about @ref SceneMappingType and @ref SceneFieldType
          * detection.
          */
-        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView2D<U>& fieldData) noexcept;
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::StridedArrayView1D<T>& mappingData, const Containers::StridedArrayView2D<U>& fieldData) noexcept;
 
         /** @overload */
-        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& objectData, const Containers::StridedArrayView2D<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(objectData), fieldData} {}
+        template<class T, class U> constexpr explicit SceneFieldData(SceneField name, const Containers::ArrayView<T>& mappingData, const Containers::StridedArrayView2D<U>& fieldData) noexcept: SceneFieldData{name, Containers::stridedArrayView(mappingData), fieldData} {}
 
         /**
          * @brief Construct an offset-only field
          * @param name              Field name
          * @param size              Number of entries
-         * @param objectType        Object type
-         * @param objectOffset      Object data offset
-         * @param objectStride      Object data stride
+         * @param mappingType       Object mapping type
+         * @param mappingOffset     Object mapping data offset
+         * @param mappingStride     Object mapping data stride
          * @param fieldType         Field type
          * @param fieldOffset       Field data offset
          * @param fieldStride       Field data stride
@@ -644,24 +644,24 @@ class MAGNUM_TRADE_EXPORT SceneFieldData {
          * @p name and @p fieldArraySize is zero for builtin attributes.
          *
          * Note that due to the @cpp constexpr @ce nature of this constructor,
-         * no @p objectType checks against @p objectStride or
+         * no @p mappingType checks against @p mappingStride or
          * @p fieldType / @p fieldArraySize checks against @p fieldStride can
-         * be done. You're encouraged to use the @ref SceneFieldData(SceneField, SceneObjectType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort)
+         * be done. You're encouraged to use the @ref SceneFieldData(SceneField, SceneMappingType, const Containers::StridedArrayView1D<const void>&, SceneFieldType, const Containers::StridedArrayView1D<const void>&, UnsignedShort)
          * constructor if you want additional safeguards.
          * @see @ref isOffsetOnly(), @ref fieldArraySize(),
-         *      @ref objectData(Containers::ArrayView<const void>) const,
+         *      @ref mappingData(Containers::ArrayView<const void>) const,
          *      @ref fieldData(Containers::ArrayView<const void>) const
          */
-        explicit constexpr SceneFieldData(SceneField name, std::size_t size, SceneObjectType objectType, std::size_t objectOffset, std::ptrdiff_t objectStride, SceneFieldType fieldType, std::size_t fieldOffset, std::ptrdiff_t fieldStride, UnsignedShort fieldArraySize = 0) noexcept;
+        explicit constexpr SceneFieldData(SceneField name, std::size_t size, SceneMappingType mappingType, std::size_t mappingOffset, std::ptrdiff_t mappingStride, SceneFieldType fieldType, std::size_t fieldOffset, std::ptrdiff_t fieldStride, UnsignedShort fieldArraySize = 0) noexcept;
 
         /**
          * @brief If the field is offset-only
          *
          * Returns @cpp true @ce if the field doesn't contain the data views
          * directly, but instead refers to unspecified external data.
-         * @see @ref objectData(Containers::ArrayView<const void>) const,
+         * @see @ref mappingData(Containers::ArrayView<const void>) const,
          *      @ref fieldData(Containers::ArrayView<const void>) const,
-         *      @ref SceneFieldData(SceneField, std::size_t, SceneObjectType, std::size_t, std::ptrdiff_t, SceneFieldType, std::size_t, std::ptrdiff_t, UnsignedShort)
+         *      @ref SceneFieldData(SceneField, std::size_t, SceneMappingType, std::size_t, std::ptrdiff_t, SceneFieldType, std::size_t, std::ptrdiff_t, UnsignedShort)
          */
         constexpr bool isOffsetOnly() const { return _isOffsetOnly; }
 
@@ -671,36 +671,36 @@ class MAGNUM_TRADE_EXPORT SceneFieldData {
         /** @brief Number of entries */
         constexpr UnsignedLong size() const { return _size; }
 
-        /** @brief Object type */
-        constexpr SceneObjectType objectType() const { return _objectType; }
+        /** @brief Object mapping type */
+        constexpr SceneMappingType mappingType() const { return _mappingType; }
 
         /**
-         * @brief Type-erased object data
+         * @brief Type-erased object mapping data
          *
          * Expects that the field is not offset-only, in that case use the
-         * @ref objectData(Containers::ArrayView<const void>) const overload
+         * @ref mappingData(Containers::ArrayView<const void>) const overload
          * instead.
          * @see @ref isOffsetOnly()
          */
-        constexpr Containers::StridedArrayView1D<const void> objectData() const {
+        constexpr Containers::StridedArrayView1D<const void> mappingData() const {
             return Containers::StridedArrayView1D<const void>{
                 /* We're *sure* the view is correct, so faking the view size */
                 /** @todo better ideas for the StridedArrayView API? */
-                {_objectData.pointer, ~std::size_t{}}, _size,
-                (CORRADE_CONSTEXPR_ASSERT(!_isOffsetOnly, "Trade::SceneFieldData::objectData(): the field is offset-only, supply a data array"), _objectStride)};
+                {_mappingData.pointer, ~std::size_t{}}, _size,
+                (CORRADE_CONSTEXPR_ASSERT(!_isOffsetOnly, "Trade::SceneFieldData::mappingData(): the field is offset-only, supply a data array"), _mappingStride)};
         }
 
         /**
-         * @brief Type-erased object data for an offset-only attribute
+         * @brief Type-erased object mapping data for an offset-only attribute
          *
          * If the field is not offset-only, the @p data parameter is ignored.
-         * @see @ref isOffsetOnly(), @ref objectData() const
+         * @see @ref isOffsetOnly(), @ref mappingData() const
          */
-        Containers::StridedArrayView1D<const void> objectData(Containers::ArrayView<const void> data) const {
+        Containers::StridedArrayView1D<const void> mappingData(Containers::ArrayView<const void> data) const {
             return Containers::StridedArrayView1D<const void>{
                 /* We're *sure* the view is correct, so faking the view size */
                 /** @todo better ideas for the StridedArrayView API? */
-                data, _isOffsetOnly ? reinterpret_cast<const char*>(data.data()) + _objectData.offset : _objectData.pointer, _size, _objectStride};
+                data, _isOffsetOnly ? reinterpret_cast<const char*>(data.data()) + _mappingData.offset : _mappingData.pointer, _size, _mappingStride};
         }
 
         /** @brief Field type */
@@ -755,9 +755,9 @@ class MAGNUM_TRADE_EXPORT SceneFieldData {
         UnsignedLong _size;
         SceneField _name;
         bool _isOffsetOnly;
-        SceneObjectType _objectType;
-        Short _objectStride;
-        Data _objectData;
+        SceneMappingType _mappingType;
+        Short _mappingStride;
+        Data _mappingData;
 
         SceneFieldType _fieldType;
         Short _fieldStride;
@@ -788,58 +788,60 @@ class MAGNUM_TRADE_EXPORT SceneData {
     public:
         /**
          * @brief Construct scene data
-         * @param objectType    Object type
-         * @param objectCount   Total count of all objects in the scene
-         * @param data          Data for all fields and objects
+         * @param mappingType   Object mapping type
+         * @param mappingBound  Upper bound on object mapping indices in the
+         *      scene
+         * @param data          Data for all fields and object mappings
          * @param fields        Description of all scene field data
          * @param importerState Importer-specific state
          * @m_since_latest
          *
-         * The @p objectType is expected to be large enough to index all
-         * @p objectCount objects. The @p fields are expected to reference
+         * The @p mappingType is expected to be large enough to index
+         * @p mappingBound objects. The @p fields are expected to reference
          * (sparse) sub-ranges of @p data, each having an unique
-         * @ref SceneField and @ref SceneObjectType equal to @p objectType.
+         * @ref SceneField, and @ref SceneMappingType equal to @p mappingType.
          * Particular fields can have additional restrictions, see
          * documentation of @ref SceneField values for more information.
          *
          * The @ref dataFlags() are implicitly set to a combination of
          * @ref DataFlag::Owned and @ref DataFlag::Mutable. For non-owned data
-         * use the @ref SceneData(SceneObjectType, UnsignedLong, DataFlags, Containers::ArrayView<const void>, Containers::Array<SceneFieldData>&&, const void*)
+         * use the @ref SceneData(SceneMappingType, UnsignedLong, DataFlags, Containers::ArrayView<const void>, Containers::Array<SceneFieldData>&&, const void*)
          * constructor or its variants instead.
          */
-        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, Containers::Array<char>&& data, Containers::Array<SceneFieldData>&& fields, const void* importerState = nullptr) noexcept;
+        explicit SceneData(SceneMappingType mappingType, UnsignedLong mappingBound, Containers::Array<char>&& data, Containers::Array<SceneFieldData>&& fields, const void* importerState = nullptr) noexcept;
 
         /**
          * @overload
          * @m_since_latest
          */
         /* Not noexcept because allocation happens inside */
-        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, Containers::Array<char>&& data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
+        explicit SceneData(SceneMappingType mappingType, UnsignedLong mappingBound, Containers::Array<char>&& data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
 
         /**
          * @brief Construct non-owned scene data
-         * @param objectType    Object type
-         * @param objectCount   Total count of all objects in the scene
+         * @param mappingType   Object mapping type
+         * @param mappingBound  Upper bound on object mapping indices in the
+         *      scene
          * @param dataFlags     Data flags
-         * @param data          View on data for all fields and objects
+         * @param data          View on data for all fields and object mappings
          * @param fields        Description of all scene field data
          * @param importerState Importer-specific state
          * @m_since_latest
          *
-         * Compared to @ref SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+         * Compared to @ref SceneData(SceneMappingType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
          * creates an instance that doesn't own the passed data. The
          * @p dataFlags parameter can contain @ref DataFlag::Mutable to
          * indicate the external data can be modified, and is expected to *not*
          * have @ref DataFlag::Owned set.
          */
-        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, DataFlags dataFlags, Containers::ArrayView<const void> data, Containers::Array<SceneFieldData>&& fields, const void* importerState = nullptr) noexcept;
+        explicit SceneData(SceneMappingType mappingType, UnsignedLong mappingBound, DataFlags dataFlags, Containers::ArrayView<const void> data, Containers::Array<SceneFieldData>&& fields, const void* importerState = nullptr) noexcept;
 
         /**
          * @overload
          * @m_since_latest
          */
         /* Not noexcept because allocation happens inside */
-        explicit SceneData(SceneObjectType objectType, UnsignedLong objectCount, DataFlags dataFlags, Containers::ArrayView<const void> data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
+        explicit SceneData(SceneMappingType mappingType, UnsignedLong mappingBound, DataFlags dataFlags, Containers::ArrayView<const void> data, std::initializer_list<SceneFieldData> fields, const void* importerState = nullptr);
 
         #ifdef MAGNUM_BUILD_DEPRECATED
          /**
@@ -847,10 +849,10 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @param children2D        Two-dimensional child objects
          * @param children3D        Three-dimensional child objects
          * @param importerState     Importer-specific state
-         * @m_deprecated_since_latest Use @ref SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
+         * @m_deprecated_since_latest Use @ref SceneData(SceneMappingType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*)
          *      instead.
          */
-        explicit CORRADE_DEPRECATED("use SceneData(SceneObjectType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*) instead") SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* importerState = nullptr);
+        explicit CORRADE_DEPRECATED("use SceneData(SceneMappingType, UnsignedLong, Containers::Array<char>&&, Containers::Array<SceneFieldData>&&, const void*) instead") SceneData(std::vector<UnsignedInt> children2D, std::vector<UnsignedInt> children3D, const void* importerState = nullptr);
         #endif
 
         /** @brief Copying is not allowed */
@@ -871,8 +873,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Data flags
          * @m_since_latest
          *
-         * @see @ref releaseData(), @ref mutableData(), @ref mutableField(),
-         *      @ref mutableObjects()
+         * @see @ref releaseData(), @ref mutableData(), @ref mutableMapping(),
+         *      @ref mutableField()
          */
         DataFlags dataFlags() const { return _dataFlags; }
 
@@ -910,20 +912,20 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Type used for object mapping
          * @m_since_latest
          *
-         * Type returned from @ref objects() and @ref mutableObjects(). It's
+         * Type returned from @ref mapping() and @ref mutableMapping(). It's
          * the same for all fields and is guaranteed to be large enough to fit
-         * all @ref objectCount() objects.
+         * @ref mappingBound() objects.
          */
-        SceneObjectType objectType() const { return _objectType; }
+        SceneMappingType mappingType() const { return _mappingType; }
 
         /**
-         * @brief Total object count
+         * @brief Object mapping bound
          * @m_since_latest
          *
-         * Total number of objects contained in the scene.
+         * Upper bound on object mapping indices of all fields in the scene.
          * @see @ref fieldCount(), @ref fieldSize()
          */
-        UnsignedLong objectCount() const { return _objectCount; }
+        UnsignedLong mappingBound() const { return _mappingBound; }
 
         /**
          * @brief Field count
@@ -933,8 +935,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * a scene with no fields. Each @ref SceneField can be present only
          * once, however an object can have a certain field associated with it
          * multiple times with different values (for example an object having
-         * multiple meshes). See also @ref objectCount() which returns count of
-         * actual objects.
+         * multiple meshes).
          */
         UnsignedInt fieldCount() const { return _fields.size(); }
 
@@ -945,7 +946,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * Returns the raw data that are used as a base for all `field*()`
          * accessors, or @cpp nullptr @ce if the scene has no fields. In most
          * cases you don't want to access those directly, but rather use the
-         * @ref objects(), @ref field(), @ref fieldName(), @ref fieldType(),
+         * @ref mapping(), @ref field(), @ref fieldName(), @ref fieldType(),
          * @ref fieldSize() and @ref fieldArraySize() accessors. Compared to
          * those and to @ref fieldData(UnsignedInt) const, the
          * @ref SceneFieldData instances returned by this function may have
@@ -967,7 +968,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * Returns the raw data that are used as a base for all `field*()`
          * accessors. In most cases you don't want to access those directly,
-         * but rather use the @ref objects(), @ref field(), @ref fieldName(),
+         * but rather use the @ref mapping(), @ref field(), @ref fieldName(),
          * @ref fieldType(), @ref fieldSize() and @ref fieldArraySize()
          * accessors. This is also the reason why there's no overload taking a
          * @ref SceneField, unlike the other accessors.
@@ -998,7 +999,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p id is expected to be smaller than @ref fieldCount(). You can
          * also use @ref fieldType(SceneField) const to directly get a type of
          * given named field.
-         * @see @ref fieldName(), @ref objectType()
+         * @see @ref fieldName(), @ref mappingType()
          */
         SceneFieldType fieldType(UnsignedInt id) const;
 
@@ -1006,9 +1007,9 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @brief Size of given field
          * @m_since_latest
          *
-         * Size of the view returned by @ref field() / @ref mutableField() and
-         * also @ref objects() / @ref mutableObjects() for given @p id. Since
-         * an object can have multiple entries of the same field (for example
+         * Size of the view returned by @ref mapping() / @ref mutableMapping()
+         * and @ref field() / @ref mutableField() for given @p id. Since an
+         * object can have multiple entries of the same field (for example
          * multiple meshes associated with an object), the size doesn't
          * necessarily match the number of objects having given field.
          *
@@ -1107,7 +1108,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * If @p object isn't present in @p fieldId starting at @p offset,
          * returns @ref Containers::NullOpt. The @p fieldId is expected to be
          * smaller than @ref fieldCount(), @p object smaller than
-         * @ref objectCount() and @p offset not larger than
+         * @ref mappingBound() and @p offset not larger than
          * @ref fieldSize(UnsignedInt) const.
          *
          * The lookup is done in an @f$ \mathcal{O}(n) @f$ complexity with
@@ -1126,7 +1127,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * If @p object isn't present in @p fieldName starting at @p offset,
          * returns @ref Containers::NullOpt. The @p fieldName is expected to
-         * exist, @p object is expected to be smaller than @ref objectCount()
+         * exist, @p object is expected to be smaller than @ref mappingBound()
          * and @p offset not be larger than @ref fieldSize(SceneField) const.
          *
          * The lookup is done in an @f$ \mathcal{O}(m + n) @f$ complexity with
@@ -1165,7 +1166,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * The @p fieldId is expected to be smaller than @ref fieldCount() and
-         * @p object smaller than @ref objectCount().
+         * @p object smaller than @ref mappingBound().
          */
         bool hasFieldObject(UnsignedInt fieldId, UnsignedInt object) const;
 
@@ -1174,7 +1175,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * The @p fieldName is expected to exist and @p object is expected to
-         * be smaller than @ref objectCount().
+         * be smaller than @ref mappingBound().
          * @see @ref hasField()
          */
         bool hasFieldObject(SceneField fieldName, UnsignedInt object) const;
@@ -1212,33 +1213,33 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p fieldId is expected to be smaller than @ref fieldCount(). The
          * second dimension represents the actual data type (its size is equal
-         * to @ref SceneObjectType size) and is guaranteed to be contiguous.
-         * Use the templated overload below to get the objects in a concrete
+         * to @ref SceneMappingType size) and is guaranteed to be contiguous.
+         * Use the templated overload below to get the mapping in a concrete
          * type.
-         * @see @ref mutableObjects(UnsignedInt),
+         * @see @ref mutableMapping(UnsignedInt),
          *      @ref Corrade::Containers::StridedArrayView::isContiguous(),
-         *      @ref sceneObjectTypeSize()
+         *      @ref sceneMappingTypeSize()
          */
-        Containers::StridedArrayView2D<const char> objects(UnsignedInt fieldId) const;
+        Containers::StridedArrayView2D<const char> mapping(UnsignedInt fieldId) const;
 
         /**
          * @brief Mutable object mapping data for given field
          * @m_since_latest
          *
-         * Like @ref objects(UnsignedInt) const, but returns a mutable view.
+         * Like @ref mapping(UnsignedInt) const, but returns a mutable view.
          * Expects that the scene is mutable.
          * @see @ref dataFlags()
          */
-        Containers::StridedArrayView2D<char> mutableObjects(UnsignedInt fieldId);
+        Containers::StridedArrayView2D<char> mutableMapping(UnsignedInt fieldId);
 
         /**
          * @brief Object mapping for given field
          * @m_since_latest
          *
          * The @p fieldId is expected to be smaller than @ref fieldCount() and
-         * @p T is expected to correspond to @ref objectType().
+         * @p T is expected to correspond to @ref mappingType().
          *
-         * You can also use the non-templated @ref objectsAsArray() accessor
+         * You can also use the non-templated @ref mappingAsArray() accessor
          * (or the combined @ref parentsAsArray(),
          * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
          * @ref translationsRotationsScalings2DAsArray(),
@@ -1248,19 +1249,19 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref importerStateAsArray() accessors) to get the object mapping
          * converted to the usual type, but note that these operations involve
          * extra allocation and data conversion.
-         * @see @ref mutableObjects(UnsignedInt)
+         * @see @ref mutableMapping(UnsignedInt)
          */
-        template<class T> Containers::StridedArrayView1D<const T> objects(UnsignedInt fieldId) const;
+        template<class T> Containers::StridedArrayView1D<const T> mapping(UnsignedInt fieldId) const;
 
         /**
          * @brief Mutable object mapping for given field
          * @m_since_latest
          *
-         * Like @ref objects(UnsignedInt) const, but returns a mutable view.
+         * Like @ref mapping(UnsignedInt) const, but returns a mutable view.
          * Expects that the scene is mutable.
          * @see @ref dataFlags()
          */
-        template<class T> Containers::StridedArrayView1D<T> mutableObjects(UnsignedInt fieldId);
+        template<class T> Containers::StridedArrayView1D<T> mutableMapping(UnsignedInt fieldId);
 
         /**
          * @brief Object mapping data for given named field
@@ -1268,32 +1269,33 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p fieldName is expected to exist. The second dimension
          * represents the actual data type (its size is equal to
-         * @ref SceneObjectType size) and is guaranteed to be contiguous. Use
-         * the templated overload below to get the objects in a concrete type.
-         * @see @ref hasField(), @ref objects(UnsignedInt) const,
-         *      @ref mutableObjects(SceneField),
+         * @ref SceneMappingType size) and is guaranteed to be contiguous. Use
+         * the templated overload below to get the object mapping in a concrete
+         * type.
+         * @see @ref hasField(), @ref mapping(UnsignedInt) const,
+         *      @ref mutableMapping(SceneField),
          *      @ref Corrade::Containers::StridedArrayView::isContiguous()
          */
-        Containers::StridedArrayView2D<const char> objects(SceneField fieldName) const;
+        Containers::StridedArrayView2D<const char> mapping(SceneField fieldName) const;
 
         /**
          * @brief Mutable object mapping data for given named field
          * @m_since_latest
          *
-         * Like @ref objects(SceneField) const, but returns a mutable view.
+         * Like @ref mapping(SceneField) const, but returns a mutable view.
          * Expects that the scene is mutable.
          * @see @ref dataFlags()
          */
-        Containers::StridedArrayView2D<char> mutableObjects(SceneField fieldName);
+        Containers::StridedArrayView2D<char> mutableMapping(SceneField fieldName);
 
         /**
          * @brief Object mapping for given named field
          * @m_since_latest
          *
          * The @p fieldName is expected to exist and @p T is expected to
-         * correspond to @ref objectType().
+         * correspond to @ref mappingType().
          *
-         * You can also use the non-templated @ref objectsAsArray() accessor
+         * You can also use the non-templated @ref mappingAsArray() accessor
          * (or the combined @ref parentsAsArray(),
          * @ref transformations2DAsArray(), @ref transformations3DAsArray(),
          * @ref translationsRotationsScalings2DAsArray(),
@@ -1303,20 +1305,20 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref importerStateAsArray() accessors) to get the object mapping
          * converted to the usual type, but note that these operations involve
          * extra allocation and data conversion.
-         * @see @ref hasField(), @ref objects(UnsignedInt) const,
-         *      @ref mutableObjects(UnsignedInt)
+         * @see @ref hasField(), @ref mapping(UnsignedInt) const,
+         *      @ref mutableMapping(UnsignedInt)
          */
-        template<class T> Containers::StridedArrayView1D<const T> objects(SceneField fieldName) const;
+        template<class T> Containers::StridedArrayView1D<const T> mapping(SceneField fieldName) const;
 
         /**
          * @brief Mutable object mapping for given named field
          * @m_since_latest
          *
-         * Like @ref objects(SceneField) const, but returns a mutable view.
+         * Like @ref mapping(SceneField) const, but returns a mutable view.
          * Expects that the scene is mutable.
          * @see @ref dataFlags()
          */
-        template<class T> Containers::StridedArrayView1D<T> mutableObjects(SceneField fieldName);
+        template<class T> Containers::StridedArrayView1D<T> mutableMapping(SceneField fieldName);
 
         /**
          * @brief Data for given field
@@ -1485,7 +1487,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Convenience alternative to the templated
-         * @ref objects(UnsignedInt) const that converts the field from an
+         * @ref mapping(UnsignedInt) const that converts the field from an
          * arbitrary underlying type and returns it in a newly-allocated array.
          * The @p fieldId is expected to be smaller than @ref fieldCount().
          *
@@ -1498,15 +1500,15 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref camerasAsArray(), @ref skinsAsArray(),
          * @ref importerStateAsArray() accessors, which give out the object
          * mapping together with the field data.
-         * @see @ref objectsInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * @see @ref mappingInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
          */
-        Containers::Array<UnsignedInt> objectsAsArray(UnsignedInt fieldId) const;
+        Containers::Array<UnsignedInt> mappingAsArray(UnsignedInt fieldId) const;
 
         /**
          * @brief Object mapping for given field as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Like @ref objectsAsArray(UnsignedInt) const, but puts the result
+         * Like @ref mappingAsArray(UnsignedInt) const, but puts the result
          * into @p destination instead of allocating a new array. Expects that
          * @p destination is sized to contain exactly all data.
          *
@@ -1521,13 +1523,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * @see @ref fieldSize(UnsignedInt) const
          */
-        void objectsInto(UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        void mappingInto(UnsignedInt fieldId, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief A subrange of object mapping for given field as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref objectsInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * Compared to @ref mappingInto(UnsignedInt, const Containers::StridedArrayView1D<UnsignedInt>&) const
          * extracts only a subrange of the object mapping defined by @p offset
          * and size of the @p destination view, returning the count of items
          * actually extracted. The @p offset is expected to not be larger than
@@ -1545,14 +1547,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(UnsignedInt) const,
          *      @ref fieldObjectOffset(UnsignedInt, UnsignedInt, std::size_t) const
          */
-        std::size_t objectsInto(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        std::size_t mappingInto(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief Object mapping for given named field as 32-bit integers
          * @m_since_latest
          *
          * Convenience alternative to the templated
-         * @ref objects(SceneField) const that converts the field from an
+         * @ref mapping(SceneField) const that converts the field from an
          * arbitrary underlying type and returns it in a newly-allocated array.
          * The @p fieldName is expected to exist.
          *
@@ -1565,16 +1567,16 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref camerasAsArray(), @ref skinsAsArray(),
          * @ref importerStateAsArray() accessors, which give out the object
          * mapping together with the field data.
-         * @see @ref objectsInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const,
+         * @see @ref mappingInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const,
          *      @ref hasField()
          */
-        Containers::Array<UnsignedInt> objectsAsArray(SceneField fieldName) const;
+        Containers::Array<UnsignedInt> mappingAsArray(SceneField fieldName) const;
 
         /**
          * @brief Object mapping for given named field as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Like @ref objectsAsArray(SceneField) const, but puts the result into
+         * Like @ref mappingAsArray(SceneField) const, but puts the result into
          * @p destination instead of allocating a new array. Expects that
          * @p destination is sized to contain exactly all data.
          *
@@ -1589,13 +1591,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * @see @ref fieldSize(SceneField) const
          */
-        void objectsInto(SceneField fieldName, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        void mappingInto(SceneField fieldName, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief A subrange of object mapping for given named field as 32-bit integers into a pre-allocated view
          * @m_since_latest
          *
-         * Compared to @ref objectsInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const
+         * Compared to @ref mappingInto(SceneField, const Containers::StridedArrayView1D<UnsignedInt>&) const
          * extracts only a subrange of the object mapping defined by @p offset
          * and size of the @p destination view, returning the count of items
          * actually extracted. The @p offset is expected to not be larger than
@@ -1613,13 +1615,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t objectsInto(SceneField fieldName, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        std::size_t mappingInto(SceneField fieldName, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
 
         /**
          * @brief Parent indices as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Parent as
          * the argument. Converts the object mapping and the field from
          * arbitrary underlying types and returns them in a newly-allocated
@@ -1634,14 +1636,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref parentsAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
-         * new array. Expects that each view is either @cpp nullptr @ce or
+         * @p mappingDestination and @p fieldDestination instead of allocating
+         * a new array. Expects that each view is either @cpp nullptr @ce or
          * sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
-         * @ref objectsInto() with @ref SceneField::Parent.
+         * @ref mappingInto() with @ref SceneField::Parent.
          * @see @ref fieldSize(SceneField) const
          */
-        void parentsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const;
+        void parentsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const;
 
         /**
          * @brief A subrange of parent indices as 32-bit integers into a pre-allocated view
@@ -1655,13 +1657,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t parentsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const;
+        std::size_t parentsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Int>& fieldDestination) const;
 
         /**
          * @brief 2D transformations as 3x3 float matrices
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with
          * @ref SceneField::Transformation as the argument, or, if not present,
          * to a matrix created out of a subset of the
@@ -1682,17 +1684,17 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref transformations2DAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
-         * new array. Expects that each view is either @cpp nullptr @ce or
+         * @p mappingDestination and @p fieldDestination instead of allocating
+         * a new array. Expects that each view is either @cpp nullptr @ce or
          * sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
-         * @ref objectsInto() with the first of the
+         * @ref mappingInto() with the first of the
          * @ref SceneField::Transformation, @ref SceneField::Translation,
          * @ref SceneField::Rotation and @ref SceneField::Scaling fields that's
          * present.
          * @see @ref fieldSize(SceneField) const
          */
-        void transformations2DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const;
+        void transformations2DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const;
 
         /**
          * @brief A subrange of 2D transformations as 3x3 float matrices into a pre-allocated view
@@ -1706,13 +1708,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const;
+        std::size_t transformations2DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix3>& fieldDestination) const;
 
         /**
          * @brief 2D transformations as float translation, rotation and scaling components
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Translation,
          * @ref SceneField::Rotation and @ref SceneField::Scaling as the
          * arguments, as these are required to share the same object mapping.
@@ -1737,18 +1739,18 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref translationsRotationsScalings2DAsArray(), but puts the
-         * result into @p objectDestination, @p translationDestination,
+         * result into @p mappingDestination, @p translationDestination,
          * @p rotationDestination and @p scalingDestination instead of
          * allocating a new array. Expects that each view is either
          * @cpp nullptr @ce or sized to contain exactly all data. If
          * @p translationDestination, @p rotationDestination and
          * @p scalingDestination are all @cpp nullptr @ce, the effect is the
-         * same as calling @ref objectsInto() with one of the
+         * same as calling @ref mappingInto() with one of the
          * @ref SceneField::Translation, @ref SceneField::Rotation and
          * @ref SceneField::Scaling fields that's present.
          * @see @ref fieldSize(SceneField) const
          */
-        void translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
+        void translationsRotationsScalings2DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
 
         /**
          * @brief A subrange of 2D transformations as float translation, rotation and scaling components into a pre-allocated view
@@ -1762,13 +1764,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t translationsRotationsScalings2DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
+        std::size_t translationsRotationsScalings2DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
 
         /**
          * @brief 3D transformations as 4x4 float matrices
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with
          * @ref SceneField::Transformation as the argument, or, if not present,
          * to a matrix created out of a subset of the
@@ -1789,17 +1791,17 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref transformations3DAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
-         * new array. Expects that the two views are either @cpp nullptr @ce or
-         * sized to contain exactly all data. If @p fieldDestination is
+         * @p mappingDestination and @p fieldDestination instead of allocating
+         * a new array. Expects that the two views are either @cpp nullptr @ce
+         * or sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
-         * @ref objectsInto() with the first of the
+         * @ref mappingInto() with the first of the
          * @ref SceneField::Transformation, @ref SceneField::Translation,
          * @ref SceneField::Rotation and @ref SceneField::Scaling fields that's
          * present.
          * @see @ref fieldSize(SceneField) const
          */
-        void transformations3DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        void transformations3DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix4>& destination) const;
 
         /**
          * @brief A subrange of 3D transformations as 4x4 float matrices into a pre-allocated view
@@ -1813,13 +1815,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Matrix4>& destination) const;
+        std::size_t transformations3DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Matrix4>& destination) const;
 
         /**
          * @brief 3D transformations as float translation, rotation and scaling components
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Translation,
          * @ref SceneField::Rotation and @ref SceneField::Scaling as the
          * arguments, as these are required to share the same object mapping.
@@ -1844,18 +1846,18 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref translationsRotationsScalings3DAsArray(), but puts the
-         * result into @p objectDestination, @p translationDestination,
+         * result into @p mappingDestination, @p translationDestination,
          * @p rotationDestination and @p scalingDestination instead of
          * allocating a new array. Expects that each view is either
          * @cpp nullptr @ce or sized to contain exactly all data. If
          * @p translationDestination, @p rotationDestination and
          * @p scalingDestination are all @cpp nullptr @ce, the effect is the
-         * same as calling @ref objectsInto() with one of the
+         * same as calling @ref mappingInto() with one of the
          * @ref SceneField::Translation, @ref SceneField::Rotation and
          * @ref SceneField::Scaling fields that's present.
          * @see @ref fieldSize(SceneField) const
          */
-        void translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
+        void translationsRotationsScalings3DInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
 
         /**
          * @brief A subrange of 3D transformations as float translation, rotation and scaling components into a pre-allocated view
@@ -1869,13 +1871,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t translationsRotationsScalings3DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
+        std::size_t translationsRotationsScalings3DInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<Vector3>& translationDestination, const Containers::StridedArrayView1D<Quaternion>& rotationDestination, const Containers::StridedArrayView1D<Vector3>& scalingDestination) const;
 
         /**
          * @brief Mesh and material IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Mesh and
          * @ref SceneField::MeshMaterial as the argument, as the two are
          * required to share the same object mapping. Converts the object
@@ -1893,15 +1895,15 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref meshesMaterialsAsArray(), but puts the results into
-         * @p objectDestination, @p meshDestination and
+         * @p mappingDestination, @p meshDestination and
          * @p meshMaterialDestination instead of allocating a new array.
          * Expects that each view is either @cpp nullptr @ce or sized to
          * contain exactly all data. If @p meshDestination and
          * @p meshMaterialDestination are both @cpp nullptr @ce, the effect is
-         * the same as calling @ref objectsInto() with @ref SceneField::Mesh.
+         * the same as calling @ref mappingInto() with @ref SceneField::Mesh.
          * @see @ref fieldSize(SceneField) const
          */
-        void meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const;
+        void meshesMaterialsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialDestination) const;
 
         /**
          * @brief A subrange of mesh and material IDs as 32-bit integers into a pre-allocated view
@@ -1915,13 +1917,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t meshesMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialsDestination) const;
+        std::size_t meshesMaterialsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& meshDestination, const Containers::StridedArrayView1D<Int>& meshMaterialsDestination) const;
 
         /**
          * @brief Light IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Light as the
          * argument. Converts the object mapping and the field from arbitrary
          * underlying types and returns them in a newly-allocated array. The
@@ -1935,14 +1937,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref lightsAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
-         * new array. Expects that each view is either @cpp nullptr @ce or
+         * @p mappingDestination and @p fieldDestination instead of allocating
+         * a new array. Expects that each view is either @cpp nullptr @ce or
          * sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
          * @ref lightsInto() with @ref SceneField::Light.
          * @see @ref fieldSize(SceneField) const
          */
-        void lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
+        void lightsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief A subrange of light IDs as 32-bit integers into a pre-allocated view
@@ -1956,13 +1958,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t lightsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
+        std::size_t lightsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief Camera IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Camera as
          * the argument. Converts the object mapping and the field from
          * arbitrary underlying types and returns them in a newly-allocated
@@ -1976,14 +1978,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref camerasAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
-         * new array. Expects that each view is either @cpp nullptr @ce or
+         * @p mappingDestination and @p fieldDestination instead of allocating
+         * a new array. Expects that each view is either @cpp nullptr @ce or
          * sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
-         * @ref objectsInto() with @ref SceneField::Camera.
+         * @ref mappingInto() with @ref SceneField::Camera.
          * @see @ref fieldSize(SceneField) const
          */
-        void camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
+        void camerasInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief A subrange of camera IDs as 32-bit integers into a pre-allocated view
@@ -1997,13 +1999,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t camerasInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
+        std::size_t camerasInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief Skin IDs as 32-bit integers
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::Skin as the
          * argument. Converts the object mapping and the field from arbitrary
          * underlying types and returns them in a newly-allocated array. The
@@ -2017,14 +2019,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref skinsAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
+         * @p mappingDestination and @p fieldDestination instead of allocating a
          * new array. Expects that each view is either @cpp nullptr @ce or
          * sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
-         * @ref objectsInto() with @ref SceneField::Skin.
+         * @ref mappingInto() with @ref SceneField::Skin.
          * @see @ref fieldSize(SceneField) const
          */
-        void skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
+        void skinsInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief A subrange of skin IDs as 32-bit integers into a pre-allocated view
@@ -2038,13 +2040,13 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
+        std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<UnsignedInt>& fieldDestination) const;
 
         /**
          * @brief Per-object importer state as `void` pointers
          * @m_since_latest
          *
-         * Convenience alternative to @ref objects(SceneField) const together
+         * Convenience alternative to @ref mapping(SceneField) const together
          * with @ref field(SceneField) const with @ref SceneField::ImporterState
          * as the argument. Converts the object mapping and the field from
          * arbitrary underlying types and returns them in a newly-allocated
@@ -2061,14 +2063,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @m_since_latest
          *
          * Like @ref importerStateAsArray(), but puts the result into
-         * @p objectDestination and @p fieldDestination instead of allocating a
-         * new array. Expects that each view is either @cpp nullptr @ce or
+         * @p mappingDestination and @p fieldDestination instead of allocating
+         * a new array. Expects that each view is either @cpp nullptr @ce or
          * sized to contain exactly all data. If @p fieldDestination is
          * @cpp nullptr @ce, the effect is the same as calling
-         * @ref objectsInto() with @ref SceneField::ImporterState.
+         * @ref mappingInto() with @ref SceneField::ImporterState.
          * @see @ref fieldSize(SceneField) const
          */
-        void importerStateInto(const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const;
+        void importerStateInto(const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const;
 
         /**
          * @brief A subrange of per-object importer state as `void` pointers into a pre-allocated view
@@ -2082,7 +2084,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        std::size_t importerStateInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& objectDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const;
+        std::size_t importerStateInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& mappingDestination, const Containers::StridedArrayView1D<const void*>& fieldDestination) const;
 
         /**
          * @brief Parent for given object
@@ -2100,7 +2102,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * parent for @p object, returns @ref Containers::NullOpt. If @p object
          * is top-level, returns @cpp -1 @ce.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          * @see @ref childrenFor()
          */
         Containers::Optional<Int> parentFor(UnsignedInt object) const;
@@ -2121,7 +2123,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * objects which would have @p object listed as their parent, returns
          * an empty array. Pass @cpp -1 @ce to get a list of top-level objects.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          * @see @ref parentFor()
          */
         Containers::Array<UnsignedInt> childrenFor(Int object) const;
@@ -2147,7 +2149,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * 3D transformation or there's no transformation for @p object,
          * returns @ref Containers::NullOpt.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          * @see @ref translationRotationScaling2DFor()
          */
         Containers::Optional<Matrix3> transformation2DFor(UnsignedInt object) const;
@@ -2176,7 +2178,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * there's no transformation for @p object, returns
          * @ref Containers::NullOpt.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          * @see @ref transformation2DFor()
          */
         Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> translationRotationScaling2DFor(UnsignedInt object) const;
@@ -2202,7 +2204,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * 2D transformation or there's no transformation for @p object,
          * returns @ref Containers::NullOpt.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          * @see @ref translationRotationScaling3DFor()
          */
         Containers::Optional<Matrix4> transformation3DFor(UnsignedInt object) const;
@@ -2231,7 +2233,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * there's no transformation for @p object, returns
          * @ref Containers::NullOpt.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          * @see @ref transformation3DFor()
          */
         Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> translationRotationScaling3DFor(UnsignedInt object) const;
@@ -2254,7 +2256,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref SceneField::Mesh is not present or if there's no mesh for
          * @p object, returns an empty array.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          */
         Containers::Array<Containers::Pair<UnsignedInt, Int>> meshesMaterialsFor(UnsignedInt object) const;
 
@@ -2272,7 +2274,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * If the @ref SceneField::Light field is not present or if there's no
          * light for @p object, returns an empty array.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          */
         Containers::Array<UnsignedInt> lightsFor(UnsignedInt object) const;
 
@@ -2291,7 +2293,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * If the @ref SceneField::Camera field is not present or if there's no
          * camera for @p object, returns an empty array.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          */
         Containers::Array<UnsignedInt> camerasFor(UnsignedInt object) const;
 
@@ -2309,7 +2311,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * If the @ref SceneField::Skin field is not present or if there's no
          * skin for @p object, returns an empty array.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          */
         Containers::Array<UnsignedInt> skinsFor(UnsignedInt object) const;
 
@@ -2329,7 +2331,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * there's no importer state for @p object, returns
          * @ref Containers::NullOpt.
          *
-         * The @p object is expected to be less than @ref objectCount().
+         * The @p object is expected to be less than @ref mappingBound().
          */
         Containers::Optional<const void*> importerStateFor(UnsignedInt object) const;
 
@@ -2407,14 +2409,14 @@ class MAGNUM_TRADE_EXPORT SceneData {
 
         /* Returns the offset at which `object` is for field at index `id`, or
            the end offset if the object is not found. The returned offset can
-           be then passed to fieldData{Object,Field}ViewInternal(). */
+           be then passed to fieldData{Mapping,Field}ViewInternal(). */
         MAGNUM_TRADE_LOCAL std::size_t findFieldObjectOffsetInternal(const SceneFieldData& field, UnsignedInt object, std::size_t offset) const;
 
         /* Like objects() / field(), but returning just a 1D view, sliced from
            offset to offset + size. The parameterless overloads are equal to
            offset = 0 and size = field.size(). */
-        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataObjectViewInternal(const SceneFieldData& field, std::size_t offset, std::size_t size) const;
-        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataObjectViewInternal(const SceneFieldData& field) const;
+        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataMappingViewInternal(const SceneFieldData& field, std::size_t offset, std::size_t size) const;
+        MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataMappingViewInternal(const SceneFieldData& field) const;
         MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataFieldViewInternal(const SceneFieldData& field, std::size_t offset, std::size_t size) const;
         MAGNUM_TRADE_LOCAL Containers::StridedArrayView1D<const void> fieldDataFieldViewInternal(const SceneFieldData& field) const;
 
@@ -2422,7 +2424,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
         template<class T> bool checkFieldTypeCompatibility(const SceneFieldData& attribute, const char* prefix) const;
         #endif
 
-        MAGNUM_TRADE_LOCAL void objectsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+        MAGNUM_TRADE_LOCAL void mappingIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
         MAGNUM_TRADE_LOCAL UnsignedInt findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
         MAGNUM_TRADE_LOCAL UnsignedInt findTranslationRotationScalingFields(UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
@@ -2437,10 +2439,10 @@ class MAGNUM_TRADE_EXPORT SceneData {
         MAGNUM_TRADE_LOCAL void importerStateIntoInternal(const UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<const void*>& destination) const;
 
         DataFlags _dataFlags;
-        SceneObjectType _objectType;
+        SceneMappingType _mappingType;
         UnsignedByte _dimensions;
         /* 1/5 bytes free */
-        UnsignedLong _objectCount;
+        UnsignedLong _mappingBound;
         const void* _importerState;
         Containers::Array<SceneFieldData> _fields;
         Containers::Array<char> _data;
@@ -2569,13 +2571,13 @@ namespace Implementation {
         }
     };
 
-    template<class T> constexpr SceneObjectType sceneObjectTypeFor() {
-        static_assert(sizeof(T) == 0, "unsupported object type");
+    template<class T> constexpr SceneMappingType sceneMappingTypeFor() {
+        static_assert(sizeof(T) == 0, "unsupported mapping type");
         return {};
     }
     #ifndef DOXYGEN_GENERATING_OUTPUT
     #define _c(type) \
-        template<> constexpr SceneObjectType sceneObjectTypeFor<type>() { return SceneObjectType::type; }
+        template<> constexpr SceneMappingType sceneMappingTypeFor<type>() { return SceneMappingType::type; }
     _c(UnsignedByte)
     _c(UnsignedShort)
     _c(UnsignedInt)
@@ -2638,16 +2640,16 @@ namespace Implementation {
     }
 }
 
-constexpr SceneFieldData::SceneFieldData(const SceneField name, const SceneObjectType objectType, const Containers::StridedArrayView1D<const void>& objectData, const SceneFieldType fieldType, const Containers::StridedArrayView1D<const void>& fieldData, const UnsignedShort fieldArraySize) noexcept:
-    _size{(CORRADE_CONSTEXPR_ASSERT(objectData.size() == fieldData.size(),
-        "Trade::SceneFieldData: expected object and field view to have the same size but got" << objectData.size() << "and" << fieldData.size()), objectData.size())},
+constexpr SceneFieldData::SceneFieldData(const SceneField name, const SceneMappingType mappingType, const Containers::StridedArrayView1D<const void>& mappingData, const SceneFieldType fieldType, const Containers::StridedArrayView1D<const void>& fieldData, const UnsignedShort fieldArraySize) noexcept:
+    _size{(CORRADE_CONSTEXPR_ASSERT(mappingData.size() == fieldData.size(),
+        "Trade::SceneFieldData: expected mapping and field view to have the same size but got" << mappingData.size() << "and" << fieldData.size()), mappingData.size())},
     _name{(CORRADE_CONSTEXPR_ASSERT(Implementation::isSceneFieldTypeCompatibleWithField(name, fieldType),
         "Trade::SceneFieldData:" << fieldType << "is not a valid type for" << name), name)},
     _isOffsetOnly{false},
-    _objectType{objectType},
-    _objectStride{(CORRADE_CONSTEXPR_ASSERT(objectData.stride() >= -32768 && objectData.stride() <= 32767,
-        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got" << objectData.stride()), Short(objectData.stride()))},
-    _objectData{objectData.data()},
+    _mappingType{mappingType},
+    _mappingStride{(CORRADE_CONSTEXPR_ASSERT(mappingData.stride() >= -32768 && mappingData.stride() <= 32767,
+        "Trade::SceneFieldData: expected mapping view stride to fit into 16 bits, but got" << mappingData.stride()), Short(mappingData.stride()))},
+    _mappingData{mappingData.data()},
     _fieldType{fieldType},
     _fieldStride{(CORRADE_CONSTEXPR_ASSERT(fieldData.stride() >= -32768 && fieldData.stride() <= 32767,
         "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got" << fieldData.stride()), Short(fieldData.stride()))},
@@ -2655,27 +2657,27 @@ constexpr SceneFieldData::SceneFieldData(const SceneField name, const SceneObjec
         "Trade::SceneFieldData:" << name << "can't be an array field"), fieldArraySize)},
     _fieldData{fieldData.data()} {}
 
-template<class T, class U> constexpr SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView1D<U>& fieldData) noexcept: SceneFieldData{name, Implementation::sceneObjectTypeFor<typename std::remove_const<T>::type>(), objectData, Implementation::SceneFieldTypeFor<typename std::remove_const<U>::type>::type(), fieldData, 0} {}
+template<class T, class U> constexpr SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView1D<T>& mappingData, const Containers::StridedArrayView1D<U>& fieldData) noexcept: SceneFieldData{name, Implementation::sceneMappingTypeFor<typename std::remove_const<T>::type>(), mappingData, Implementation::SceneFieldTypeFor<typename std::remove_const<U>::type>::type(), fieldData, 0} {}
 
-template<class T, class U> constexpr SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView1D<T>& objectData, const Containers::StridedArrayView2D<U>& fieldData) noexcept: SceneFieldData{
+template<class T, class U> constexpr SceneFieldData::SceneFieldData(const SceneField name, const Containers::StridedArrayView1D<T>& mappingData, const Containers::StridedArrayView2D<U>& fieldData) noexcept: SceneFieldData{
     name,
-    Implementation::sceneObjectTypeFor<typename std::remove_const<T>::type>(),
-    objectData,
+    Implementation::sceneMappingTypeFor<typename std::remove_const<T>::type>(),
+    mappingData,
     Implementation::SceneFieldTypeFor<typename std::remove_const<U>::type>::type(),
     Containers::StridedArrayView1D<const void>{{fieldData.data(), ~std::size_t{}}, fieldData.size()[0], fieldData.stride()[0]},
     /* Not using isContiguous<1>() as that's not constexpr */
     (CORRADE_CONSTEXPR_ASSERT(fieldData.stride()[1] == sizeof(U), "Trade::SceneFieldData: second field view dimension is not contiguous"), UnsignedShort(fieldData.size()[1]))
 } {}
 
-constexpr SceneFieldData::SceneFieldData(const SceneField name, const std::size_t size, const SceneObjectType objectType, const std::size_t objectOffset, const std::ptrdiff_t objectStride, const SceneFieldType fieldType, const std::size_t fieldOffset, const std::ptrdiff_t fieldStride, const UnsignedShort fieldArraySize) noexcept:
+constexpr SceneFieldData::SceneFieldData(const SceneField name, const std::size_t size, const SceneMappingType mappingType, const std::size_t mappingOffset, const std::ptrdiff_t mappingStride, const SceneFieldType fieldType, const std::size_t fieldOffset, const std::ptrdiff_t fieldStride, const UnsignedShort fieldArraySize) noexcept:
     _size{size},
     _name{(CORRADE_CONSTEXPR_ASSERT(Implementation::isSceneFieldTypeCompatibleWithField(name, fieldType),
         "Trade::SceneFieldData:" << fieldType << "is not a valid type for" << name), name)},
     _isOffsetOnly{true},
-    _objectType{objectType},
-    _objectStride{(CORRADE_CONSTEXPR_ASSERT(objectStride >= -32768 && objectStride <= 32767,
-        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got" << objectStride), Short(objectStride))},
-    _objectData{objectOffset},
+    _mappingType{mappingType},
+    _mappingStride{(CORRADE_CONSTEXPR_ASSERT(mappingStride >= -32768 && mappingStride <= 32767,
+        "Trade::SceneFieldData: expected mapping view stride to fit into 16 bits, but got" << mappingStride), Short(mappingStride))},
+    _mappingData{mappingOffset},
     _fieldType{fieldType},
     _fieldStride{(CORRADE_CONSTEXPR_ASSERT(fieldStride >= -32768 && fieldStride <= 32767,
         "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got" << fieldStride), Short(fieldStride))},
@@ -2683,43 +2685,43 @@ constexpr SceneFieldData::SceneFieldData(const SceneField name, const std::size_
         "Trade::SceneFieldData:" << name << "can't be an array field"), fieldArraySize)},
     _fieldData{fieldOffset} {}
 
-template<class T> Containers::StridedArrayView1D<const T> SceneData::objects(const UnsignedInt fieldId) const {
-    Containers::StridedArrayView2D<const char> data = objects(fieldId);
+template<class T> Containers::StridedArrayView1D<const T> SceneData::mapping(const UnsignedInt fieldId) const {
+    Containers::StridedArrayView2D<const char> data = mapping(fieldId);
     #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
     if(!data.stride()[1]) return {};
     #endif
-    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
-        "Trade::SceneData::objects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    CORRADE_ASSERT(Implementation::sceneMappingTypeFor<T>() == _mappingType,
+        "Trade::SceneData::mapping(): mapping is" << _mappingType << "but requested" << Implementation::sceneMappingTypeFor<T>(), {});
     return Containers::arrayCast<1, const T>(data);
 }
 
-template<class T> Containers::StridedArrayView1D<T> SceneData::mutableObjects(const UnsignedInt fieldId) {
-    Containers::StridedArrayView2D<char> data = mutableObjects(fieldId);
+template<class T> Containers::StridedArrayView1D<T> SceneData::mutableMapping(const UnsignedInt fieldId) {
+    Containers::StridedArrayView2D<char> data = mutableMapping(fieldId);
     #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
     if(!data.stride()[1]) return {};
     #endif
-    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
-        "Trade::SceneData::mutableObjects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    CORRADE_ASSERT(Implementation::sceneMappingTypeFor<T>() == _mappingType,
+        "Trade::SceneData::mutableMapping(): mapping is" << _mappingType << "but requested" << Implementation::sceneMappingTypeFor<T>(), {});
     return Containers::arrayCast<1, T>(data);
 }
 
-template<class T> Containers::StridedArrayView1D<const T> SceneData::objects(const SceneField fieldName) const {
-    Containers::StridedArrayView2D<const char> data = objects(fieldName);
+template<class T> Containers::StridedArrayView1D<const T> SceneData::mapping(const SceneField fieldName) const {
+    Containers::StridedArrayView2D<const char> data = mapping(fieldName);
     #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
     if(!data.stride()[1]) return {};
     #endif
-    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
-        "Trade::SceneData::objects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    CORRADE_ASSERT(Implementation::sceneMappingTypeFor<T>() == _mappingType,
+        "Trade::SceneData::mapping(): mapping is" << _mappingType << "but requested" << Implementation::sceneMappingTypeFor<T>(), {});
     return Containers::arrayCast<1, const T>(data);
 }
 
-template<class T> Containers::StridedArrayView1D<T> SceneData::mutableObjects(const SceneField fieldName) {
-    Containers::StridedArrayView2D<char> data = mutableObjects(fieldName);
+template<class T> Containers::StridedArrayView1D<T> SceneData::mutableMapping(const SceneField fieldName) {
+    Containers::StridedArrayView2D<char> data = mutableMapping(fieldName);
     #ifdef CORRADE_GRACEFUL_ASSERT /* Sigh. Brittle. Better idea? */
     if(!data.stride()[1]) return {};
     #endif
-    CORRADE_ASSERT(Implementation::sceneObjectTypeFor<T>() == _objectType,
-        "Trade::SceneData::mutableObjects(): objects are" << _objectType << "but requested" << Implementation::sceneObjectTypeFor<T>(), {});
+    CORRADE_ASSERT(Implementation::sceneMappingTypeFor<T>() == _mappingType,
+        "Trade::SceneData::mutableMapping(): mapping is" << _mappingType << "but requested" << Implementation::sceneMappingTypeFor<T>(), {});
     return Containers::arrayCast<1, T>(data);
 }
 

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -121,15 +121,18 @@ enum class SceneField: UnsignedInt {
      *
      * The transformation can be also represented by separate
      * @ref SceneField::Translation, @ref SceneField::Rotation and
-     * @ref SceneField::Scaling fields. If both @ref SceneField::Transformation
-     * and TRS fields are specified, it's expected that all objects that have
-     * TRS fields have a combined transformation field as well, and
+     * @ref SceneField::Scaling fields. All present transformation-related
+     * fields are expected to have the same dimensionality --- either all 2D or
+     * all 3D. If both @ref SceneField::Transformation and TRS fields are
+     * specified, it's expected that all objects that have TRS fields have a
+     * combined transformation field as well, and
      * @ref SceneData::transformations2DAsArray() /
      * @ref SceneData::transformations3DAsArray() then takes into account only
      * the combined transformation field. TRS fields can however be specified
      * only for a subset of transformed objects, useful for example when only
      * certain objects have these properties animated.
-     * @see @ref SceneData::transformations2DAsArray(),
+     * @see @ref SceneData::is2D(), @ref SceneData::is3D(),
+     *      @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
      *      @ref SceneData::transformation2DFor(),
      *      @ref SceneData::transformation3DFor()
@@ -146,11 +149,13 @@ enum class SceneField: UnsignedInt {
      *
      * The translation field usually is (but doesn't have to be) complemented
      * by a @ref SceneField::Rotation and @ref SceneField::Scaling, which, if
-     * present, are expected to all share the same object mapping view. The TRS
+     * present, are expected to all share the same object mapping view and have
+     * the same dimensionality, either all 2D or all 3D. The TRS
      * components can either completely replace @ref SceneField::Transformation
      * or be provided just for a subset of it --- see its documentation for
      * details.
-     * @see @ref SceneData::transformations2DAsArray(),
+     * @see @ref SceneData::is2D(), @ref SceneData::is3D(),
+     *      @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
      *      @ref SceneData::transformation2DFor(),
      *      @ref SceneData::transformation3DFor(),
@@ -171,11 +176,13 @@ enum class SceneField: UnsignedInt {
      *
      * The rotation field usually is (but doesn't have to be) complemented by a
      * @ref SceneField::Translation and @ref SceneField::Scaling, which, if
-     * present, are expected to all share the same object mapping view. The TRS
+     * present, are expected to all share the same object mapping view and have
+     * the same dimensionality, either all 2D or all 3D. The TRS
      * components can either completely replace @ref SceneField::Transformation
      * or be provided just for a subset of it --- see its documentation for
      * details.
-     * @see @ref SceneData::transformations2DAsArray(),
+     * @see @ref SceneData::is2D(), @ref SceneData::is3D(),
+     *      @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
      *      @ref SceneData::transformation2DFor(),
      *      @ref SceneData::transformation3DFor(),
@@ -196,11 +203,13 @@ enum class SceneField: UnsignedInt {
      *
      * The scaling field usually is (but doesn't have to be) complemented by a
      * @ref SceneField::Translation and @ref SceneField::Rotation, which, if
-     * present, are expected to all share the same object mapping view. The TRS
+     * present, are expected to all share the same object mapping view and have
+     * the same dimensionality, either all 2D or all 3D. The TRS
      * components can either completely replace @ref SceneField::Transformation
      * or be provided just for a subset of it --- see its documentation for
      * details.
-     * @see @ref SceneData::transformations2DAsArray(),
+     * @see @ref SceneData::is2D(), @ref SceneData::is3D(),
+     *      @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
      *      @ref SceneData::transformation2DFor(),
      *      @ref SceneData::transformation3DFor(),
@@ -994,8 +1003,46 @@ class MAGNUM_TRADE_EXPORT SceneData {
         UnsignedShort fieldArraySize(UnsignedInt id) const;
 
         /**
+         * @brief Whether the scene is two-dimensional
+         * @m_since_latest
+         *
+         * Returns @cpp true @ce if the present
+         * @ref SceneField::Transformation,
+         * @relativeref{SceneField,Translation},
+         * @relativeref{SceneField,Rotation} and
+         * @relativeref{SceneField,Scaling} fields have a 2D type,
+         * @cpp false @ce otherwise.
+         *
+         * If there's no transformation-related field, the scene is treated as
+         * neither 2D nor 3D and both @ref is2D() and @ref is3D() return
+         * @cpp false @ce. On the other hand, a scene can't be both 2D and 3D.
+         * @see @ref hasField()
+         */
+        bool is2D() const { return _dimensions == 2; }
+
+        /**
+         * @brief Whether the scene is three-dimensional
+         * @m_since_latest
+         *
+         * Returns @cpp true @ce if the present
+         * @ref SceneField::Transformation,
+         * @relativeref{SceneField,Translation},
+         * @relativeref{SceneField,Rotation} and
+         * @relativeref{SceneField,Scaling} fields have a 3D type,
+         * @cpp false @ce otherwise.
+         *
+         * If there's no transformation-related field, the scene is treated as
+         * neither 2D nor 3D and both @ref is2D() and @ref is3D() return
+         * @cpp false @ce. On the other hand, a scene can't be both 2D and 3D.
+         * @see @ref hasField()
+         */
+        bool is3D() const { return _dimensions == 3; }
+
+        /**
          * @brief Whether the scene has given field
          * @m_since_latest
+         *
+         * @see @ref is2D(), @ref is3D()
          */
         bool hasField(SceneField name) const;
 
@@ -1430,7 +1477,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * expected to exist and they are expected to have a type corresponding
          * to 2D, otherwise you're supposed to use
          * @ref transformations3DAsArray().
-         * @see @ref transformations2DInto(), @ref hasField(),
+         * @see @ref is2D(), @ref transformations2DInto(), @ref hasField(),
          *      @ref fieldType(SceneField) const, @ref transformation2DFor()
          */
         Containers::Array<Matrix3> transformations2DAsArray() const;
@@ -1476,8 +1523,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * field isn't present, the second value is an identity rotation. If
          * the @relativeref{SceneField,Scaling} field isn't present, the third
          * value is an identity scaling (@cpp 1.0f @ce in both dimensions).
-         * @see @ref translationsRotationsScalings2DInto(), @ref hasField(),
-         *      @ref fieldType(SceneField) const,
+         * @see @ref is2D(), @ref translationsRotationsScalings2DInto(),
+         *      @ref hasField(), @ref fieldType(SceneField) const,
          *      @ref translationRotationScaling2DFor()
          */
         Containers::Array<Containers::Triple<Vector2, Complex, Vector2>> translationsRotationsScalings2DAsArray() const;
@@ -1522,7 +1569,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * expected to exist and they are expected to have a type corresponding
          * to 3D, otherwise you're supposed to use
          * @ref transformations2DAsArray().
-         * @see @ref transformations3DInto(), @ref hasField(),
+         * @see @ref is3D(), @ref transformations3DInto(), @ref hasField(),
          *      @ref fieldType(SceneField) const, @ref transformation3DFor()
          */
         Containers::Array<Matrix4> transformations3DAsArray() const;
@@ -1568,8 +1615,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * field isn't present, the second value is an identity rotation. If
          * the @relativeref{SceneField,Scaling} field isn't present, the third
          * value is an identity scaling (@cpp 1.0f @ce in all dimensions).
-         * @see @ref translationsRotationsScalings3DInto(), @ref hasField(),
-         *      @ref fieldType(SceneField) const,
+         * @see @ref is3D(), @ref translationsRotationsScalings3DInto(),
+         *      @ref hasField(), @ref fieldType(SceneField) const,
          *      @ref translationRotationScaling3DFor()
          */
         Containers::Array<Containers::Triple<Vector3, Quaternion, Vector3>> translationsRotationsScalings3DAsArray() const;
@@ -2114,7 +2161,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
 
         DataFlags _dataFlags;
         SceneObjectType _objectType;
-        /* 2/6 bytes free */
+        UnsignedByte _dimensions;
+        /* 1/5 bytes free */
         UnsignedLong _objectCount;
         const void* _importerState;
         Containers::Array<SceneFieldData> _fields;

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -127,9 +127,15 @@ enum class SceneField: UnsignedInt {
      * Transformation. Type is usually @ref SceneFieldType::Matrix3x3 for 2D
      * and @ref SceneFieldType::Matrix4x4 for 3D, but can be also any of
      * @relativeref{SceneFieldType,Matrix3x3d},
+     * @relativeref{SceneFieldType,Matrix3x2} or
+     * @relativeref{SceneFieldType,Matrix3x2d} (with the bottom row implicitly
+     * assumed to be @f$ \begin{pmatrix} 0 & 0 & 1 \end{pmatrix} @f$),
      * @relativeref{SceneFieldType,DualComplex} or
      * @relativeref{SceneFieldType,DualComplexd} for 2D and
      * @relativeref{SceneFieldType,Matrix4x4d},
+     * @relativeref{SceneFieldType,Matrix4x3} or
+     * @relativeref{SceneFieldType,Matrix4x3d} (with the bottom row implicitly
+     * assumed to be @f$ \begin{pmatrix} 0 & 0 & 0 & 1 \end{pmatrix} @f$),
      * @relativeref{SceneFieldType,DualQuaternion} or
      * @relativeref{SceneFieldType,DualQuaterniond} for 3D. An object should
      * have only one transformation, altough this isn't enforced in any way,
@@ -2490,6 +2496,10 @@ namespace Implementation {
                  type == SceneFieldType::Matrix3x3d ||
                  type == SceneFieldType::Matrix4x4 ||
                  type == SceneFieldType::Matrix4x4d ||
+                 type == SceneFieldType::Matrix3x2 ||
+                 type == SceneFieldType::Matrix3x2d ||
+                 type == SceneFieldType::Matrix4x3 ||
+                 type == SceneFieldType::Matrix4x3d ||
                  type == SceneFieldType::DualComplex ||
                  type == SceneFieldType::DualComplexd ||
                  type == SceneFieldType::DualQuaternion ||

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -1510,7 +1510,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref hasFieldObject(UnsignedInt, UnsignedInt) const,
          *      @ref fieldObjectOffset(UnsignedInt, UnsignedInt, std::size_t) const
          */
-        Containers::Optional<std::size_t> findFieldObjectOffset(UnsignedInt fieldId, UnsignedInt object, std::size_t offset = 0) const;
+        Containers::Optional<std::size_t> findFieldObjectOffset(UnsignedInt fieldId, UnsignedLong object, std::size_t offset = 0) const;
 
         /**
          * @brief Find offset of an object in given named field
@@ -1532,7 +1532,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref hasField(), @ref hasFieldObject(SceneField, UnsignedInt) const,
          *      @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          */
-        Containers::Optional<std::size_t> findFieldObjectOffset(SceneField fieldName, UnsignedInt object, std::size_t offset = 0) const;
+        Containers::Optional<std::size_t> findFieldObjectOffset(SceneField fieldName, UnsignedLong object, std::size_t offset = 0) const;
 
         /**
          * @brief Offset of an object in given field
@@ -1545,7 +1545,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * You can also use @ref fieldObjectOffset(SceneField, UnsignedInt, std::size_t) const
          * to directly get offset of an object in given named field.
          */
-        std::size_t fieldObjectOffset(UnsignedInt fieldId, UnsignedInt object, std::size_t offset = 0) const;
+        std::size_t fieldObjectOffset(UnsignedInt fieldId, UnsignedLong object, std::size_t offset = 0) const;
 
         /**
          * @brief Offset of an object in given named field
@@ -1555,7 +1555,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * but @p object is additionally expected to be present in @p fieldName
          * starting at @p offset.
          */
-        std::size_t fieldObjectOffset(SceneField fieldName, UnsignedInt object, std::size_t offset = 0) const;
+        std::size_t fieldObjectOffset(SceneField fieldName, UnsignedLong object, std::size_t offset = 0) const;
 
         /**
          * @brief Whether a scene field has given object
@@ -1564,7 +1564,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p fieldId is expected to be smaller than @ref fieldCount() and
          * @p object smaller than @ref mappingBound().
          */
-        bool hasFieldObject(UnsignedInt fieldId, UnsignedInt object) const;
+        bool hasFieldObject(UnsignedInt fieldId, UnsignedLong object) const;
 
         /**
          * @brief Whether a named scene field has given object
@@ -1574,7 +1574,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * be smaller than @ref mappingBound().
          * @see @ref hasField()
          */
-        bool hasFieldObject(SceneField fieldName, UnsignedInt object) const;
+        bool hasFieldObject(SceneField fieldName, UnsignedLong object) const;
 
         /**
          * @brief Field flags
@@ -2510,7 +2510,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref mappingBound().
          * @see @ref childrenFor()
          */
-        Containers::Optional<Int> parentFor(UnsignedInt object) const;
+        Containers::Optional<Long> parentFor(UnsignedLong object) const;
 
         /**
          * @brief Children for given object
@@ -2531,7 +2531,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref mappingBound().
          * @see @ref parentFor()
          */
-        Containers::Array<UnsignedInt> childrenFor(Int object) const;
+        Containers::Array<UnsignedLong> childrenFor(Long object) const;
 
         /**
          * @brief 2D transformation for given object
@@ -2557,7 +2557,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref mappingBound().
          * @see @ref translationRotationScaling2DFor()
          */
-        Containers::Optional<Matrix3> transformation2DFor(UnsignedInt object) const;
+        Containers::Optional<Matrix3> transformation2DFor(UnsignedLong object) const;
 
         /**
          * @brief 2D translation, rotation and scaling for given object
@@ -2586,7 +2586,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref mappingBound().
          * @see @ref transformation2DFor()
          */
-        Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> translationRotationScaling2DFor(UnsignedInt object) const;
+        Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> translationRotationScaling2DFor(UnsignedLong object) const;
 
         /**
          * @brief 3D transformation for given object
@@ -2612,7 +2612,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref mappingBound().
          * @see @ref translationRotationScaling3DFor()
          */
-        Containers::Optional<Matrix4> transformation3DFor(UnsignedInt object) const;
+        Containers::Optional<Matrix4> transformation3DFor(UnsignedLong object) const;
 
         /**
          * @brief 3D translation, rotation and scaling for given object
@@ -2641,7 +2641,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * The @p object is expected to be less than @ref mappingBound().
          * @see @ref transformation3DFor()
          */
-        Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> translationRotationScaling3DFor(UnsignedInt object) const;
+        Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> translationRotationScaling3DFor(UnsignedLong object) const;
 
         /**
          * @brief Meshes and materials for given object
@@ -2663,7 +2663,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p object is expected to be less than @ref mappingBound().
          */
-        Containers::Array<Containers::Pair<UnsignedInt, Int>> meshesMaterialsFor(UnsignedInt object) const;
+        Containers::Array<Containers::Pair<UnsignedInt, Int>> meshesMaterialsFor(UnsignedLong object) const;
 
         /**
          * @brief Lights for given object
@@ -2681,7 +2681,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p object is expected to be less than @ref mappingBound().
          */
-        Containers::Array<UnsignedInt> lightsFor(UnsignedInt object) const;
+        Containers::Array<UnsignedInt> lightsFor(UnsignedLong object) const;
 
         /**
          * @brief Cameras for given object
@@ -2700,7 +2700,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p object is expected to be less than @ref mappingBound().
          */
-        Containers::Array<UnsignedInt> camerasFor(UnsignedInt object) const;
+        Containers::Array<UnsignedInt> camerasFor(UnsignedLong object) const;
 
         /**
          * @brief Skins for given object
@@ -2718,7 +2718,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p object is expected to be less than @ref mappingBound().
          */
-        Containers::Array<UnsignedInt> skinsFor(UnsignedInt object) const;
+        Containers::Array<UnsignedInt> skinsFor(UnsignedLong object) const;
 
         /**
          * @brief Importer state for given object
@@ -2738,7 +2738,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *
          * The @p object is expected to be less than @ref mappingBound().
          */
-        Containers::Optional<const void*> importerStateFor(UnsignedInt object) const;
+        Containers::Optional<const void*> importerStateFor(UnsignedLong object) const;
 
         #ifdef MAGNUM_BUILD_DEPRECATED
         /**
@@ -2815,7 +2815,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
         /* Returns the offset at which `object` is for field at index `id`, or
            the end offset if the object is not found. The returned offset can
            be then passed to fieldData{Mapping,Field}ViewInternal(). */
-        MAGNUM_TRADE_LOCAL std::size_t findFieldObjectOffsetInternal(const SceneFieldData& field, UnsignedInt object, std::size_t offset) const;
+        MAGNUM_TRADE_LOCAL std::size_t findFieldObjectOffsetInternal(const SceneFieldData& field, UnsignedLong object, std::size_t offset) const;
 
         /* Like objects() / field(), but returning just a 1D view, sliced from
            offset to offset + size. The parameterless overloads are equal to

--- a/src/Magnum/Trade/SceneData.h
+++ b/src/Magnum/Trade/SceneData.h
@@ -102,7 +102,7 @@ enum class SceneField: UnsignedInt {
      * Note that the index points to the parent array itself and isn't the
      * actual object index --- the object mapping is stored in the
      * corresponding @ref SceneData::objects() array.
-     * @see @ref SceneData::parentsAsArray()
+     * @see @ref SceneData::parentsAsArray(), @ref SceneData::childrenFor()
      */
     Parent = 1,
 
@@ -129,7 +129,9 @@ enum class SceneField: UnsignedInt {
      * only for a subset of transformed objects, useful for example when only
      * certain objects have these properties animated.
      * @see @ref SceneData::transformations2DAsArray(),
-     *      @ref SceneData::transformations3DAsArray()
+     *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::transformation2DFor(),
+     *      @ref SceneData::transformation3DFor()
      */
     Transformation,
 
@@ -149,8 +151,12 @@ enum class SceneField: UnsignedInt {
      * details.
      * @see @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::transformation2DFor(),
+     *      @ref SceneData::transformation3DFor(),
      *      @ref SceneData::translationsRotationsScalings2DAsArray(),
-     *      @ref SceneData::translationsRotationsScalings3DAsArray()
+     *      @ref SceneData::translationsRotationsScalings3DAsArray(),
+     *      @ref SceneData::translationRotationScaling2DFor(),
+     *      @ref SceneData::translationRotationScaling3DFor()
      */
     Translation,
 
@@ -170,8 +176,12 @@ enum class SceneField: UnsignedInt {
      * details.
      * @see @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::transformation2DFor(),
+     *      @ref SceneData::transformation3DFor(),
      *      @ref SceneData::translationsRotationsScalings2DAsArray(),
-     *      @ref SceneData::translationsRotationsScalings3DAsArray()
+     *      @ref SceneData::translationsRotationsScalings3DAsArray(),
+     *      @ref SceneData::translationRotationScaling2DFor(),
+     *      @ref SceneData::translationRotationScaling3DFor()
      */
     Rotation,
 
@@ -191,8 +201,12 @@ enum class SceneField: UnsignedInt {
      * details.
      * @see @ref SceneData::transformations2DAsArray(),
      *      @ref SceneData::transformations3DAsArray(),
+     *      @ref SceneData::transformation2DFor(),
+     *      @ref SceneData::transformation3DFor(),
      *      @ref SceneData::translationsRotationsScalings2DAsArray(),
-     *      @ref SceneData::translationsRotationsScalings3DAsArray()
+     *      @ref SceneData::translationsRotationsScalings3DAsArray(),
+     *      @ref SceneData::translationRotationScaling2DFor(),
+     *      @ref SceneData::translationRotationScaling3DFor()
      */
     Scaling,
 
@@ -208,7 +222,8 @@ enum class SceneField: UnsignedInt {
      * required. If present, both should share the same object mapping view.
      * Objects with multiple meshes then have the Nth mesh associated with the
      * Nth material.
-     * @see @ref SceneData::meshesMaterialsAsArray()
+     * @see @ref SceneData::meshesMaterialsAsArray(),
+     *      @ref SceneData::meshesMaterialsFor()
      */
     Mesh,
 
@@ -219,7 +234,8 @@ enum class SceneField: UnsignedInt {
      * but can be also any of @relativeref{SceneFieldType,Byte} or
      * @relativeref{SceneFieldType,Short}. Expected to share the
      * object mapping view with @ref SceneField::Mesh.
-     * @see @ref SceneData::meshesMaterialsAsArray()
+     * @see @ref SceneData::meshesMaterialsAsArray(),
+     *      @ref SceneData::meshesMaterialsFor()
      */
     MeshMaterial,
 
@@ -230,7 +246,7 @@ enum class SceneField: UnsignedInt {
      * @relativeref{SceneFieldType,UnsignedByte} or
      * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
      * lights associated.
-     * @see @ref SceneData::lightsAsArray()
+     * @see @ref SceneData::lightsAsArray(), @ref SceneData::lightsFor()
      */
     Light,
 
@@ -241,7 +257,7 @@ enum class SceneField: UnsignedInt {
      * @relativeref{SceneFieldType,UnsignedByte} or
      * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
      * cameras associated.
-     * @see @ref SceneData::camerasAsArray()
+     * @see @ref SceneData::camerasAsArray(), @ref SceneData::camerasFor()
      */
     Camera,
 
@@ -252,7 +268,7 @@ enum class SceneField: UnsignedInt {
      * @relativeref{SceneFieldType,UnsignedByte} or
      * @relativeref{SceneFieldType,UnsignedShort}. An object can have multiple
      * skins associated.
-     * @see @ref SceneData::skinsAsArray()
+     * @see @ref SceneData::skinsAsArray(), @ref SceneData::skinsFor()
      */
     Skin,
 
@@ -1342,7 +1358,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          *      is larger than the max representable 32-bit value, this
          *      function can't be used, only an appropriately typed
          *      @ref field(SceneField) const.
-         * @see @ref parentsInto(), @ref hasField()
+         * @see @ref parentsInto(), @ref hasField(), @ref childrenFor()
          */
         Containers::Array<Int> parentsAsArray() const;
 
@@ -1385,7 +1401,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * to 2D, otherwise you're supposed to use
          * @ref transformations3DAsArray().
          * @see @ref transformations2DInto(), @ref hasField(),
-         *      @ref fieldType(SceneField) const
+         *      @ref fieldType(SceneField) const, @ref transformation2DFor()
          */
         Containers::Array<Matrix3> transformations2DAsArray() const;
 
@@ -1431,7 +1447,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * the @relativeref{SceneField,Scaling} field isn't present, the third
          * value is an identity scaling (@cpp 1.0f @ce in both dimensions).
          * @see @ref translationsRotationsScalings2DInto(), @ref hasField(),
-         *      @ref fieldType(SceneField) const
+         *      @ref fieldType(SceneField) const,
+         *      @ref translationRotationScaling2DFor()
          */
         Containers::Array<Containers::Triple<Vector2, Complex, Vector2>> translationsRotationsScalings2DAsArray() const;
 
@@ -1476,7 +1493,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * to 3D, otherwise you're supposed to use
          * @ref transformations2DAsArray().
          * @see @ref transformations3DInto(), @ref hasField(),
-         *      @ref fieldType(SceneField) const
+         *      @ref fieldType(SceneField) const, @ref transformation3DFor()
          */
         Containers::Array<Matrix4> transformations3DAsArray() const;
 
@@ -1522,7 +1539,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * the @relativeref{SceneField,Scaling} field isn't present, the third
          * value is an identity scaling (@cpp 1.0f @ce in all dimensions).
          * @see @ref translationsRotationsScalings3DInto(), @ref hasField(),
-         *      @ref fieldType(SceneField) const
+         *      @ref fieldType(SceneField) const,
+         *      @ref translationRotationScaling3DFor()
          */
         Containers::Array<Containers::Triple<Vector3, Quaternion, Vector3>> translationsRotationsScalings3DAsArray() const;
 
@@ -1563,7 +1581,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * in a newly-allocated array. The @ref SceneField::Mesh field is
          * expected to exist, if @ref SceneField::MeshMaterial isn't present,
          * the second returned values are all @cpp -1 @ce.
-         * @see @ref meshesMaterialsInto(), @ref hasField()
+         * @see @ref meshesMaterialsInto(), @ref hasField(),
+         *      @ref meshesMaterialsFor()
          */
         Containers::Array<Containers::Pair<UnsignedInt, Int>> meshesMaterialsAsArray() const;
 
@@ -1600,7 +1619,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref SceneField::Light as the argument that converts the field from
          * an arbitrary underlying type and returns it in a newly-allocated
          * array. The field is expected to exist.
-         * @see @ref lightsInto(), @ref hasField()
+         * @see @ref lightsInto(), @ref hasField(), @ref lightsFor()
          */
         Containers::Array<UnsignedInt> lightsAsArray() const;
 
@@ -1636,7 +1655,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref SceneField::Camera as the argument that converts the field from
          * an arbitrary underlying type and returns it in a newly-allocated
          * array. The field is expected to exist.
-         * @see @ref camerasInto(), @ref hasField()
+         * @see @ref camerasInto(), @ref hasField(), @ref camerasFor()
          */
         Containers::Array<UnsignedInt> camerasAsArray() const;
 
@@ -1672,7 +1691,7 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @ref SceneField::Skin as the argument that converts the field from
          * an arbitrary underlying type and returns it in a newly-allocated
          * array. The field is expected to exist.
-         * @see @ref skinsInto(), @ref hasField()
+         * @see @ref skinsInto(), @ref hasField(), @ref skinsFor()
          */
         Containers::Array<UnsignedInt> skinsAsArray() const;
 
@@ -1699,6 +1718,209 @@ class MAGNUM_TRADE_EXPORT SceneData {
          * @see @ref fieldSize(SceneField) const
          */
         std::size_t skinsInto(std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
+
+        /**
+         * @brief Children for given object
+         * @m_since_latest
+         *
+         * Looks up @p object in the object mapping array for
+         * @ref SceneField::Parent and returns a list of all object IDs that
+         * have it listed as the parent. The lookup is done in an
+         * @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$ being the field
+         * count and @f$ n @f$ the size of the parent field, thus for
+         * retrieving parent/child info for many objects it's recommended to
+         * access the field data directly with @ref parentsAsArray() and
+         * related APIs.
+         *
+         * If the @ref SceneField::Parent field doesn't exist or there are no
+         * objects which would have @p object listed as their parent, returns
+         * an empty array. Pass @cpp -1 @ce to get a list of top-level objects.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         */
+        Containers::Array<UnsignedInt> childrenFor(Int object) const;
+
+        /**
+         * @brief 2D transformation for given object
+         * @m_since_latest
+         *
+         * Looks up the @ref SceneField::Transformation field for @p object or
+         * combines it from a @ref SceneField::Translation,
+         * @relativeref{SceneField,Rotation} and
+         * @relativeref{SceneField,Scaling} in the same way as
+         * @ref transformations2DAsArray(). The lookup is done in an
+         * @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$ being the field
+         * count and @f$ n @f$ the size of the transformation field, thus for
+         * retrieving transformation info for many objects it's recommended to
+         * access the field data directly with @ref transformations2DAsArray()
+         * and related APIs.
+         *
+         * If neither @ref SceneField::Transformation nor any of
+         * @ref SceneField::Translation, @relativeref{SceneField,Rotation} or
+         * @relativeref{SceneField,Scaling} is present, the fields represent a
+         * 3D transformation or there's no transformation for @p object,
+         * returns @ref Containers::NullOpt.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         * @see @ref translationRotationScaling2DFor()
+         */
+        Containers::Optional<Matrix3> transformation2DFor(UnsignedInt object) const;
+
+        /**
+         * @brief 2D translation, rotation and scaling for given object
+         * @m_since_latest
+         *
+         * Looks up the @ref SceneField::Translation,
+         * @relativeref{SceneField,Rotation} and
+         * @relativeref{SceneField,Scaling} fields for @p object. The lookup
+         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
+         * being the field count and @f$ n @f$ the size of the transformation
+         * field, thus for retrieving transformation info for many objects it's
+         * recommended to access the field data directly with
+         * @ref translationsRotationsScalings2DAsArray() and related APIs.
+         *
+         * If the @ref SceneField::Translation field isn't present, the first
+         * returned value is a zero vector. If the
+         * @relativeref{SceneField,Rotation} field isn't present, the second
+         * value is an identity rotation. If the @relativeref{SceneField,Scaling}
+         * field isn't present, the third value is an identity scaling
+         * (@cpp 1.0f @ce in both dimensions). If neither of those fields is
+         * present, if any of the fields represents a 3D transformation or if
+         * there's no transformation for @p object, returns
+         * @ref Containers::NullOpt.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         * @see @ref transformation2DFor()
+         */
+        Containers::Optional<Containers::Triple<Vector2, Complex, Vector2>> translationRotationScaling2DFor(UnsignedInt object) const;
+
+        /**
+         * @brief 3D transformation for given object
+         * @m_since_latest
+         *
+         * Looks up the @ref SceneField::Transformation field for @p object or
+         * combines it from a @ref SceneField::Translation,
+         * @relativeref{SceneField,Rotation} and
+         * @relativeref{SceneField,Scaling} in the same way as
+         * @ref transformations3DAsArray(). The lookup is done in an
+         * @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$ being the field
+         * count and @f$ n @f$ the size of the transformation field, thus for
+         * retrieving transformation info for many objects it's recommended to
+         * access the field data directly with @ref transformations3DAsArray()
+         * and related APIs.
+         *
+         * If neither @ref SceneField::Transformation nor any of
+         * @ref SceneField::Translation, @relativeref{SceneField,Rotation} or
+         * @relativeref{SceneField,Scaling} is present, the fields represent a
+         * 2D transformation or there's no transformation for @p object,
+         * returns @ref Containers::NullOpt.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         * @see @ref translationRotationScaling3DFor()
+         */
+        Containers::Optional<Matrix4> transformation3DFor(UnsignedInt object) const;
+
+        /**
+         * @brief 3D translation, rotation and scaling for given object
+         * @m_since_latest
+         *
+         * Looks up the @ref SceneField::Translation,
+         * @relativeref{SceneField,Rotation} and
+         * @relativeref{SceneField,Scaling} fields for @p object. The lookup
+         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
+         * being the field count and @f$ n @f$ the size of the transformation
+         * field, thus for retrieving transformation info for many objects it's
+         * recommended to access the field data directly with
+         * @ref translationsRotationsScalings3DAsArray() and related APIs.
+         *
+         * If the @ref SceneField::Translation field isn't present, the first
+         * returned value is a zero vector. If the
+         * @relativeref{SceneField,Rotation} field isn't present, the second
+         * value is an identity rotation. If the @relativeref{SceneField,Scaling}
+         * field isn't present, the third value is an identity scaling
+         * (@cpp 1.0f @ce in all dimensions). If neither of those fields is
+         * present, if any of the fields represents a 2D transformation or if
+         * there's no transformation for @p object, returns
+         * @ref Containers::NullOpt.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         * @see @ref transformation3DFor()
+         */
+        Containers::Optional<Containers::Triple<Vector3, Quaternion, Vector3>> translationRotationScaling3DFor(UnsignedInt object) const;
+
+        /**
+         * @brief Meshes and materials for given object
+         * @m_since_latest
+         *
+         * Looks up all @ref SceneField::Mesh and @ref SceneField::MeshMaterial
+         * @relativeref{SceneField,Scaling} fields for @p object. The lookup
+         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
+         * being the field count and @f$ n @f$ the size of the mesh field, thus
+         * for retrieving mesh info for many objects it's recommended to access
+         * the field data directly with @ref meshesMaterialsAsArray() and
+         * related APIs.
+         *
+         * If the @ref SceneField::MeshMaterial field is not present, the
+         * second returned value is always @cpp -1 @ce. If
+         * @ref SceneField::Mesh is not present or if there's no mesh for
+         * @p object, returns an empty array.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         */
+        Containers::Array<Containers::Pair<UnsignedInt, Int>> meshesMaterialsFor(UnsignedInt object) const;
+
+        /**
+         * @brief Lights for given object
+         * @m_since_latest
+         *
+         * Looks up all @ref SceneField::Light fields for @p object. The lookup
+         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
+         * being the field count and @f$ n @f$ the size of the light field,
+         * thus for retrieving light info for many objects it's recommended to
+         * access the field data directly with @ref lightsAsArray() and related
+         * APIs.
+         *
+         * If the @ref SceneField::Light field is not present or if there's no
+         * light for @p object, returns an empty array.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         */
+        Containers::Array<UnsignedInt> lightsFor(UnsignedInt object) const;
+
+        /**
+         * @brief Cameras for given object
+         * @m_since_latest
+         *
+         * Looks up all @ref SceneField::Camera fields for @p object. The
+         * lookup is done in an @f$ \mathcal{O}(m + n) @f$ complexity with
+         * @f$ m @f$ being the field count and @f$ n @f$ the size of the camera
+         * field, thus for retrieving camera info for many objects it's
+         * recommended to access the field data directly with
+         * @ref camerasAsArray() and related APIs.
+         *
+         * If the @ref SceneField::Camera field is not present or if there's no
+         * camera for @p object, returns an empty array.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         */
+        Containers::Array<UnsignedInt> camerasFor(UnsignedInt object) const;
+
+        /**
+         * @brief Skins for given object
+         * @m_since_latest
+         *
+         * Looks up all @ref SceneField::Skin fields for @p object. The lookup
+         * is done in an @f$ \mathcal{O}(m + n) @f$ complexity with @f$ m @f$
+         * being the field count and @f$ n @f$ the size of the skin field, thus
+         * for retrieving skin info for many objects it's recommended to access
+         * the field data directly with @ref skinsAsArray() and related APIs.
+         *
+         * If the @ref SceneField::Skin field is not present or if there's no
+         * skin for @p object, returns an empty array.
+         *
+         * The @p object is expected to be less than @ref objectCount().
+         */
+        Containers::Array<UnsignedInt> skinsFor(UnsignedInt object) const;
 
         /**
          * @brief Release field data storage
@@ -1746,6 +1968,11 @@ class MAGNUM_TRADE_EXPORT SceneData {
         /* Internal helper that doesn't assert, unlike fieldId() */
         UnsignedInt fieldFor(SceneField name) const;
 
+        /* Returns the offset at which `object` is for field at index `id`, or
+           the end offset if the object is not found. The returned offset can
+           be then passed to fieldData{Object,Field}ViewInternal(). */
+        std::size_t fieldFor(const SceneFieldData& field, std::size_t offset, UnsignedInt object) const;
+
         /* Like objects() / field(), but returning just a 1D view, sliced from
            offset to offset + size. The parameterless overloads are equal to
            offset = 0 and size = field.size(). */
@@ -1760,8 +1987,8 @@ class MAGNUM_TRADE_EXPORT SceneData {
 
         MAGNUM_TRADE_LOCAL void objectsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<UnsignedInt>& destination) const;
         MAGNUM_TRADE_LOCAL void parentsIntoInternal(UnsignedInt fieldId, std::size_t offset, const Containers::StridedArrayView1D<Int>& destination) const;
-        MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
-        MAGNUM_TRADE_LOCAL std::size_t findTranslationRotationScalingFields(UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId) const;
+        MAGNUM_TRADE_LOCAL std::size_t findTransformFields(UnsignedInt& transformationFieldId, UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId, UnsignedInt* fieldWithObjectMappingDestination = nullptr) const;
+        MAGNUM_TRADE_LOCAL std::size_t findTranslationRotationScalingFields(UnsignedInt& translationFieldId, UnsignedInt& rotationFieldId, UnsignedInt& scalingFieldId, UnsignedInt* fieldWithObjectMappingDestination = nullptr) const;
         MAGNUM_TRADE_LOCAL void transformations2DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix3>& destination) const;
         MAGNUM_TRADE_LOCAL void translationsRotationsScalings2DIntoInternal(UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Vector2>& translationDestination, const Containers::StridedArrayView1D<Complex>& rotationDestination, const Containers::StridedArrayView1D<Vector2>& scalingDestination) const;
         MAGNUM_TRADE_LOCAL void transformations3DIntoInternal(UnsignedInt transformationFieldId, UnsignedInt translationFieldId, UnsignedInt rotationFieldId, UnsignedInt scalingFieldId, std::size_t offset, const Containers::StridedArrayView1D<Matrix4>& destination) const;

--- a/src/Magnum/Trade/SkinData.cpp
+++ b/src/Magnum/Trade/SkinData.cpp
@@ -43,6 +43,8 @@ template<UnsignedInt dimensions> SkinData<dimensions>::SkinData(DataFlags, const
 
 template<UnsignedInt dimensions> SkinData<dimensions>::SkinData(SkinData<dimensions>&&) noexcept = default;
 
+template<UnsignedInt dimensions> SkinData<dimensions>::~SkinData() = default;
+
 template<UnsignedInt dimensions> SkinData<dimensions>& SkinData<dimensions>::operator=(SkinData<dimensions>&&) noexcept = default;
 
 template<UnsignedInt dimensions> Containers::Array<UnsignedInt> SkinData<dimensions>::releaseJointData() {

--- a/src/Magnum/Trade/SkinData.h
+++ b/src/Magnum/Trade/SkinData.h
@@ -82,6 +82,8 @@ template<UnsignedInt dimensions> class SkinData {
         /** @brief Move constructor */
         SkinData(SkinData<dimensions>&& other) noexcept;
 
+        ~SkinData();
+
         /** @brief Copying is not allowed */
         SkinData<dimensions>& operator=(const SkinData<dimensions>&) = delete;
 

--- a/src/Magnum/Trade/Test/AbstractImporterTest.cpp
+++ b/src/Magnum/Trade/Test/AbstractImporterTest.cpp
@@ -2710,13 +2710,19 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
         UnsignedInt object;
         UnsignedInt camera;
     };
+    struct Skin {
+        UnsignedInt object;
+        UnsignedInt skin;
+    };
     Containers::StridedArrayView1D<Parent> parents;
     Containers::StridedArrayView1D<Mesh> meshes;
     Containers::StridedArrayView1D<Camera> cameras;
+    Containers::StridedArrayView1D<Skin> skins;
     Containers::Array<char> dataData = Containers::ArrayTuple{
         {NoInit, 5, parents},
         {NoInit, 7, meshes},
         {NoInit, 2, cameras},
+        {NoInit, 2, skins},
     };
     Utility::copy({{15, -1}, {21, -1}, {22, 21}, {23, 22}, {1, -1}}, parents);
     Utility::copy({
@@ -2729,6 +2735,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
         {21, 5, -1}
     }, meshes);
     Utility::copy({{22, 1}, {1, 5}}, cameras);
+    Utility::copy({{15, 9}, {21, 10}}, skins);
 
     /* Second scene that also has a duplicate, to verify the newly added object
        IDs don't conflict with each other. A potential downside is that
@@ -2752,6 +2759,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
         SceneFieldData{SceneField::Mesh, meshes.slice(&Mesh::object), meshes.slice(&Mesh::mesh)},
         SceneFieldData{SceneField::MeshMaterial, meshes.slice(&Mesh::object), meshes.slice(&Mesh::meshMaterial)},
         SceneFieldData{SceneField::Camera, cameras.slice(&Camera::object), cameras.slice(&Camera::camera)},
+        SceneFieldData{SceneField::Skin, skins.slice(&Skin::object), skins.slice(&Skin::skin)},
         /* Just to disambiguate this as a 2D scene */
         SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr},
     }};
@@ -2844,6 +2852,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), 2);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(15);
         CORRADE_VERIFY(o);
@@ -2854,6 +2863,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), 4);
+        CORRADE_COMPARE(mo.skin(), 9);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(21);
         CORRADE_VERIFY(o);
@@ -2864,6 +2874,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), -1);
+        CORRADE_COMPARE(mo.skin(), 10);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(22);
         CORRADE_VERIFY(o);
@@ -2882,6 +2893,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), 0);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(63);
         CORRADE_VERIFY(o);
@@ -2892,6 +2904,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), 3);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(64);
         CORRADE_VERIFY(o);
@@ -2902,6 +2915,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), 2);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(65);
         CORRADE_VERIFY(o);
@@ -2912,6 +2926,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             TestSuite::Compare::Container);
         MeshObjectData2D& mo = static_cast<MeshObjectData2D&>(*o);
         CORRADE_COMPARE(mo.material(), 1);
+        CORRADE_COMPARE(mo.skin(), 9);
     } {
         Containers::Pointer<ObjectData2D> o = importer.object2D(66);
         CORRADE_VERIFY(o);
@@ -2977,13 +2992,19 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
         UnsignedInt object;
         UnsignedInt camera;
     };
+    struct Skin {
+        UnsignedInt object;
+        UnsignedInt skin;
+    };
     Containers::StridedArrayView1D<Parent> parents;
     Containers::StridedArrayView1D<Mesh> meshes;
     Containers::StridedArrayView1D<Camera> cameras;
+    Containers::StridedArrayView1D<Skin> skins;
     Containers::Array<char> dataData = Containers::ArrayTuple{
         {NoInit, 5, parents},
         {NoInit, 7, meshes},
         {NoInit, 2, cameras},
+        {NoInit, 2, skins},
     };
     Utility::copy({{15, -1}, {21, -1}, {22, 21}, {23, 22}, {1, -1}}, parents);
     Utility::copy({
@@ -2996,6 +3017,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
         {21, 5, -1}
     }, meshes);
     Utility::copy({{22, 1}, {1, 5}}, cameras);
+    Utility::copy({{15, 9}, {21, 10}}, skins);
 
     /* Second scene that also has a duplicate, to verify the newly added object
        IDs don't conflict with each other. A potential downside is that
@@ -3019,6 +3041,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
         SceneFieldData{SceneField::Mesh, meshes.slice(&Mesh::object), meshes.slice(&Mesh::mesh)},
         SceneFieldData{SceneField::MeshMaterial, meshes.slice(&Mesh::object), meshes.slice(&Mesh::meshMaterial)},
         SceneFieldData{SceneField::Camera, cameras.slice(&Camera::object), cameras.slice(&Camera::camera)},
+        SceneFieldData{SceneField::Skin, skins.slice(&Skin::object), skins.slice(&Skin::skin)},
         /* Just to disambiguate this as a 3D scene */
         SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr},
     }};
@@ -3111,6 +3134,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), 2);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(15);
         CORRADE_VERIFY(o);
@@ -3121,6 +3145,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), 4);
+        CORRADE_COMPARE(mo.skin(), 9);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(21);
         CORRADE_VERIFY(o);
@@ -3131,6 +3156,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), -1);
+        CORRADE_COMPARE(mo.skin(), 10);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(22);
         CORRADE_VERIFY(o);
@@ -3149,6 +3175,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), 0);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(63);
         CORRADE_VERIFY(o);
@@ -3159,6 +3186,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), 3);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(64);
         CORRADE_VERIFY(o);
@@ -3169,6 +3197,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), 2);
+        CORRADE_COMPARE(mo.skin(), -1);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(65);
         CORRADE_VERIFY(o);
@@ -3179,6 +3208,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             TestSuite::Compare::Container);
         MeshObjectData3D& mo = static_cast<MeshObjectData3D&>(*o);
         CORRADE_COMPARE(mo.material(), 1);
+        CORRADE_COMPARE(mo.skin(), 9);
     } {
         Containers::Pointer<ObjectData3D> o = importer.object3D(66);
         CORRADE_VERIFY(o);

--- a/src/Magnum/Trade/Test/AbstractImporterTest.cpp
+++ b/src/Magnum/Trade/Test/AbstractImporterTest.cpp
@@ -1703,8 +1703,8 @@ void AbstractImporterTest::scene() {
         }
         Containers::Optional<SceneData> doScene(UnsignedInt id) override {
             if(id == 7)
-                return SceneData{SceneObjectType::UnsignedByte, 0, nullptr, {}, &state};
-            return SceneData{SceneObjectType::UnsignedByte, 0, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedByte, 0, nullptr, {}, &state};
+            return SceneData{SceneMappingType::UnsignedByte, 0, nullptr, {}};
         }
     } importer;
 
@@ -1899,21 +1899,21 @@ void AbstractImporterTest::sceneDeprecatedFallback2D() {
             /* This one has seven objects, but no fields for them so it should
                get skipped */
             if(id == 0)
-                return SceneData{SceneObjectType::UnsignedByte, 7, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedByte, 7, nullptr, {}};
             /* This one has no objects, so it should get skipped as well
                without even querying any fieldFor() API (as those would
                assert) */
             if(id == 1)
-                return SceneData{SceneObjectType::UnsignedShort, 0, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedShort, 0, nullptr, {}};
             /* This one is the one */
             if(id == 2)
-                return SceneData{SceneObjectType::UnsignedInt, 7, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+                return SceneData{SceneMappingType::UnsignedInt, 7, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
             CORRADE_INTERNAL_ASSERT_UNREACHABLE();
         }
 
         private:
             SceneData _data;
-    } importer{SceneData{SceneObjectType::UnsignedInt, 7, std::move(data), {
+    } importer{SceneData{SceneMappingType::UnsignedInt, 7, std::move(data), {
         SceneFieldData{SceneField::Parent,
             transformations.slice(&Transform::object),
             transformations.slice(&Transform::parent)},
@@ -2171,21 +2171,21 @@ void AbstractImporterTest::sceneDeprecatedFallback3D() {
             /* This one has seven objects, but no fields for them so it should
                get skipped */
             if(id == 0)
-                return SceneData{SceneObjectType::UnsignedByte, 7, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedByte, 7, nullptr, {}};
             /* This one has no objects, so it should get skipped as well
                without even querying any fieldFor() API (as those would
                assert) */
             if(id == 1)
-                return SceneData{SceneObjectType::UnsignedShort, 0, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedShort, 0, nullptr, {}};
             /* This one is the one */
             if(id == 2)
-                return SceneData{SceneObjectType::UnsignedInt, 7, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+                return SceneData{SceneMappingType::UnsignedInt, 7, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
             CORRADE_INTERNAL_ASSERT_UNREACHABLE();
         }
 
         private:
             SceneData _data;
-    } importer{SceneData{SceneObjectType::UnsignedInt, 7, std::move(data), {
+    } importer{SceneData{SceneMappingType::UnsignedInt, 7, std::move(data), {
         SceneFieldData{SceneField::Parent,
             transformations.slice(&Transform::object),
             transformations.slice(&Transform::parent)},
@@ -2356,12 +2356,12 @@ void AbstractImporterTest::sceneDeprecatedFallbackParentless2D() {
         UnsignedInt doSceneCount() const override { return 1; }
         UnsignedLong doObjectCount() const override { return 6; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+            return SceneData{SceneMappingType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
         }
 
         private:
             SceneData _data;
-    } importer{SceneData{SceneObjectType::UnsignedInt, 6, {}, fields, {
+    } importer{SceneData{SceneMappingType::UnsignedInt, 6, {}, fields, {
         SceneFieldData{SceneField::Transformation,
             view.slice(&Field::object),
             view.slice(&Field::transformation)}
@@ -2431,12 +2431,12 @@ void AbstractImporterTest::sceneDeprecatedFallbackParentless3D() {
         UnsignedInt doSceneCount() const override { return 1; }
         UnsignedLong doObjectCount() const override { return 6; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+            return SceneData{SceneMappingType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
         }
 
         private:
             SceneData _data;
-    } importer{SceneData{SceneObjectType::UnsignedInt, 6, {}, fields, {
+    } importer{SceneData{SceneMappingType::UnsignedInt, 6, {}, fields, {
         SceneFieldData{SceneField::Transformation,
             view.slice(&Field::object),
             view.slice(&Field::transformation)}
@@ -2506,17 +2506,17 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless2D() {
         UnsignedInt doSceneCount() const override { return 1; }
         UnsignedLong doObjectCount() const override { return 6; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+            return SceneData{SceneMappingType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
         }
 
         private:
             SceneData _data;
-    } importer{SceneData{SceneObjectType::UnsignedInt, 6, {}, fields, {
+    } importer{SceneData{SceneMappingType::UnsignedInt, 6, {}, fields, {
         SceneFieldData{SceneField::Parent,
             view.slice(&Field::object),
             view.slice(&Field::parent)},
         /* Required in order to have the scene recognized as 2D */
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr}
+        SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr}
     }}};
 
     CORRADE_COMPARE(importer.sceneCount(), 1);
@@ -2612,17 +2612,17 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless3D() {
         UnsignedInt doSceneCount() const override { return 1; }
         UnsignedLong doObjectCount() const override { return 6; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+            return SceneData{SceneMappingType::UnsignedInt, 6, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
         }
 
         private:
             SceneData _data;
-    } importer{SceneData{SceneObjectType::UnsignedInt, 6, {}, fields, {
+    } importer{SceneData{SceneMappingType::UnsignedInt, 6, {}, fields, {
         SceneFieldData{SceneField::Parent,
             view.slice(&Field::object),
             view.slice(&Field::parent)},
         /* Required in order to have the scene recognized as 3D */
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr}
+        SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr}
     }}};
 
     CORRADE_COMPARE(importer.sceneCount(), 1);
@@ -2747,20 +2747,20 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
         {30, 1, -1}
     }, meshesSecondary);
 
-    SceneData data{SceneObjectType::UnsignedInt, 32, std::move(dataData), {
+    SceneData data{SceneMappingType::UnsignedInt, 32, std::move(dataData), {
         SceneFieldData{SceneField::Parent, parents.slice(&Parent::object), parents.slice(&Parent::parent)},
         SceneFieldData{SceneField::Mesh, meshes.slice(&Mesh::object), meshes.slice(&Mesh::mesh)},
         SceneFieldData{SceneField::MeshMaterial, meshes.slice(&Mesh::object), meshes.slice(&Mesh::meshMaterial)},
         SceneFieldData{SceneField::Camera, cameras.slice(&Camera::object), cameras.slice(&Camera::camera)},
         /* Just to disambiguate this as a 2D scene */
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr},
+        SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr},
     }};
-    SceneData dataSecondary{SceneObjectType::UnsignedInt, 31, std::move(dataDataSecondary), {
+    SceneData dataSecondary{SceneMappingType::UnsignedInt, 31, std::move(dataDataSecondary), {
         SceneFieldData{SceneField::Parent, parentsSecondary.slice(&Parent::object), parentsSecondary.slice(&Parent::parent)},
         SceneFieldData{SceneField::Mesh, meshesSecondary.slice(&Mesh::object), meshesSecondary.slice(&Mesh::mesh)},
         SceneFieldData{SceneField::MeshMaterial, meshesSecondary.slice(&Mesh::object), meshesSecondary.slice(&Mesh::meshMaterial)},
         /* Just to disambiguate this as a 2D scene */
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr},
+        SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix3x3, nullptr},
     }};
 
     struct Importer: AbstractImporter {
@@ -2784,19 +2784,19 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
             /* This scene should get skipped when querying names as it's not
                2D */
             if(id == 0)
-                return SceneData{SceneObjectType::UnsignedByte, 32, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedByte, 32, nullptr, {}};
             /* This scene should get skipped when querying names as it has too
                little objects */
             if(id == 1)
-                return SceneData{SceneObjectType::UnsignedByte, 32, nullptr, {
-                    SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Matrix3x3, nullptr}
+                return SceneData{SceneMappingType::UnsignedByte, 32, nullptr, {
+                    SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Matrix3x3, nullptr}
                 }};
             if(id == 2)
-                return SceneData{SceneObjectType::UnsignedInt, 32, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+                return SceneData{SceneMappingType::UnsignedInt, 32, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
             /* A secondary scene, which should have non-overlapping IDs for the
                newly added objects */
             if(id == 3)
-                return SceneData{SceneObjectType::UnsignedInt, 31, {}, _dataSecondary.data(), sceneFieldDataNonOwningArray(_dataSecondary.fieldData())};
+                return SceneData{SceneMappingType::UnsignedInt, 31, {}, _dataSecondary.data(), sceneFieldDataNonOwningArray(_dataSecondary.fieldData())};
             CORRADE_INTERNAL_ASSERT_UNREACHABLE();
         }
 
@@ -3014,20 +3014,20 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
         {30, 1, -1}
     }, meshesSecondary);
 
-    SceneData data{SceneObjectType::UnsignedInt, 32, std::move(dataData), {
+    SceneData data{SceneMappingType::UnsignedInt, 32, std::move(dataData), {
         SceneFieldData{SceneField::Parent, parents.slice(&Parent::object), parents.slice(&Parent::parent)},
         SceneFieldData{SceneField::Mesh, meshes.slice(&Mesh::object), meshes.slice(&Mesh::mesh)},
         SceneFieldData{SceneField::MeshMaterial, meshes.slice(&Mesh::object), meshes.slice(&Mesh::meshMaterial)},
         SceneFieldData{SceneField::Camera, cameras.slice(&Camera::object), cameras.slice(&Camera::camera)},
         /* Just to disambiguate this as a 3D scene */
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr},
+        SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr},
     }};
-    SceneData dataSecondary{SceneObjectType::UnsignedInt, 31, std::move(dataDataSecondary), {
+    SceneData dataSecondary{SceneMappingType::UnsignedInt, 31, std::move(dataDataSecondary), {
         SceneFieldData{SceneField::Parent, parentsSecondary.slice(&Parent::object), parentsSecondary.slice(&Parent::parent)},
         SceneFieldData{SceneField::Mesh, meshesSecondary.slice(&Mesh::object), meshesSecondary.slice(&Mesh::mesh)},
         SceneFieldData{SceneField::MeshMaterial, meshesSecondary.slice(&Mesh::object), meshesSecondary.slice(&Mesh::meshMaterial)},
         /* Just to disambiguate this as a 3D scene */
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr},
+        SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Matrix4x4, nullptr},
     }};
 
     struct Importer: AbstractImporter {
@@ -3051,19 +3051,19 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
             /* This scene should get skipped when querying names as it's not
                2D */
             if(id == 0)
-                return SceneData{SceneObjectType::UnsignedByte, 32, nullptr, {}};
+                return SceneData{SceneMappingType::UnsignedByte, 32, nullptr, {}};
             /* This scene should get skipped when querying names as it has too
                little objects */
             if(id == 1)
-                return SceneData{SceneObjectType::UnsignedByte, 32, nullptr, {
-                    SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Matrix4x4, nullptr}
+                return SceneData{SceneMappingType::UnsignedByte, 32, nullptr, {
+                    SceneFieldData{SceneField::Transformation, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Matrix4x4, nullptr}
                 }};
             if(id == 2)
-                return SceneData{SceneObjectType::UnsignedInt, 32, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
+                return SceneData{SceneMappingType::UnsignedInt, 32, {}, _data.data(), sceneFieldDataNonOwningArray(_data.fieldData())};
             /* A secondary scene, which should have non-overlapping IDs for the
                newly added objects */
             if(id == 3)
-                return SceneData{SceneObjectType::UnsignedInt, 31, {}, _dataSecondary.data(), sceneFieldDataNonOwningArray(_dataSecondary.fieldData())};
+                return SceneData{SceneMappingType::UnsignedInt, 31, {}, _dataSecondary.data(), sceneFieldDataNonOwningArray(_dataSecondary.fieldData())};
             CORRADE_INTERNAL_ASSERT_UNREACHABLE();
         }
 
@@ -3282,13 +3282,13 @@ void AbstractImporterTest::sceneDeprecatedFallbackBoth2DAnd3DScene() {
             return {};
         }
         Containers::Optional<SceneData> doScene(UnsignedInt id) override {
-            if(id == 0) return SceneData{SceneObjectType::UnsignedInt, 7, nullptr, {
-                SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
-                SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector2, nullptr},
+            if(id == 0) return SceneData{SceneMappingType::UnsignedInt, 7, nullptr, {
+                SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+                SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector2, nullptr},
             }};
-            if(id == 1) return SceneData{SceneObjectType::UnsignedInt, 7, nullptr, {
-                SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
-                SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
+            if(id == 1) return SceneData{SceneMappingType::UnsignedInt, 7, nullptr, {
+                SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+                SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
             }};
             CORRADE_INTERNAL_ASSERT_UNREACHABLE();
         }
@@ -3432,14 +3432,14 @@ void AbstractImporterTest::sceneNonOwningDeleters() {
 
         UnsignedInt doSceneCount() const override { return 1; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 0,
+            return SceneData{SceneMappingType::UnsignedInt, 0,
                 Containers::Array<char>{data, 1, Implementation::nonOwnedArrayDeleter},
                 sceneFieldDataNonOwningArray(fields)};
         }
 
         char data[1];
         SceneFieldData fields[1]{
-            SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr}
+            SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr}
         };
     } importer;
 
@@ -3462,7 +3462,7 @@ void AbstractImporterTest::sceneCustomDataDeleter() {
         UnsignedInt doSceneCount() const override { return 1; }
         Int doSceneForName(const std::string&) override { return 0; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 0,
+            return SceneData{SceneMappingType::UnsignedInt, 0,
                 Containers::Array<char>{data, 1, [](char*, std::size_t) {}},
                 {}};
         }
@@ -3493,10 +3493,10 @@ void AbstractImporterTest::sceneCustomFieldDataDeleter() {
         UnsignedInt doSceneCount() const override { return 1; }
         Int doSceneForName(const std::string&) override { return 0; }
         Containers::Optional<SceneData> doScene(UnsignedInt) override {
-            return SceneData{SceneObjectType::UnsignedInt, 0, nullptr, Containers::Array<SceneFieldData>{&parents, 1, [](SceneFieldData*, std::size_t) {}}};
+            return SceneData{SceneMappingType::UnsignedInt, 0, nullptr, Containers::Array<SceneFieldData>{&parents, 1, [](SceneFieldData*, std::size_t) {}}};
         }
 
-        SceneFieldData parents{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
+        SceneFieldData parents{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
     } importer;
 
     std::ostringstream out;

--- a/src/Magnum/Trade/Test/AbstractImporterTest.cpp
+++ b/src/Magnum/Trade/Test/AbstractImporterTest.cpp
@@ -1850,13 +1850,13 @@ void AbstractImporterTest::sceneDeprecatedFallback2D() {
     cameras[0] = {3, 15};
     importerState[0] = {3, &a};
 
-    /* Object 5 is a child of object 3 (which is at index 0), has a skin (which
-       gets ignored by the legacy interface) */
-    transformations[1] = {5, 0, Matrix3::rotation(-15.0_degf)};
+    /* Object 5 is a child of object 3, has a skin (which gets ignored by the
+       legacy interface) */
+    transformations[1] = {5, 3, Matrix3::rotation(-15.0_degf)};
     skins[0] = {5, 226};
 
-    /* Object 1 is a child of object 2 (which will be at index 3) */
-    transformations[2] = {1, 3, Matrix3::translation({1.0f, 0.5f})*Matrix3::rotation(15.0_degf)};
+    /* Object 1 is a child of object 2 */
+    transformations[2] = {1, 2, Matrix3::translation({1.0f, 0.5f})*Matrix3::rotation(15.0_degf)};
 
     /* Object 2 is in the root, has object 1 as a child but nothing else */
     transformations[3] = {2, -1, {}};
@@ -1866,9 +1866,9 @@ void AbstractImporterTest::sceneDeprecatedFallback2D() {
     meshes[0] = {0, 33, -1};
 
     /* Object 4 has TRS also, a mesh with a material and a skin and is a child
-       of object 3 (which is at index 0). The transformation gets ignored
-       again. Has importer state. */
-    transformations[5] = {4, 0, Matrix3::translation(Vector2::xAxis(5.0f))};
+       of object 3. The transformation gets ignored again. Has importer
+       state. */
+    transformations[5] = {4, 3, Matrix3::translation(Vector2::xAxis(5.0f))};
     trs[1] = {4, {}, {}, {1.5f, -0.5f}};
     meshes[1] = {4, 27, 46};
     skins[1] = {4, 72};
@@ -2121,13 +2121,13 @@ void AbstractImporterTest::sceneDeprecatedFallback3D() {
     cameras[0] = {3, 15};
     importerState[0] = {3, &a};
 
-    /* Object 5 is a child of object 3 (which is at index 0), has a skin (which
-       gets ignored by the legacy interface) */
-    transformations[1] = {5, 0, Matrix4::rotationY(-15.0_degf)};
+    /* Object 5 is a child of object 3, has a skin (which gets ignored by the
+       legacy interface) */
+    transformations[1] = {5, 3, Matrix4::rotationY(-15.0_degf)};
     skins[0] = {5, 226};
 
-    /* Object 1 is a child of object 2 (which will be at index 3), has a light. */
-    transformations[2] = {1, 3, Matrix4::translation({1.0f, 0.0f, 1.0f})*Matrix4::rotationZ(15.0_degf)};
+    /* Object 1 is a child of object 2, has a light. */
+    transformations[2] = {1, 2, Matrix4::translation({1.0f, 0.0f, 1.0f})*Matrix4::rotationZ(15.0_degf)};
     lights[0] = {1, 113};
 
     /* Object 2 is in the root, has object 1 as a child but nothing else */
@@ -2138,9 +2138,9 @@ void AbstractImporterTest::sceneDeprecatedFallback3D() {
     meshes[0] = {0, 33, -1};
 
     /* Object 4 has TRS also, a mesh with a material and a skin and is a child
-       of object 3 (which is at index 0). The transformation gets ignored
-       again. Has importer state. */
-    transformations[5] = {4, 0, Matrix4::translation(Vector3::xAxis(5.0f))};
+       of object 3. The transformation gets ignored again. Has importer
+       state. */
+    transformations[5] = {4, 3, Matrix4::translation(Vector3::xAxis(5.0f))};
     trs[1] = {4, {}, {}, {1.5f, 3.0f, -0.5f}};
     meshes[1] = {4, 27, 46};
     skins[1] = {4, 72};
@@ -2489,8 +2489,8 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless2D() {
         Int parent;
     } fields[]{
         {5, -1},
-        {2, 0},
-        {3, 0},
+        {2, 5},
+        {3, 5},
         {1, -1}
     };
 
@@ -2595,8 +2595,8 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless3D() {
         Int parent;
     } fields[]{
         {5, -1},
-        {2, 0},
-        {3, 0},
+        {2, 5},
+        {3, 5},
         {1, -1}
     };
 
@@ -2718,7 +2718,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects2D() {
         {NoInit, 7, meshes},
         {NoInit, 2, cameras},
     };
-    Utility::copy({{15, -1}, {21, -1}, {22, 1}, {23, 2}, {1, -1}}, parents);
+    Utility::copy({{15, -1}, {21, -1}, {22, 21}, {23, 22}, {1, -1}}, parents);
     Utility::copy({
         {15, 6, 4},
         {23, 1, 0},
@@ -2985,7 +2985,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackMultiFunctionObjects3D() {
         {NoInit, 7, meshes},
         {NoInit, 2, cameras},
     };
-    Utility::copy({{15, -1}, {21, -1}, {22, 1}, {23, 2}, {1, -1}}, parents);
+    Utility::copy({{15, -1}, {21, -1}, {22, 21}, {23, 22}, {1, -1}}, parents);
     Utility::copy({
         {15, 6, 4},
         {23, 1, 0},

--- a/src/Magnum/Trade/Test/AbstractImporterTest.cpp
+++ b/src/Magnum/Trade/Test/AbstractImporterTest.cpp
@@ -2530,13 +2530,15 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless2D() {
         std::vector<UnsignedInt>{},
         TestSuite::Compare::Container);
 
+    /* If we have neither a matrix nor a TRS, having an identity TRS is better
+       as it's more flexible compared to a matrix */
     {
         Containers::Pointer<ObjectData2D> o = importer.object2D(5);
         CORRADE_VERIFY(o);
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType2D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags2D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag2D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix3{});
         CORRADE_COMPARE_AS(o->children(),
             (std::vector<UnsignedInt>{2, 3}),
@@ -2547,7 +2549,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless2D() {
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType2D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags2D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag2D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix3{});
         CORRADE_COMPARE_AS(o->children(),
             std::vector<UnsignedInt>{},
@@ -2558,7 +2560,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless2D() {
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType2D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags2D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag2D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix3{});
         CORRADE_COMPARE_AS(o->children(),
             std::vector<UnsignedInt>{},
@@ -2569,7 +2571,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless2D() {
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType2D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags2D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag2D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix3{});
         CORRADE_COMPARE_AS(o->children(),
             std::vector<UnsignedInt>{},
@@ -2634,13 +2636,15 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless3D() {
         (std::vector<UnsignedInt>{5, 1}),
         TestSuite::Compare::Container);
 
+    /* If we have neither a matrix nor a TRS, having an identity TRS is better
+       as it's more flexible compared to a matrix */
     {
         Containers::Pointer<ObjectData3D> o = importer.object3D(5);
         CORRADE_VERIFY(o);
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType3D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags3D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag3D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix4{});
         CORRADE_COMPARE_AS(o->children(),
             (std::vector<UnsignedInt>{2, 3}),
@@ -2651,7 +2655,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless3D() {
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType3D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags3D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag3D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix4{});
         CORRADE_COMPARE_AS(o->children(),
             std::vector<UnsignedInt>{},
@@ -2662,7 +2666,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless3D() {
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType3D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags3D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag3D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix4{});
         CORRADE_COMPARE_AS(o->children(),
             std::vector<UnsignedInt>{},
@@ -2673,7 +2677,7 @@ void AbstractImporterTest::sceneDeprecatedFallbackTransformless3D() {
         CORRADE_COMPARE(o->importerState(), nullptr);
         CORRADE_COMPARE(o->instanceType(), ObjectInstanceType3D::Empty);
         CORRADE_COMPARE(o->instance(), -1);
-        CORRADE_COMPARE(o->flags(), ObjectFlags3D{});
+        CORRADE_COMPARE(o->flags(), ObjectFlag3D::HasTranslationRotationScaling);
         CORRADE_COMPARE(o->transformation(), Matrix4{});
         CORRADE_COMPARE_AS(o->children(),
             std::vector<UnsignedInt>{},

--- a/src/Magnum/Trade/Test/AbstractImporterTest.cpp
+++ b/src/Magnum/Trade/Test/AbstractImporterTest.cpp
@@ -1644,8 +1644,9 @@ void AbstractImporterTest::scene() {
             return {};
         }
         Containers::Optional<SceneData> doScene(UnsignedInt id) override {
-            if(id == 7) return SceneData{{}, {}, &state};
-            return SceneData{{}, {}};
+            if(id == 7)
+                return SceneData{SceneObjectType::UnsignedByte, 0, nullptr, {}, &state};
+            return SceneData{SceneObjectType::UnsignedByte, 0, nullptr, {}};
         }
     } importer;
 

--- a/src/Magnum/Trade/Test/CMakeLists.txt
+++ b/src/Magnum/Trade/Test/CMakeLists.txt
@@ -54,8 +54,6 @@ corrade_add_test(TradeImageDataTest ImageDataTest.cpp LIBRARIES MagnumTradeTestL
 corrade_add_test(TradeLightDataTest LightDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradeMaterialDataTest MaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradeMeshDataTest MeshDataTest.cpp LIBRARIES MagnumTradeTestLib)
-corrade_add_test(TradeObjectData2DTest ObjectData2DTest.cpp LIBRARIES MagnumTradeTestLib)
-corrade_add_test(TradeObjectData3DTest ObjectData3DTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradePbrClearCoatMaterialDataTest PbrClearCoatMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradePbrMetallicRoughnessMate___Test PbrMetallicRoughnessMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradePbrSpecularGlossinessMat___Test PbrSpecularGlossinessMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
@@ -81,8 +79,6 @@ set_target_properties(
     TradeImageDataTest
     TradeLightDataTest
     TradeMaterialDataTest
-    TradeObjectData2DTest
-    TradeObjectData3DTest
     TradePbrClearCoatMaterialDataTest
     TradePbrMetallicRoughnessMate___Test
     TradePbrSpecularGlossinessMat___Test
@@ -94,9 +90,13 @@ set_target_properties(
 if(MAGNUM_BUILD_DEPRECATED)
     corrade_add_test(TradeMeshData2DTest MeshData2DTest.cpp LIBRARIES MagnumTrade)
     corrade_add_test(TradeMeshData3DTest MeshData3DTest.cpp LIBRARIES MagnumTrade)
+    corrade_add_test(TradeObjectData2DTest ObjectData2DTest.cpp LIBRARIES MagnumTradeTestLib)
+    corrade_add_test(TradeObjectData3DTest ObjectData3DTest.cpp LIBRARIES MagnumTradeTestLib)
 
     set_target_properties(
         TradeMeshData2DTest
         TradeMeshData3DTest
+        TradeObjectData2DTest
+        TradeObjectData3DTest
         PROPERTIES FOLDER "Magnum/Trade/Test")
 endif()

--- a/src/Magnum/Trade/Test/CMakeLists.txt
+++ b/src/Magnum/Trade/Test/CMakeLists.txt
@@ -60,7 +60,7 @@ corrade_add_test(TradePbrClearCoatMaterialDataTest PbrClearCoatMaterialDataTest.
 corrade_add_test(TradePbrMetallicRoughnessMate___Test PbrMetallicRoughnessMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradePbrSpecularGlossinessMat___Test PbrSpecularGlossinessMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradePhongMaterialDataTest PhongMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
-corrade_add_test(TradeSceneDataTest SceneDataTest.cpp LIBRARIES MagnumTrade)
+corrade_add_test(TradeSceneDataTest SceneDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradeSkinDataTest SkinDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradeTextureDataTest TextureDataTest.cpp LIBRARIES MagnumTrade)
 
@@ -68,6 +68,7 @@ set_property(TARGET
     TradeAnimationDataTest
     TradeMaterialDataTest
     TradeMeshDataTest
+    TradeSceneDataTest
     APPEND PROPERTY COMPILE_DEFINITIONS "CORRADE_GRACEFUL_ASSERT")
 
 set_target_properties(

--- a/src/Magnum/Trade/Test/CMakeLists.txt
+++ b/src/Magnum/Trade/Test/CMakeLists.txt
@@ -59,6 +59,7 @@ corrade_add_test(TradePbrMetallicRoughnessMate___Test PbrMetallicRoughnessMateri
 corrade_add_test(TradePbrSpecularGlossinessMat___Test PbrSpecularGlossinessMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradePhongMaterialDataTest PhongMaterialDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradeSceneDataTest SceneDataTest.cpp LIBRARIES MagnumTradeTestLib)
+corrade_add_test(TradeSceneToolsTest SceneToolsTest.cpp LIBRARIES MagnumTrade)
 corrade_add_test(TradeSkinDataTest SkinDataTest.cpp LIBRARIES MagnumTradeTestLib)
 corrade_add_test(TradeTextureDataTest TextureDataTest.cpp LIBRARIES MagnumTrade)
 
@@ -84,6 +85,7 @@ set_target_properties(
     TradePbrSpecularGlossinessMat___Test
     TradePhongMaterialDataTest
     TradeSceneDataTest
+    TradeSceneToolsTest
     TradeTextureDataTest
     PROPERTIES FOLDER "Magnum/Trade/Test")
 

--- a/src/Magnum/Trade/Test/ObjectData2DTest.cpp
+++ b/src/Magnum/Trade/Test/ObjectData2DTest.cpp
@@ -23,6 +23,9 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+/* There's no better way to disable file deprecation warnings */
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA
+
 #include <sstream>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
@@ -50,6 +53,8 @@ class ObjectData2DTest: public TestSuite::Tester {
         void debugFlag();
         void debugFlags();
 };
+
+CORRADE_IGNORE_DEPRECATED_PUSH
 
 ObjectData2DTest::ObjectData2DTest() {
     addTests({&ObjectData2DTest::constructEmpty,
@@ -263,6 +268,8 @@ void ObjectData2DTest::debugFlags() {
     Debug(&o) << (ObjectFlag2D::HasTranslationRotationScaling|ObjectFlags2D{}) << ObjectFlags2D{};
     CORRADE_COMPARE(o.str(), "Trade::ObjectFlag2D::HasTranslationRotationScaling Trade::ObjectFlags2D{}\n");
 }
+
+CORRADE_IGNORE_DEPRECATED_POP
 
 }}}}
 

--- a/src/Magnum/Trade/Test/ObjectData3DTest.cpp
+++ b/src/Magnum/Trade/Test/ObjectData3DTest.cpp
@@ -23,6 +23,9 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+/* There's no better way to disable file deprecation warnings */
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA
+
 #include <sstream>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
@@ -69,6 +72,8 @@ ObjectData3DTest::ObjectData3DTest() {
               &ObjectData3DTest::debugFlag,
               &ObjectData3DTest::debugFlags});
 }
+
+CORRADE_IGNORE_DEPRECATED_PUSH
 
 using namespace Math::Literals;
 
@@ -277,6 +282,8 @@ void ObjectData3DTest::debugFlags() {
     Debug(&o) << (ObjectFlag3D::HasTranslationRotationScaling|ObjectFlags3D{}) << ObjectFlags3D{};
     CORRADE_COMPARE(o.str(), "Trade::ObjectFlag3D::HasTranslationRotationScaling Trade::ObjectFlags3D{}\n");
 }
+
+CORRADE_IGNORE_DEPRECATED_POP
 
 }}}}
 

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -448,6 +448,7 @@ void SceneDataTest::constructField() {
     CORRADE_COMPARE(rotations.objectData(someArray).stride(), sizeof(UnsignedShort));
     CORRADE_VERIFY(rotations.objectData(someArray).data() == rotationObjectData);
 
+    #ifndef CORRADE_MSVC2015_COMPATIBILITY /* Won't bother anymore */
     constexpr SceneFieldData crotations{SceneField::Rotation, Containers::arrayView(RotationObjects2D), Containers::arrayView(Rotations2D)};
     constexpr bool isOffsetOnly = crotations.isOffsetOnly();
     constexpr SceneField name = crotations.name();
@@ -467,6 +468,7 @@ void SceneDataTest::constructField() {
     CORRADE_COMPARE(fieldData.size(), 3);
     CORRADE_COMPARE(fieldData.stride(), sizeof(Complexd));
     CORRADE_COMPARE(fieldData.data(), Rotations2D);
+    #endif
 }
 
 void SceneDataTest::constructFieldDefault() {

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -98,6 +98,7 @@ struct SceneDataTest: TestSuite::Tester {
     void constructMismatchedTRSViews();
     template<class T> void constructMismatchedTRSDimensionality();
     void constructMismatchedMeshMaterialView();
+    void constructAmbiguousSkinDimensions();
 
     void constructCopy();
     void constructMove();
@@ -253,6 +254,7 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::constructMismatchedTRSDimensionality<Float>,
               &SceneDataTest::constructMismatchedTRSDimensionality<Double>,
               &SceneDataTest::constructMismatchedMeshMaterialView,
+              &SceneDataTest::constructAmbiguousSkinDimensions,
 
               &SceneDataTest::constructCopy,
               &SceneDataTest::constructMove,
@@ -1776,6 +1778,19 @@ void SceneDataTest::constructMismatchedMeshMaterialView() {
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData: Trade::SceneField::MeshMaterial object data [0xcafe0018:0xcafe0024] is different from Trade::SceneField::Mesh object data [0xcafe0000:0xcafe000c]\n"
         "Trade::SceneData: Trade::SceneField::MeshMaterial object data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Mesh object data [0xcafe0000:0xcafe000c]\n");
+}
+
+void SceneDataTest::constructAmbiguousSkinDimensions() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Skin, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr}
+    }};
+    CORRADE_COMPARE(out.str(), "Trade::SceneData: a skin field requires some transformation field to be present in order to disambiguate between 2D and 3D\n");
 }
 
 void SceneDataTest::constructCopy() {
@@ -3649,8 +3664,10 @@ template<class T> void SceneDataTest::skinsAsArray() {
     Containers::StridedArrayView1D<Field> view = fields;
 
     SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
-        /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        /* To verify it isn't just picking the first ever field; also to
+           satisfy the requirement of having a transformation field to
+           disambiguate the dimensionality */
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
@@ -3679,8 +3696,10 @@ void SceneDataTest::skinsIntoArray() {
     Containers::StridedArrayView1D<Field> view = fields;
 
     SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
-        /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        /* To verify it isn't just picking the first ever field; also to
+           satisfy the requirement of having a transformation field to
+           disambiguate the dimensionality */
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin,
             view.slice(&Field::object),
             view.slice(&Field::skin)},
@@ -3718,6 +3737,9 @@ void SceneDataTest::skinsIntoArrayInvalidSizeOrOffset() {
     Containers::StridedArrayView1D<Field> view = fields;
 
     SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To satisfy the requirement of having a transformation field to
+           disambiguate the dimensionality */
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
@@ -4617,6 +4639,9 @@ void SceneDataTest::skinsFor() {
     Containers::StridedArrayView1D<Field> view = fields;
 
     SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+        /* To satisfy the requirement of having a transformation field to
+           disambiguate the dimensionality */
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -4812,8 +4812,8 @@ void SceneDataTest::parentFor() {
         Int parent;
     } fields[]{
         {3, -1},
-        {4, 0},
-        {2, 1},
+        {4, 3},
+        {2, 4},
         {4, 2} /* duplicate, ignored */
     };
     Containers::StridedArrayView1D<Field> view = fields;
@@ -4865,10 +4865,10 @@ void SceneDataTest::childrenFor() {
         Int parent;
     } fields[]{
         {4, -1},
-        {3, 0},
-        {2, 1},
-        {1, 0},
-        {5, 0},
+        {3, 4},
+        {2, 3},
+        {1, 4},
+        {5, 4},
         {0, -1},
     };
     Containers::StridedArrayView1D<Field> view = fields;

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -1786,8 +1786,18 @@ template<class T> void SceneDataTest::parentsAsArray() {
         SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::UnsignedInt, nullptr},
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
-    CORRADE_COMPARE_AS(scene.parentsAsArray(),
-        Containers::arrayView<Int>({15, -1, 44}),
+
+    Int expected[]{15, -1, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.parentsAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    Int out[3];
+    scene.parentsInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
         TestSuite::Compare::Container);
 }
 

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -50,9 +50,9 @@ namespace Magnum { namespace Trade { namespace Test { namespace {
 struct SceneDataTest: TestSuite::Tester {
     explicit SceneDataTest();
 
-    void objectTypeSizeAlignment();
-    void objectTypeSizeAlignmentInvalid();
-    void debugObjectType();
+    void mappingTypeSizeAlignment();
+    void mappingTypeSizeAlignmentInvalid();
+    void debugMappingType();
 
     void customFieldName();
     void customFieldNameTooLarge();
@@ -77,7 +77,7 @@ struct SceneDataTest: TestSuite::Tester {
 
     void constructFieldWrongType();
     void constructFieldInconsistentViewSize();
-    void constructFieldTooLargeObjectStride();
+    void constructFieldTooLargeMappingStride();
     void constructFieldTooLargeFieldStride();
     void constructFieldWrongDataAccess();
     void constructField2DWrongSize();
@@ -99,10 +99,10 @@ struct SceneDataTest: TestSuite::Tester {
 
     void constructDuplicateField();
     void constructDuplicateCustomField();
-    void constructInconsistentObjectType();
-    void constructObjectDataNotContained();
+    void constructInconsistentMappingType();
+    void constructMappingDataNotContained();
     void constructFieldDataNotContained();
-    void constructObjectTypeTooSmall();
+    void constructMappingTypeTooSmall();
     void constructNotOwnedFlagOwned();
     void constructMismatchedTRSViews();
     template<class T> void constructMismatchedTRSDimensionality();
@@ -117,11 +117,11 @@ struct SceneDataTest: TestSuite::Tester {
     void findFieldObjectOffsetInvalidOffset();
     void fieldObjectOffsetNotFound();
 
-    template<class T> void objectsAsArrayByIndex();
-    template<class T> void objectsAsArrayByName();
-    void objectsIntoArrayByIndex();
-    void objectsIntoArrayByName();
-    void objectsIntoArrayInvalidSizeOrOffset();
+    template<class T> void mappingAsArrayByIndex();
+    template<class T> void mappingAsArrayByName();
+    void mappingIntoArrayByIndex();
+    void mappingIntoArrayByName();
+    void mappingIntoArrayInvalidSizeOrOffset();
 
     template<class T> void parentsAsArray();
     void parentsIntoArray();
@@ -160,8 +160,8 @@ struct SceneDataTest: TestSuite::Tester {
 
     void mutableAccessNotAllowed();
 
-    void objectsNotFound();
-    void objectsWrongType();
+    void mappingNotFound();
+    void mappingWrongType();
 
     void fieldNotFound();
     void fieldWrongType();
@@ -220,13 +220,13 @@ const struct {
     std::size_t offset;
     std::size_t size;
     std::size_t expectedSize;
-    bool objects, field;
+    bool mapping, field;
 } IntoArrayOffset1Data[]{
     {"whole", 0, 3, 3, true, true},
     {"one element in the middle", 1, 1, 1, true, true},
     {"suffix to a larger array", 2, 10, 1, true, true},
     {"offset at the end", 3, 10, 0, true, true},
-    {"only objects", 0, 3, 3, true, false},
+    {"only mapping", 0, 3, 3, true, false},
     {"only field", 0, 3, 3, false, true},
     {"neither", 0, 3, 0, false, false}
 };
@@ -236,13 +236,13 @@ const struct {
     std::size_t offset;
     std::size_t size;
     std::size_t expectedSize;
-    bool objects, field1, field2;
+    bool mapping, field1, field2;
 } IntoArrayOffset2Data[]{
     {"whole", 0, 3, 3, true, true, true},
     {"one element in the middle", 1, 1, 1, true, true, true},
     {"suffix to a larger array", 2, 10, 1, true, true, true},
     {"offset at the end", 3, 10, 0, true, true, true},
-    {"only objects", 0, 3, 3, true, false, false},
+    {"only mapping", 0, 3, 3, true, false, false},
     {"only fields", 0, 3, 3, false, true, true},
     {"only first field", 0, 3, 3, false, true, false},
     {"only second field", 0, 3, 3, false, false, true},
@@ -254,13 +254,13 @@ const struct {
     std::size_t offset;
     std::size_t size;
     std::size_t expectedSize;
-    bool objects, field1, field2, field3;
+    bool mapping, field1, field2, field3;
 } IntoArrayOffset3Data[]{
     {"whole", 0, 3, 3, true, true, true, true},
     {"one element in the middle", 1, 1, 1, true, true, true, true},
     {"suffix to a larger array", 2, 10, 1, true, true, true, true},
     {"offset at the end", 3, 10, 0, true, true, true, true},
-    {"only objects", 0, 3, 3, true, false, false, true},
+    {"only mapping", 0, 3, 3, true, false, false, true},
     {"only fields", 0, 3, 3, false, true, true, true},
     {"only first field", 0, 3, 3, false, true, false, false},
     {"only second field", 0, 3, 3, false, false, true, false},
@@ -285,9 +285,9 @@ const struct {
 #endif
 
 SceneDataTest::SceneDataTest() {
-    addTests({&SceneDataTest::objectTypeSizeAlignment,
-              &SceneDataTest::objectTypeSizeAlignmentInvalid,
-              &SceneDataTest::debugObjectType,
+    addTests({&SceneDataTest::mappingTypeSizeAlignment,
+              &SceneDataTest::mappingTypeSizeAlignmentInvalid,
+              &SceneDataTest::debugMappingType,
 
               &SceneDataTest::customFieldName,
               &SceneDataTest::customFieldNameTooLarge,
@@ -312,7 +312,7 @@ SceneDataTest::SceneDataTest() {
 
               &SceneDataTest::constructFieldWrongType,
               &SceneDataTest::constructFieldInconsistentViewSize,
-              &SceneDataTest::constructFieldTooLargeObjectStride,
+              &SceneDataTest::constructFieldTooLargeMappingStride,
               &SceneDataTest::constructFieldTooLargeFieldStride,
               &SceneDataTest::constructFieldWrongDataAccess,
               &SceneDataTest::constructField2DWrongSize,
@@ -339,10 +339,10 @@ SceneDataTest::SceneDataTest() {
 
     addTests({&SceneDataTest::constructDuplicateField,
               &SceneDataTest::constructDuplicateCustomField,
-              &SceneDataTest::constructInconsistentObjectType,
-              &SceneDataTest::constructObjectDataNotContained,
+              &SceneDataTest::constructInconsistentMappingType,
+              &SceneDataTest::constructMappingDataNotContained,
               &SceneDataTest::constructFieldDataNotContained,
-              &SceneDataTest::constructObjectTypeTooSmall,
+              &SceneDataTest::constructMappingTypeTooSmall,
               &SceneDataTest::constructNotOwnedFlagOwned,
               &SceneDataTest::constructMismatchedTRSViews,
               &SceneDataTest::constructMismatchedTRSDimensionality<Float>,
@@ -361,20 +361,20 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::findFieldObjectOffsetInvalidOffset,
               &SceneDataTest::fieldObjectOffsetNotFound,
 
-              &SceneDataTest::objectsAsArrayByIndex<UnsignedByte>,
-              &SceneDataTest::objectsAsArrayByIndex<UnsignedShort>,
-              &SceneDataTest::objectsAsArrayByIndex<UnsignedInt>,
-              &SceneDataTest::objectsAsArrayByIndex<UnsignedLong>,
-              &SceneDataTest::objectsAsArrayByName<UnsignedByte>,
-              &SceneDataTest::objectsAsArrayByName<UnsignedShort>,
-              &SceneDataTest::objectsAsArrayByName<UnsignedInt>,
-              &SceneDataTest::objectsAsArrayByName<UnsignedLong>});
+              &SceneDataTest::mappingAsArrayByIndex<UnsignedByte>,
+              &SceneDataTest::mappingAsArrayByIndex<UnsignedShort>,
+              &SceneDataTest::mappingAsArrayByIndex<UnsignedInt>,
+              &SceneDataTest::mappingAsArrayByIndex<UnsignedLong>,
+              &SceneDataTest::mappingAsArrayByName<UnsignedByte>,
+              &SceneDataTest::mappingAsArrayByName<UnsignedShort>,
+              &SceneDataTest::mappingAsArrayByName<UnsignedInt>,
+              &SceneDataTest::mappingAsArrayByName<UnsignedLong>});
 
-    addInstancedTests({&SceneDataTest::objectsIntoArrayByIndex,
-                       &SceneDataTest::objectsIntoArrayByName},
+    addInstancedTests({&SceneDataTest::mappingIntoArrayByIndex,
+                       &SceneDataTest::mappingIntoArrayByName},
         Containers::arraySize(IntoArrayOffsetData));
 
-    addTests({&SceneDataTest::objectsIntoArrayInvalidSizeOrOffset,
+    addTests({&SceneDataTest::mappingIntoArrayInvalidSizeOrOffset,
 
               &SceneDataTest::parentsAsArray<Byte>,
               &SceneDataTest::parentsAsArray<Short>,
@@ -465,8 +465,8 @@ SceneDataTest::SceneDataTest() {
 
               &SceneDataTest::mutableAccessNotAllowed,
 
-              &SceneDataTest::objectsNotFound,
-              &SceneDataTest::objectsWrongType,
+              &SceneDataTest::mappingNotFound,
+              &SceneDataTest::mappingWrongType,
 
               &SceneDataTest::fieldNotFound,
               &SceneDataTest::fieldWrongType,
@@ -503,18 +503,18 @@ SceneDataTest::SceneDataTest() {
 
 using namespace Math::Literals;
 
-void SceneDataTest::objectTypeSizeAlignment() {
-    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedByte), 1);
-    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedByte), 1);
-    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedShort), 2);
-    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedShort), 2);
-    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedInt), 4);
-    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedInt), 4);
-    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedLong), 8);
-    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedLong), 8);
+void SceneDataTest::mappingTypeSizeAlignment() {
+    CORRADE_COMPARE(sceneMappingTypeSize(SceneMappingType::UnsignedByte), 1);
+    CORRADE_COMPARE(sceneMappingTypeAlignment(SceneMappingType::UnsignedByte), 1);
+    CORRADE_COMPARE(sceneMappingTypeSize(SceneMappingType::UnsignedShort), 2);
+    CORRADE_COMPARE(sceneMappingTypeAlignment(SceneMappingType::UnsignedShort), 2);
+    CORRADE_COMPARE(sceneMappingTypeSize(SceneMappingType::UnsignedInt), 4);
+    CORRADE_COMPARE(sceneMappingTypeAlignment(SceneMappingType::UnsignedInt), 4);
+    CORRADE_COMPARE(sceneMappingTypeSize(SceneMappingType::UnsignedLong), 8);
+    CORRADE_COMPARE(sceneMappingTypeAlignment(SceneMappingType::UnsignedLong), 8);
 }
 
-void SceneDataTest::objectTypeSizeAlignmentInvalid() {
+void SceneDataTest::mappingTypeSizeAlignmentInvalid() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -522,22 +522,22 @@ void SceneDataTest::objectTypeSizeAlignmentInvalid() {
     std::ostringstream out;
     Error redirectError{&out};
 
-    sceneObjectTypeSize(SceneObjectType{});
-    sceneObjectTypeAlignment(SceneObjectType{});
-    sceneObjectTypeSize(SceneObjectType(0x73));
-    sceneObjectTypeAlignment(SceneObjectType(0x73));
+    sceneMappingTypeSize(SceneMappingType{});
+    sceneMappingTypeAlignment(SceneMappingType{});
+    sceneMappingTypeSize(SceneMappingType(0x73));
+    sceneMappingTypeAlignment(SceneMappingType(0x73));
 
     CORRADE_COMPARE(out.str(),
-        "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x0)\n"
-        "Trade::sceneObjectTypeAlignment(): invalid type Trade::SceneObjectType(0x0)\n"
-        "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x73)\n"
-        "Trade::sceneObjectTypeAlignment(): invalid type Trade::SceneObjectType(0x73)\n");
+        "Trade::sceneMappingTypeSize(): invalid type Trade::SceneMappingType(0x0)\n"
+        "Trade::sceneMappingTypeAlignment(): invalid type Trade::SceneMappingType(0x0)\n"
+        "Trade::sceneMappingTypeSize(): invalid type Trade::SceneMappingType(0x73)\n"
+        "Trade::sceneMappingTypeAlignment(): invalid type Trade::SceneMappingType(0x73)\n");
 }
 
-void SceneDataTest::debugObjectType() {
+void SceneDataTest::debugMappingType() {
     std::ostringstream out;
-    Debug{&out} << SceneObjectType::UnsignedLong << SceneObjectType(0x73);
-    CORRADE_COMPARE(out.str(), "Trade::SceneObjectType::UnsignedLong Trade::SceneObjectType(0x73)\n");
+    Debug{&out} << SceneMappingType::UnsignedLong << SceneMappingType(0x73);
+    CORRADE_COMPARE(out.str(), "Trade::SceneMappingType::UnsignedLong Trade::SceneMappingType(0x73)\n");
 }
 
 void SceneDataTest::customFieldName() {
@@ -645,29 +645,29 @@ void SceneDataTest::debugFieldType() {
     CORRADE_COMPARE(out.str(), "Trade::SceneFieldType::Matrix3x4h Trade::SceneFieldType(0xdead)\n");
 }
 
-constexpr Complexd Rotations2D[3] {
-    Complexd{Constantsd::sqrtHalf(), Constantsd::sqrtHalf()}, /* 45° */
-    Complexd{1.0, 0.0}, /* 0° */
-    Complexd{0.0, 1.0}, /* 90° */
-};
-const UnsignedShort RotationObjects2D[3] {
+const UnsignedShort RotationMapping2D[3] {
     17,
     35,
     98
 };
+constexpr Complexd RotationField2D[3] {
+    Complexd{Constantsd::sqrtHalf(), Constantsd::sqrtHalf()}, /* 45° */
+    Complexd{1.0, 0.0}, /* 0° */
+    Complexd{0.0, 1.0}, /* 90° */
+};
 
 void SceneDataTest::constructField() {
-    const UnsignedShort rotationObjectData[3]{};
+    const UnsignedShort rotationMappingData[3]{};
     const Complexd rotationFieldData[3];
 
-    SceneFieldData rotations{SceneField::Rotation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
+    SceneFieldData rotations{SceneField::Rotation, Containers::arrayView(rotationMappingData), Containers::arrayView(rotationFieldData)};
     CORRADE_VERIFY(!rotations.isOffsetOnly());
     CORRADE_COMPARE(rotations.name(), SceneField::Rotation);
     CORRADE_COMPARE(rotations.size(), 3);
-    CORRADE_COMPARE(rotations.objectType(), SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(rotations.objectData().size(), 3);
-    CORRADE_COMPARE(rotations.objectData().stride(), sizeof(UnsignedShort));
-    CORRADE_VERIFY(rotations.objectData().data() == rotationObjectData);
+    CORRADE_COMPARE(rotations.mappingType(), SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(rotations.mappingData().size(), 3);
+    CORRADE_COMPARE(rotations.mappingData().stride(), sizeof(UnsignedShort));
+    CORRADE_VERIFY(rotations.mappingData().data() == rotationMappingData);
     CORRADE_COMPARE(rotations.fieldType(), SceneFieldType::Complexd);
     CORRADE_COMPARE(rotations.fieldArraySize(), 0);
     CORRADE_COMPARE(rotations.fieldData().size(), 3);
@@ -680,30 +680,30 @@ void SceneDataTest::constructField() {
     CORRADE_COMPARE(rotations.fieldData(someArray).size(), 3);
     CORRADE_COMPARE(rotations.fieldData(someArray).stride(), sizeof(Complexd));
     CORRADE_VERIFY(rotations.fieldData(someArray).data() == rotationFieldData);
-    CORRADE_COMPARE(rotations.objectData(someArray).size(), 3);
-    CORRADE_COMPARE(rotations.objectData(someArray).stride(), sizeof(UnsignedShort));
-    CORRADE_VERIFY(rotations.objectData(someArray).data() == rotationObjectData);
+    CORRADE_COMPARE(rotations.mappingData(someArray).size(), 3);
+    CORRADE_COMPARE(rotations.mappingData(someArray).stride(), sizeof(UnsignedShort));
+    CORRADE_VERIFY(rotations.mappingData(someArray).data() == rotationMappingData);
 
     #ifndef CORRADE_MSVC2015_COMPATIBILITY /* Won't bother anymore */
-    constexpr SceneFieldData crotations{SceneField::Rotation, Containers::arrayView(RotationObjects2D), Containers::arrayView(Rotations2D)};
+    constexpr SceneFieldData crotations{SceneField::Rotation, Containers::arrayView(RotationMapping2D), Containers::arrayView(RotationField2D)};
     constexpr bool isOffsetOnly = crotations.isOffsetOnly();
     constexpr SceneField name = crotations.name();
-    constexpr SceneObjectType objectType = crotations.objectType();
-    constexpr Containers::StridedArrayView1D<const void> objectData = crotations.objectData();
+    constexpr SceneMappingType mappingType = crotations.mappingType();
+    constexpr Containers::StridedArrayView1D<const void> mappingData = crotations.mappingData();
     constexpr SceneFieldType fieldType = crotations.fieldType();
     constexpr UnsignedShort fieldArraySize = crotations.fieldArraySize();
     constexpr Containers::StridedArrayView1D<const void> fieldData = crotations.fieldData();
     CORRADE_VERIFY(!isOffsetOnly);
     CORRADE_COMPARE(name, SceneField::Rotation);
-    CORRADE_COMPARE(objectType, SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(objectData.size(), 3);
-    CORRADE_COMPARE(objectData.stride(), sizeof(UnsignedShort));
-    CORRADE_COMPARE(objectData.data(), RotationObjects2D);
+    CORRADE_COMPARE(mappingType, SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(mappingData.size(), 3);
+    CORRADE_COMPARE(mappingData.stride(), sizeof(UnsignedShort));
+    CORRADE_COMPARE(mappingData.data(), RotationMapping2D);
     CORRADE_COMPARE(fieldType, SceneFieldType::Complexd);
     CORRADE_COMPARE(fieldArraySize, 0);
     CORRADE_COMPARE(fieldData.size(), 3);
     CORRADE_COMPARE(fieldData.stride(), sizeof(Complexd));
-    CORRADE_COMPARE(fieldData.data(), Rotations2D);
+    CORRADE_COMPARE(fieldData.data(), RotationField2D);
     #endif
 }
 
@@ -711,42 +711,42 @@ void SceneDataTest::constructFieldDefault() {
     SceneFieldData data;
     CORRADE_COMPARE(data.name(), SceneField{});
     CORRADE_COMPARE(data.fieldType(), SceneFieldType{});
-    CORRADE_COMPARE(data.objectType(), SceneObjectType{});
+    CORRADE_COMPARE(data.mappingType(), SceneMappingType{});
 
     constexpr SceneFieldData cdata;
     CORRADE_COMPARE(cdata.name(), SceneField{});
     CORRADE_COMPARE(cdata.fieldType(), SceneFieldType{});
-    CORRADE_COMPARE(cdata.objectType(), SceneObjectType{});
+    CORRADE_COMPARE(cdata.mappingType(), SceneMappingType{});
 }
 
 void SceneDataTest::constructFieldCustom() {
     /* Verifying it doesn't hit any assertion about disallowed type for given
        attribute */
 
-    const UnsignedByte rangeObjectData[3]{};
+    const UnsignedByte rangeMappingData[3]{};
     const Range2Dh rangeFieldData[3];
-    SceneFieldData ranges{sceneFieldCustom(13), Containers::arrayView(rangeObjectData), Containers::arrayView(rangeFieldData)};
+    SceneFieldData ranges{sceneFieldCustom(13), Containers::arrayView(rangeMappingData), Containers::arrayView(rangeFieldData)};
     CORRADE_COMPARE(ranges.name(), sceneFieldCustom(13));
-    CORRADE_COMPARE(ranges.objectType(), SceneObjectType::UnsignedByte);
-    CORRADE_VERIFY(ranges.objectData().data() == rangeObjectData);
+    CORRADE_COMPARE(ranges.mappingType(), SceneMappingType::UnsignedByte);
+    CORRADE_VERIFY(ranges.mappingData().data() == rangeMappingData);
     CORRADE_COMPARE(ranges.fieldType(), SceneFieldType::Range2Dh);
     CORRADE_VERIFY(ranges.fieldData().data() == rangeFieldData);
 }
 
 void SceneDataTest::constructField2D() {
-    char rotationObjectData[6*sizeof(UnsignedShort)];
+    char rotationMappingData[6*sizeof(UnsignedShort)];
     char rotationFieldData[6*sizeof(Complexd)];
-    auto rotationObjectView = Containers::StridedArrayView2D<char>{rotationObjectData, {6, sizeof(UnsignedShort)}}.every(2);
+    auto rotationMappingView = Containers::StridedArrayView2D<char>{rotationMappingData, {6, sizeof(UnsignedShort)}}.every(2);
     auto rotationFieldView = Containers::StridedArrayView2D<char>{rotationFieldData, {6, sizeof(Complexd)}}.every(2);
 
-    SceneFieldData rotations{SceneField::Rotation, rotationObjectView, SceneFieldType::Complexd, rotationFieldView};
+    SceneFieldData rotations{SceneField::Rotation, rotationMappingView, SceneFieldType::Complexd, rotationFieldView};
     CORRADE_VERIFY(!rotations.isOffsetOnly());
     CORRADE_COMPARE(rotations.name(), SceneField::Rotation);
     CORRADE_COMPARE(rotations.size(), 3);
-    CORRADE_COMPARE(rotations.objectType(), SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(rotations.objectData().size(), 3);
-    CORRADE_COMPARE(rotations.objectData().stride(), 2*sizeof(UnsignedShort));
-    CORRADE_COMPARE(rotations.objectData().data(), rotationObjectView.data());
+    CORRADE_COMPARE(rotations.mappingType(), SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(rotations.mappingData().size(), 3);
+    CORRADE_COMPARE(rotations.mappingData().stride(), 2*sizeof(UnsignedShort));
+    CORRADE_COMPARE(rotations.mappingData().data(), rotationMappingView.data());
     CORRADE_COMPARE(rotations.fieldType(), SceneFieldType::Complexd);
     CORRADE_COMPARE(rotations.fieldArraySize(), 0);
     CORRADE_COMPARE(rotations.fieldData().size(), 3);
@@ -755,16 +755,16 @@ void SceneDataTest::constructField2D() {
 }
 
 void SceneDataTest::constructFieldTypeErased() {
-    const UnsignedLong scalingObjectData[3]{};
+    const UnsignedLong scalingMappingData[3]{};
     const Vector3 scalingFieldData[3];
-    SceneFieldData scalings{SceneField::Scaling, SceneObjectType::UnsignedLong, Containers::arrayCast<const char>(Containers::stridedArrayView(scalingObjectData)), SceneFieldType::Vector3, Containers::arrayCast<const char>(Containers::stridedArrayView(scalingFieldData))};
+    SceneFieldData scalings{SceneField::Scaling, SceneMappingType::UnsignedLong, Containers::arrayCast<const char>(Containers::stridedArrayView(scalingMappingData)), SceneFieldType::Vector3, Containers::arrayCast<const char>(Containers::stridedArrayView(scalingFieldData))};
     CORRADE_VERIFY(!scalings.isOffsetOnly());
     CORRADE_COMPARE(scalings.name(), SceneField::Scaling);
     CORRADE_COMPARE(scalings.size(), 3);
-    CORRADE_COMPARE(scalings.objectType(), SceneObjectType::UnsignedLong);
-    CORRADE_COMPARE(scalings.objectData().size(), 3);
-    CORRADE_COMPARE(scalings.objectData().stride(), sizeof(UnsignedLong));
-    CORRADE_COMPARE(scalings.objectData().data(), scalingObjectData);
+    CORRADE_COMPARE(scalings.mappingType(), SceneMappingType::UnsignedLong);
+    CORRADE_COMPARE(scalings.mappingData().size(), 3);
+    CORRADE_COMPARE(scalings.mappingData().stride(), sizeof(UnsignedLong));
+    CORRADE_COMPARE(scalings.mappingData().data(), scalingMappingData);
     CORRADE_COMPARE(scalings.fieldType(), SceneFieldType::Vector3);
     CORRADE_COMPARE(scalings.fieldArraySize(), 0);
     CORRADE_COMPARE(scalings.fieldData().size(), 3);
@@ -789,14 +789,14 @@ void SceneDataTest::constructFieldOffsetOnly() {
         {0, 15, {67.0f, -1.1f}}
     };
 
-    SceneFieldData a{SceneField::Translation, 2, SceneObjectType::UnsignedShort, offsetof(Data, object), sizeof(Data), SceneFieldType::Vector2, offsetof(Data, translation), sizeof(Data)};
+    SceneFieldData a{SceneField::Translation, 2, SceneMappingType::UnsignedShort, offsetof(Data, object), sizeof(Data), SceneFieldType::Vector2, offsetof(Data, translation), sizeof(Data)};
     CORRADE_VERIFY(a.isOffsetOnly());
     CORRADE_COMPARE(a.name(), SceneField::Translation);
     CORRADE_COMPARE(a.size(), 2);
-    CORRADE_COMPARE(a.objectType(), SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(a.objectData(data).size(), 2);
-    CORRADE_COMPARE(a.objectData(data).stride(), sizeof(Data));
-    CORRADE_COMPARE_AS(Containers::arrayCast<const UnsignedShort>(a.objectData(data)),
+    CORRADE_COMPARE(a.mappingType(), SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(a.mappingData(data).size(), 2);
+    CORRADE_COMPARE(a.mappingData(data).stride(), sizeof(Data));
+    CORRADE_COMPARE_AS(Containers::arrayCast<const UnsignedShort>(a.mappingData(data)),
         Containers::arrayView<UnsignedShort>({2, 15}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE(a.fieldType(), SceneFieldType::Vector2);
@@ -808,34 +808,34 @@ void SceneDataTest::constructFieldOffsetOnly() {
         TestSuite::Compare::Container);
 }
 
-constexpr UnsignedByte ArrayOffsetObjectData[3]{};
+constexpr UnsignedByte ArrayOffsetMappingData[3]{};
 constexpr Int ArrayOffsetFieldData[3*4]{};
 
 void SceneDataTest::constructFieldArray() {
-    UnsignedByte offsetObjectData[3];
+    UnsignedByte offsetMappingData[3];
     Int offsetFieldData[3*4];
-    SceneFieldData data{sceneFieldCustom(34), Containers::arrayView(offsetObjectData), Containers::StridedArrayView2D<Int>{offsetFieldData, {3, 4}}};
+    SceneFieldData data{sceneFieldCustom(34), Containers::arrayView(offsetMappingData), Containers::StridedArrayView2D<Int>{offsetFieldData, {3, 4}}};
     CORRADE_VERIFY(!data.isOffsetOnly());
     CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
     CORRADE_COMPARE(data.size(), 3);
-    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
-    CORRADE_COMPARE(data.objectData().size(), 3);
-    CORRADE_COMPARE(data.objectData().stride(), sizeof(UnsignedByte));
-    CORRADE_VERIFY(data.objectData().data() == offsetObjectData);
+    CORRADE_COMPARE(data.mappingType(), SceneMappingType::UnsignedByte);
+    CORRADE_COMPARE(data.mappingData().size(), 3);
+    CORRADE_COMPARE(data.mappingData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(data.mappingData().data() == offsetMappingData);
     CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
     CORRADE_COMPARE(data.fieldArraySize(), 4);
     CORRADE_COMPARE(data.fieldData().size(), 3);
     CORRADE_COMPARE(data.fieldData().stride(), 4*sizeof(Int));
     CORRADE_VERIFY(data.fieldData().data() == offsetFieldData);
 
-    constexpr SceneFieldData cdata{sceneFieldCustom(34), Containers::arrayView(ArrayOffsetObjectData), Containers::StridedArrayView2D<const Int>{ArrayOffsetFieldData, {3, 4}}};
+    constexpr SceneFieldData cdata{sceneFieldCustom(34), Containers::arrayView(ArrayOffsetMappingData), Containers::StridedArrayView2D<const Int>{ArrayOffsetFieldData, {3, 4}}};
     CORRADE_VERIFY(!cdata.isOffsetOnly());
     CORRADE_COMPARE(cdata.name(), sceneFieldCustom(34));
     CORRADE_COMPARE(cdata.size(), 3);
-    CORRADE_COMPARE(cdata.objectType(), SceneObjectType::UnsignedByte);
-    CORRADE_COMPARE(cdata.objectData().size(), 3);
-    CORRADE_COMPARE(cdata.objectData().stride(), sizeof(UnsignedByte));
-    CORRADE_VERIFY(cdata.objectData().data() == ArrayOffsetObjectData);
+    CORRADE_COMPARE(cdata.mappingType(), SceneMappingType::UnsignedByte);
+    CORRADE_COMPARE(cdata.mappingData().size(), 3);
+    CORRADE_COMPARE(cdata.mappingData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(cdata.mappingData().data() == ArrayOffsetMappingData);
     CORRADE_COMPARE(cdata.fieldType(), SceneFieldType::Int);
     CORRADE_COMPARE(cdata.fieldArraySize(), 4);
     CORRADE_COMPARE(cdata.fieldData().size(), 3);
@@ -844,16 +844,16 @@ void SceneDataTest::constructFieldArray() {
 }
 
 void SceneDataTest::constructFieldArray2D() {
-    char offsetObjectData[3*sizeof(UnsignedByte)];
+    char offsetMappingData[3*sizeof(UnsignedByte)];
     char offsetFieldData[3*4*sizeof(Int)];
-    SceneFieldData data{sceneFieldCustom(34), Containers::StridedArrayView2D<char>{offsetObjectData, {3, sizeof(UnsignedByte)}}, SceneFieldType::Int, Containers::StridedArrayView2D<char>{offsetFieldData, {3, 4*sizeof(Int)}}, 4};
+    SceneFieldData data{sceneFieldCustom(34), Containers::StridedArrayView2D<char>{offsetMappingData, {3, sizeof(UnsignedByte)}}, SceneFieldType::Int, Containers::StridedArrayView2D<char>{offsetFieldData, {3, 4*sizeof(Int)}}, 4};
     CORRADE_VERIFY(!data.isOffsetOnly());
     CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
     CORRADE_COMPARE(data.size(), 3);
-    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
-    CORRADE_COMPARE(data.objectData().size(), 3);
-    CORRADE_COMPARE(data.objectData().stride(), sizeof(UnsignedByte));
-    CORRADE_VERIFY(data.objectData().data() == offsetObjectData);
+    CORRADE_COMPARE(data.mappingType(), SceneMappingType::UnsignedByte);
+    CORRADE_COMPARE(data.mappingData().size(), 3);
+    CORRADE_COMPARE(data.mappingData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(data.mappingData().data() == offsetMappingData);
     CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
     CORRADE_COMPARE(data.fieldArraySize(), 4);
     CORRADE_COMPARE(data.fieldData().size(), 3);
@@ -862,22 +862,22 @@ void SceneDataTest::constructFieldArray2D() {
 }
 
 void SceneDataTest::constructFieldArrayTypeErased() {
-    Int offsetData[3*4];
-    Containers::StridedArrayView1D<Int> offset{offsetData, 3, 4*sizeof(Int)};
-    UnsignedByte offsetObjectData[3];
-    SceneFieldData data{sceneFieldCustom(34), SceneObjectType::UnsignedByte, Containers::arrayCast<const char>(Containers::stridedArrayView(offsetObjectData)), SceneFieldType::Int, Containers::arrayCast<const char>(offset), 4};
+    UnsignedByte offsetMappingData[3];
+    Int offsetFieldData[3*4];
+    Containers::StridedArrayView1D<Int> offset{offsetFieldData, 3, 4*sizeof(Int)};
+    SceneFieldData data{sceneFieldCustom(34), SceneMappingType::UnsignedByte, Containers::arrayCast<const char>(Containers::stridedArrayView(offsetMappingData)), SceneFieldType::Int, Containers::arrayCast<const char>(offset), 4};
     CORRADE_VERIFY(!data.isOffsetOnly());
     CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
     CORRADE_COMPARE(data.size(), 3);
     CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
-    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
-    CORRADE_COMPARE(data.objectData().size(), 3);
-    CORRADE_COMPARE(data.objectData().stride(), sizeof(UnsignedByte));
-    CORRADE_VERIFY(data.objectData().data() == offsetObjectData);
+    CORRADE_COMPARE(data.mappingType(), SceneMappingType::UnsignedByte);
+    CORRADE_COMPARE(data.mappingData().size(), 3);
+    CORRADE_COMPARE(data.mappingData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(data.mappingData().data() == offsetMappingData);
     CORRADE_COMPARE(data.fieldArraySize(), 4);
     CORRADE_COMPARE(data.fieldData().size(), 3);
     CORRADE_COMPARE(data.fieldData().stride(), 4*sizeof(Int));
-    CORRADE_VERIFY(data.fieldData().data() == offsetData);
+    CORRADE_VERIFY(data.fieldData().data() == offsetFieldData);
 }
 
 void SceneDataTest::constructFieldArrayOffsetOnly() {
@@ -887,11 +887,11 @@ void SceneDataTest::constructFieldArrayOffsetOnly() {
         Int offset[4];
     };
 
-    SceneFieldData data{sceneFieldCustom(34), 3, SceneObjectType::UnsignedByte, offsetof(Data, object), sizeof(Data), SceneFieldType::Int, offsetof(Data, offset), sizeof(Data), 4};
+    SceneFieldData data{sceneFieldCustom(34), 3, SceneMappingType::UnsignedByte, offsetof(Data, object), sizeof(Data), SceneFieldType::Int, offsetof(Data, offset), sizeof(Data), 4};
     CORRADE_VERIFY(data.isOffsetOnly());
     CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
     CORRADE_COMPARE(data.size(), 3);
-    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(data.mappingType(), SceneMappingType::UnsignedByte);
     CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
     CORRADE_COMPARE(data.fieldArraySize(), 4);
 
@@ -899,15 +899,15 @@ void SceneDataTest::constructFieldArrayOffsetOnly() {
     CORRADE_COMPARE(data.fieldData(actual).size(), 3);
     CORRADE_COMPARE(data.fieldData(actual).stride(), sizeof(Data));
     CORRADE_VERIFY(data.fieldData(actual).data() == &actual[0].offset);
-    CORRADE_COMPARE(data.objectData(actual).size(), 3);
-    CORRADE_COMPARE(data.objectData(actual).stride(), sizeof(Data));
-    CORRADE_VERIFY(data.objectData(actual).data() == &actual[0].object);
+    CORRADE_COMPARE(data.mappingData(actual).size(), 3);
+    CORRADE_COMPARE(data.mappingData(actual).stride(), sizeof(Data));
+    CORRADE_VERIFY(data.mappingData(actual).data() == &actual[0].object);
 
-    constexpr SceneFieldData cdata{sceneFieldCustom(34), 3, SceneObjectType::UnsignedByte, offsetof(Data, object), sizeof(Data), SceneFieldType::Int, offsetof(Data, offset), sizeof(Data), 4};
+    constexpr SceneFieldData cdata{sceneFieldCustom(34), 3, SceneMappingType::UnsignedByte, offsetof(Data, object), sizeof(Data), SceneFieldType::Int, offsetof(Data, offset), sizeof(Data), 4};
     CORRADE_VERIFY(cdata.isOffsetOnly());
     CORRADE_COMPARE(cdata.name(), sceneFieldCustom(34));
     CORRADE_COMPARE(cdata.size(), 3);
-    CORRADE_COMPARE(cdata.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(cdata.mappingType(), SceneMappingType::UnsignedByte);
     CORRADE_COMPARE(cdata.fieldType(), SceneFieldType::Int);
     CORRADE_COMPARE(cdata.fieldArraySize(), 4);
 }
@@ -917,13 +917,13 @@ void SceneDataTest::constructFieldInconsistentViewSize() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    const UnsignedShort rotationObjectData[3]{};
+    const UnsignedShort rotationMappingData[3]{};
     const Complexd rotationFieldData[2];
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneFieldData{SceneField::Rotation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
-    CORRADE_COMPARE(out.str(), "Trade::SceneFieldData: expected object and field view to have the same size but got 3 and 2\n");
+    SceneFieldData{SceneField::Rotation, Containers::arrayView(rotationMappingData), Containers::arrayView(rotationFieldData)};
+    CORRADE_COMPARE(out.str(), "Trade::SceneFieldData: expected mapping and field view to have the same size but got 3 and 2\n");
 }
 
 void SceneDataTest::constructFieldWrongType() {
@@ -931,19 +931,19 @@ void SceneDataTest::constructFieldWrongType() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    const UnsignedShort rotationObjectData[3]{};
+    const UnsignedShort rotationMappingData[3]{};
     const Quaternion rotationFieldData[3];
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneFieldData{SceneField::Transformation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
-    SceneFieldData{SceneField::Transformation, 3, SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort), SceneFieldType::Quaternion, 0, sizeof(Quaternion)};
+    SceneFieldData{SceneField::Transformation, Containers::arrayView(rotationMappingData), Containers::arrayView(rotationFieldData)};
+    SceneFieldData{SceneField::Transformation, 3, SceneMappingType::UnsignedShort, 0, sizeof(UnsignedShort), SceneFieldType::Quaternion, 0, sizeof(Quaternion)};
     CORRADE_COMPARE(out.str(),
         "Trade::SceneFieldData: Trade::SceneFieldType::Quaternion is not a valid type for Trade::SceneField::Transformation\n"
         "Trade::SceneFieldData: Trade::SceneFieldType::Quaternion is not a valid type for Trade::SceneField::Transformation\n");
 }
 
-void SceneDataTest::constructFieldTooLargeObjectStride() {
+void SceneDataTest::constructFieldTooLargeMappingStride() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -952,22 +952,22 @@ void SceneDataTest::constructFieldTooLargeObjectStride() {
     char toomuch[2*(32768 + sizeof(UnsignedInt))];
 
     /* These should be fine */
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32767}, SceneFieldType::UnsignedInt, enough};
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}.flipped<0>(), SceneFieldType::UnsignedInt, enough};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 32767, SceneFieldType::UnsignedInt, 0, 4};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 65536, -32768, SceneFieldType::UnsignedInt, 0, 4};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32767}, SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}.flipped<0>(), SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 0, 32767, SceneFieldType::UnsignedInt, 0, 4};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 65536, -32768, SceneFieldType::UnsignedInt, 0, 4};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}, SceneFieldType::UnsignedInt, enough};
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32769}.flipped<0>(), SceneFieldType::UnsignedInt, enough};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 32768, SceneFieldType::UnsignedInt, 0, 4};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 65538, -32769, SceneFieldType::UnsignedInt, 0, 4};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}, SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32769}.flipped<0>(), SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 0, 32768, SceneFieldType::UnsignedInt, 0, 4};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 65538, -32769, SceneFieldType::UnsignedInt, 0, 4};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got 32768\n"
-        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got -32769\n"
-        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got 32768\n"
-        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got -32769\n");
+        "Trade::SceneFieldData: expected mapping view stride to fit into 16 bits, but got 32768\n"
+        "Trade::SceneFieldData: expected mapping view stride to fit into 16 bits, but got -32769\n"
+        "Trade::SceneFieldData: expected mapping view stride to fit into 16 bits, but got 32768\n"
+        "Trade::SceneFieldData: expected mapping view stride to fit into 16 bits, but got -32769\n");
 }
 
 void SceneDataTest::constructFieldTooLargeFieldStride() {
@@ -979,17 +979,17 @@ void SceneDataTest::constructFieldTooLargeFieldStride() {
     char toomuch[2*(32768 + sizeof(UnsignedInt))];
 
     /* These should be fine */
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32767}};
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}.flipped<0>()};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 0, 32767};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 65536, -32768};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32767}};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}.flipped<0>()};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 0, 32767};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 65536, -32768};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}};
-    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32769}.flipped<0>()};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 0, 32768};
-    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 65538, -32769};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}};
+    SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32769}.flipped<0>()};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 0, 32768};
+    SceneFieldData{SceneField::Mesh, 2, SceneMappingType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 65538, -32769};
     CORRADE_COMPARE(out.str(),
         "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got 32768\n"
         "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got -32769\n"
@@ -1002,22 +1002,22 @@ void SceneDataTest::constructFieldWrongDataAccess() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    const UnsignedShort rotationObjectData[3]{};
+    const UnsignedShort rotationMappingData[3]{};
     const Quaternion rotationFieldData[3];
-    SceneFieldData a{SceneField::Rotation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
-    SceneFieldData b{SceneField::Rotation, 3, SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort), SceneFieldType::Quaternion, 0, sizeof(Quaternion)};
+    SceneFieldData a{SceneField::Rotation, Containers::arrayView(rotationMappingData), Containers::arrayView(rotationFieldData)};
+    SceneFieldData b{SceneField::Rotation, 3, SceneMappingType::UnsignedShort, 0, sizeof(UnsignedShort), SceneFieldType::Quaternion, 0, sizeof(Quaternion)};
     CORRADE_VERIFY(!a.isOffsetOnly());
     CORRADE_VERIFY(b.isOffsetOnly());
 
-    a.objectData(rotationObjectData); /* This is fine, no asserts */
+    a.mappingData(rotationMappingData); /* This is fine, no asserts */
     a.fieldData(rotationFieldData);
 
     std::ostringstream out;
     Error redirectError{&out};
-    b.objectData();
+    b.mappingData();
     b.fieldData();
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneFieldData::objectData(): the field is offset-only, supply a data array\n"
+        "Trade::SceneFieldData::mappingData(): the field is offset-only, supply a data array\n"
         "Trade::SceneFieldData::fieldData(): the field is offset-only, supply a data array\n");
 }
 
@@ -1026,21 +1026,21 @@ void SceneDataTest::constructField2DWrongSize() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
+    char rotationMappingData[5*sizeof(UnsignedInt)];
     char rotationFieldData[5*sizeof(Complex)];
-    char rotationObjectData[5*sizeof(UnsignedInt)];
 
     std::ostringstream out;
     Error redirectError{&out};
     SceneFieldData{SceneField::Rotation,
-        Containers::StridedArrayView2D<char>{rotationObjectData, {4, 5}}.every(2),
+        Containers::StridedArrayView2D<char>{rotationMappingData, {4, 5}}.every(2),
         SceneFieldType::Complex,
         Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}.every(2)};
     SceneFieldData{SceneField::Translation,
-        Containers::StridedArrayView2D<char>{rotationObjectData, {4, sizeof(UnsignedInt)}}.every(2),
+        Containers::StridedArrayView2D<char>{rotationMappingData, {4, sizeof(UnsignedInt)}}.every(2),
         SceneFieldType::Vector3,
         Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}.every(2)};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneFieldData: expected second object view dimension size 1, 2, 4 or 8 but got 5\n"
+        "Trade::SceneFieldData: expected second mapping view dimension size 1, 2, 4 or 8 but got 5\n"
         "Trade::SceneFieldData: second field view dimension size 8 doesn't match Trade::SceneFieldType::Vector3\n");
 }
 
@@ -1049,21 +1049,21 @@ void SceneDataTest::constructField2DNonContiguous() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    char rotationObjectData[8*sizeof(UnsignedInt)];
+    char rotationMappingData[8*sizeof(UnsignedInt)];
     char rotationFieldData[8*sizeof(Complex)];
 
     std::ostringstream out;
     Error redirectError{&out};
     SceneFieldData{SceneField::Rotation,
-        Containers::StridedArrayView2D<char>{rotationObjectData, {4, 2*sizeof(UnsignedInt)}}.every({1, 2}),
+        Containers::StridedArrayView2D<char>{rotationMappingData, {4, 2*sizeof(UnsignedInt)}}.every({1, 2}),
         SceneFieldType::Complex,
         Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}};
     SceneFieldData{SceneField::Rotation,
-        Containers::StridedArrayView2D<char>{rotationObjectData, {4, sizeof(UnsignedInt)}},
+        Containers::StridedArrayView2D<char>{rotationMappingData, {4, sizeof(UnsignedInt)}},
         SceneFieldType::Complex,
         Containers::StridedArrayView2D<char>{rotationFieldData, {4, 2*sizeof(Complex)}}.every({1, 2})};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneFieldData: second object view dimension is not contiguous\n"
+        "Trade::SceneFieldData: second mapping view dimension is not contiguous\n"
         "Trade::SceneFieldData: second field view dimension is not contiguous\n");
 }
 
@@ -1072,12 +1072,12 @@ void SceneDataTest::constructFieldArrayNonContiguous() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    UnsignedByte offsetObjectData[3];
+    UnsignedByte offsetMappingData[3];
     Int offsetFieldData[3*4];
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneFieldData data{sceneFieldCustom(34), Containers::arrayView(offsetObjectData), Containers::StridedArrayView2D<Int>{offsetFieldData, {3, 4}}.every({1, 2})};
+    SceneFieldData data{sceneFieldCustom(34), Containers::arrayView(offsetMappingData), Containers::StridedArrayView2D<Int>{offsetFieldData, {3, 4}}.every({1, 2})};
     CORRADE_COMPARE(out.str(), "Trade::SceneFieldData: second field view dimension is not contiguous\n");
 }
 
@@ -1086,46 +1086,46 @@ void SceneDataTest::constructFieldArrayNotAllowed() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    UnsignedShort rotationObjectData[3]{};
+    UnsignedShort rotationMappingData[3]{};
     Quaternion rotationFieldData[3];
-    Containers::ArrayView<UnsignedShort> rotationObjects = rotationObjectData;
-    Containers::ArrayView<Quaternion> rotationFields = rotationFieldData;
+    Containers::ArrayView<UnsignedShort> rotationMapping = rotationMappingData;
+    Containers::ArrayView<Quaternion> rotationField = rotationFieldData;
     Containers::StridedArrayView2D<Quaternion> rotationFields2D{rotationFieldData, {3, 3}, {0, sizeof(Quaternion)}};
-    auto rotationFields2DChar = Containers::arrayCast<2, const char>(rotationFields2D);
-    auto rotationObjectsChar = Containers::arrayCast<2, const char>(rotationObjects);
+    auto rotationMappingChar = Containers::arrayCast<2, const char>(rotationMapping);
+    auto rotationField2DChar = Containers::arrayCast<2, const char>(rotationFields2D);
 
     /* This is all fine */
     SceneFieldData{SceneField::Rotation,
-        SceneObjectType::UnsignedShort, rotationObjects,
-        SceneFieldType::Quaternion, rotationFields, 0};
+        SceneMappingType::UnsignedShort, rotationMapping,
+        SceneFieldType::Quaternion, rotationField, 0};
     SceneFieldData{SceneField::Rotation, 3,
-        SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort),
+        SceneMappingType::UnsignedShort, 0, sizeof(UnsignedShort),
         SceneFieldType::Quaternion, 0, sizeof(Quaternion), 0};
     SceneFieldData{sceneFieldCustom(37),
-        rotationObjects,
+        rotationMapping,
         rotationFields2D};
     SceneFieldData{sceneFieldCustom(37),
-        rotationObjectsChar,
-        SceneFieldType::Quaternion, rotationFields2DChar, 3};
+        rotationMappingChar,
+        SceneFieldType::Quaternion, rotationField2DChar, 3};
     SceneFieldData{sceneFieldCustom(37), 3,
-        SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort),
+        SceneMappingType::UnsignedShort, 0, sizeof(UnsignedShort),
         SceneFieldType::Quaternion, 0, sizeof(Quaternion), 3};
 
     /* This is not */
     std::ostringstream out;
     Error redirectError{&out};
     SceneFieldData{SceneField::Rotation,
-        SceneObjectType::UnsignedShort, rotationObjects,
-        SceneFieldType::Quaternion, rotationFields, 3};
+        SceneMappingType::UnsignedShort, rotationMapping,
+        SceneFieldType::Quaternion, rotationField, 3};
     SceneFieldData{SceneField::Rotation, 3,
-        SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort),
+        SceneMappingType::UnsignedShort, 0, sizeof(UnsignedShort),
         SceneFieldType::Quaternion, 0, sizeof(Quaternion), 3};
     SceneFieldData{SceneField::Rotation,
-        rotationObjects,
+        rotationMapping,
         rotationFields2D};
     SceneFieldData{SceneField::Rotation,
-        rotationObjectsChar,
-        SceneFieldType::Quaternion, rotationFields2DChar, 3};
+        rotationMappingChar,
+        SceneFieldType::Quaternion, rotationField2DChar, 3};
     CORRADE_COMPARE(out.str(),
         "Trade::SceneFieldData: Trade::SceneField::Rotation can't be an array field\n"
         "Trade::SceneFieldData: Trade::SceneField::Rotation can't be an array field\n"
@@ -1138,13 +1138,13 @@ void SceneDataTest::constructFieldArray2DWrongSize() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    char rotationObjectData[4*sizeof(UnsignedInt)];
+    char rotationMappingData[4*sizeof(UnsignedInt)];
     char rotationFieldData[4*sizeof(Complex)];
 
     std::ostringstream out;
     Error redirectError{&out};
     SceneFieldData{sceneFieldCustom(37),
-        Containers::StridedArrayView2D<char>{rotationObjectData, {4, sizeof(UnsignedInt)}}.every(2),
+        Containers::StridedArrayView2D<char>{rotationMappingData, {4, sizeof(UnsignedInt)}}.every(2),
         SceneFieldType::Int,
         Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}.every(2), 3};
     CORRADE_COMPARE(out.str(),
@@ -1156,21 +1156,21 @@ void SceneDataTest::constructFieldArray2DNonContiguous() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    char offsetObjectData[18*sizeof(UnsignedInt)];
+    char offsetMappingData[18*sizeof(UnsignedInt)];
     char offsetFieldData[18*sizeof(Int)];
 
     std::ostringstream out;
     Error redirectError{&out};
     SceneFieldData{sceneFieldCustom(37),
-        Containers::StridedArrayView2D<char>{offsetObjectData, {3, 2*sizeof(UnsignedInt)}}.every({1, 2}),
+        Containers::StridedArrayView2D<char>{offsetMappingData, {3, 2*sizeof(UnsignedInt)}}.every({1, 2}),
         SceneFieldType::Int,
         Containers::StridedArrayView2D<char>{offsetFieldData, {3, 3*sizeof(Int)}}, 3};
     SceneFieldData{sceneFieldCustom(37),
-        Containers::StridedArrayView2D<char>{offsetObjectData, {3, sizeof(UnsignedInt)}},
+        Containers::StridedArrayView2D<char>{offsetMappingData, {3, sizeof(UnsignedInt)}},
         SceneFieldType::Int,
         Containers::StridedArrayView2D<char>{offsetFieldData, {3, 6*sizeof(Int)}}.every({1, 2}), 3};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneFieldData: second object view dimension is not contiguous\n"
+        "Trade::SceneFieldData: second mapping view dimension is not contiguous\n"
         "Trade::SceneFieldData: second field view dimension is not contiguous\n");
 }
 
@@ -1181,70 +1181,70 @@ void SceneDataTest::construct() {
         Int parent;
     };
 
-    Containers::StridedArrayView1D<TransformParent> transformsParentFieldObjectData;
+    Containers::StridedArrayView1D<TransformParent> transformsParentFieldMappingData;
     Containers::StridedArrayView1D<UnsignedByte> meshFieldData;
     Containers::StridedArrayView1D<Vector2> radiusFieldData;
-    Containers::StridedArrayView1D<UnsignedShort> materialMeshRadiusObjectData;
+    Containers::StridedArrayView1D<UnsignedShort> materialMeshRadiusMappingData;
     Containers::ArrayTuple data{
-        {NoInit, 5, transformsParentFieldObjectData},
+        {NoInit, 5, transformsParentFieldMappingData},
         {NoInit, 2, meshFieldData},
         {NoInit, 2, radiusFieldData},
-        {NoInit, 2, materialMeshRadiusObjectData},
+        {NoInit, 2, materialMeshRadiusMappingData},
     };
-    transformsParentFieldObjectData[0].object = 4;
-    transformsParentFieldObjectData[0].transformation = Matrix4::translation(Vector3::xAxis(5.0f));
-    transformsParentFieldObjectData[0].parent = -1;
+    transformsParentFieldMappingData[0].object = 4;
+    transformsParentFieldMappingData[0].transformation = Matrix4::translation(Vector3::xAxis(5.0f));
+    transformsParentFieldMappingData[0].parent = -1;
 
-    transformsParentFieldObjectData[1].object = 2;
-    transformsParentFieldObjectData[1].transformation = Matrix4::translation(Vector3::yAxis(5.0f));
-    transformsParentFieldObjectData[1].parent = 0;
+    transformsParentFieldMappingData[1].object = 2;
+    transformsParentFieldMappingData[1].transformation = Matrix4::translation(Vector3::yAxis(5.0f));
+    transformsParentFieldMappingData[1].parent = 0;
 
-    transformsParentFieldObjectData[2].object = 3;
-    transformsParentFieldObjectData[2].transformation = Matrix4::translation(Vector3::zAxis(5.0f));
-    transformsParentFieldObjectData[2].parent = 2;
+    transformsParentFieldMappingData[2].object = 3;
+    transformsParentFieldMappingData[2].transformation = Matrix4::translation(Vector3::zAxis(5.0f));
+    transformsParentFieldMappingData[2].parent = 2;
 
-    transformsParentFieldObjectData[3].object = 0;
-    transformsParentFieldObjectData[3].transformation = Matrix4::translation(Vector3::yScale(5.0f));
-    transformsParentFieldObjectData[3].parent = 1;
+    transformsParentFieldMappingData[3].object = 0;
+    transformsParentFieldMappingData[3].transformation = Matrix4::translation(Vector3::yScale(5.0f));
+    transformsParentFieldMappingData[3].parent = 1;
 
-    transformsParentFieldObjectData[4].object = 1;
-    transformsParentFieldObjectData[4].transformation = Matrix4::translation(Vector3::zScale(5.0f));
-    transformsParentFieldObjectData[4].parent = -1;
+    transformsParentFieldMappingData[4].object = 1;
+    transformsParentFieldMappingData[4].transformation = Matrix4::translation(Vector3::zScale(5.0f));
+    transformsParentFieldMappingData[4].parent = -1;
 
     meshFieldData[0] = 5;
     radiusFieldData[0] = {37.5f, 1.5f};
-    materialMeshRadiusObjectData[0] = 2;
+    materialMeshRadiusMappingData[0] = 2;
 
     meshFieldData[1] = 7;
     radiusFieldData[1] = {22.5f, 0.5f};
-    materialMeshRadiusObjectData[1] = 6;
+    materialMeshRadiusMappingData[1] = 6;
 
     int importerState;
     SceneFieldData transformations{SceneField::Transformation,
-        transformsParentFieldObjectData.slice(&TransformParent::object),
-        transformsParentFieldObjectData.slice(&TransformParent::transformation)};
+        transformsParentFieldMappingData.slice(&TransformParent::object),
+        transformsParentFieldMappingData.slice(&TransformParent::transformation)};
     /* Offset-only */
     SceneFieldData parents{SceneField::Parent, 5,
-        SceneObjectType::UnsignedShort, offsetof(TransformParent, object), sizeof(TransformParent),
+        SceneMappingType::UnsignedShort, offsetof(TransformParent, object), sizeof(TransformParent),
         SceneFieldType::Int, offsetof(TransformParent, parent), sizeof(TransformParent)};
     SceneFieldData meshes{SceneField::Mesh,
-        materialMeshRadiusObjectData,
+        materialMeshRadiusMappingData,
         meshFieldData};
     /* Custom & array */
     SceneFieldData radiuses{sceneFieldCustom(37),
-        materialMeshRadiusObjectData,
+        materialMeshRadiusMappingData,
         Containers::arrayCast<2, Float>(radiusFieldData)};
-    SceneData scene{SceneObjectType::UnsignedShort, 8, std::move(data), {
+    SceneData scene{SceneMappingType::UnsignedShort, 8, std::move(data), {
         transformations, parents, meshes, radiuses
     }, &importerState};
 
     /* Basics */
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
     CORRADE_VERIFY(!scene.fieldData().empty());
-    CORRADE_COMPARE(static_cast<const void*>(scene.data()), transformsParentFieldObjectData.data());
-    CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), transformsParentFieldObjectData.data());
-    CORRADE_COMPARE(scene.objectCount(), 8);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(static_cast<const void*>(scene.data()), transformsParentFieldMappingData.data());
+    CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), transformsParentFieldMappingData.data());
+    CORRADE_COMPARE(scene.mappingBound(), 8);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldCount(), 4);
     CORRADE_COMPARE(scene.importerState(), &importerState);
 
@@ -1272,8 +1272,8 @@ void SceneDataTest::construct() {
     /* Raw field data access by ID */
     CORRADE_COMPARE(scene.fieldData(2).name(), SceneField::Mesh);
     CORRADE_COMPARE(scene.fieldData(2).size(), 2);
-    CORRADE_COMPARE(scene.fieldData(2).objectType(), SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(2).objectData())[1], 6);
+    CORRADE_COMPARE(scene.fieldData(2).mappingType(), SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(2).mappingData())[1], 6);
     CORRADE_COMPARE(Containers::arrayCast<const UnsignedByte>(scene.fieldData(2).fieldData())[1], 7);
     CORRADE_VERIFY(!scene.fieldData(2).isOffsetOnly());
     CORRADE_COMPARE(scene.fieldData(2).fieldType(), SceneFieldType::UnsignedByte);
@@ -1281,39 +1281,39 @@ void SceneDataTest::construct() {
     /* Offset-only */
     CORRADE_COMPARE(scene.fieldData(1).name(), SceneField::Parent);
     CORRADE_COMPARE(scene.fieldData(1).size(), 5);
-    CORRADE_COMPARE(scene.fieldData(1).objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldData(1).mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_VERIFY(!scene.fieldData(1).isOffsetOnly());
     CORRADE_COMPARE(scene.fieldData(1).fieldType(), SceneFieldType::Int);
     CORRADE_COMPARE(scene.fieldData(1).fieldArraySize(), 0);
-    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(1).objectData())[4], 1);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(1).mappingData())[4], 1);
     CORRADE_COMPARE(Containers::arrayCast<const Int>(scene.fieldData(1).fieldData())[4], -1);
     /* Array */
     CORRADE_COMPARE(scene.fieldData(3).name(), sceneFieldCustom(37));
     CORRADE_COMPARE(scene.fieldData(3).size(), 2);
-    CORRADE_COMPARE(scene.fieldData(3).objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldData(3).mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_VERIFY(!scene.fieldData(3).isOffsetOnly());
     CORRADE_COMPARE(scene.fieldData(3).fieldType(), SceneFieldType::Float);
     CORRADE_COMPARE(scene.fieldData(3).fieldArraySize(), 2);
-    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(3).objectData())[0], 2);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(3).mappingData())[0], 2);
     CORRADE_COMPARE(Containers::arrayCast<const Vector2>(scene.fieldData(3).fieldData())[0], (Vector2{37.5f, 1.5f}));
 
-    /* Typeless object access by ID with a cast later */
-    CORRADE_COMPARE(scene.objects(0).size()[0], 5);
-    CORRADE_COMPARE(scene.objects(1).size()[0], 5);
-    CORRADE_COMPARE(scene.objects(2).size()[0], 2);
-    CORRADE_COMPARE(scene.objects(3).size()[0], 2);
-    CORRADE_COMPARE(scene.mutableObjects(0).size()[0], 5);
-    CORRADE_COMPARE(scene.mutableObjects(1).size()[0], 5);
-    CORRADE_COMPARE(scene.mutableObjects(2).size()[0], 2);
-    CORRADE_COMPARE(scene.mutableObjects(3).size()[0], 2);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(0))[2]), 3);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(1))[4]), 1);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(2))[1]), 6);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(3))[0]), 2);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(0))[2]), 3);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(1))[4]), 1);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(2))[1]), 6);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(3))[0]), 2);
+    /* Typeless mapping access by ID with a cast later */
+    CORRADE_COMPARE(scene.mapping(0).size()[0], 5);
+    CORRADE_COMPARE(scene.mapping(1).size()[0], 5);
+    CORRADE_COMPARE(scene.mapping(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mapping(3).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableMapping(0).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableMapping(1).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableMapping(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableMapping(3).size()[0], 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(0))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(1))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(3))[0]), 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(0))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(1))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(3))[0]), 2);
 
     /* Typeless field access by ID with a cast later */
     CORRADE_COMPARE(scene.field(0).size()[0], 5);
@@ -1333,23 +1333,23 @@ void SceneDataTest::construct() {
     CORRADE_COMPARE((Containers::arrayCast<1, UnsignedByte>(scene.mutableField(2))[1]), 7);
     CORRADE_COMPARE((Containers::arrayCast<1, Vector2>(scene.mutableField(3))[0]), (Vector2{37.5f, 1.5f}));
 
-    /* Typed object access by ID */
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(0).size(), 5);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(1).size(), 5);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(2).size(), 2);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(3).size(), 2);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(0).size(), 5);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(1).size(), 5);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(2).size(), 2);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(3).size(), 2);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(0)[2], 3);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(1)[4], 1);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(2)[1], 6);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(3)[0], 2);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(0)[2], 3);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(1)[4], 1);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(2)[1], 6);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(3)[0], 2);
+    /* Typed mapping access by ID */
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(0).size(), 5);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(1).size(), 5);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(2).size(), 2);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(3).size(), 2);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(0).size(), 5);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(1).size(), 5);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(2).size(), 2);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(3).size(), 2);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(0)[2], 3);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(1)[4], 1);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(2)[1], 6);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(3)[0], 2);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(0)[2], 3);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(1)[4], 1);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(2)[1], 6);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(3)[0], 2);
 
     /* Typed field access by ID */
     CORRADE_COMPARE(scene.field<Matrix4>(0).size(), 5);
@@ -1387,23 +1387,23 @@ void SceneDataTest::construct() {
     CORRADE_COMPARE(scene.fieldArraySize(SceneField::Mesh), 0);
     CORRADE_COMPARE(scene.fieldArraySize(sceneFieldCustom(37)), 2);
 
-    /* Typeless object access by name with a cast later */
-    CORRADE_COMPARE(scene.objects(SceneField::Transformation).size()[0], 5);
-    CORRADE_COMPARE(scene.objects(SceneField::Parent).size()[0], 5);
-    CORRADE_COMPARE(scene.objects(2).size()[0], 2);
-    CORRADE_COMPARE(scene.objects(3).size()[0], 2);
-    CORRADE_COMPARE(scene.mutableObjects(SceneField::Transformation).size()[0], 5);
-    CORRADE_COMPARE(scene.mutableObjects(SceneField::Parent).size()[0], 5);
-    CORRADE_COMPARE(scene.mutableObjects(2).size()[0], 2);
-    CORRADE_COMPARE(scene.mutableObjects(3).size()[0], 2);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(SceneField::Transformation))[2]), 3);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(SceneField::Parent))[4]), 1);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(2))[1]), 6);
-    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(3))[0]), 2);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(SceneField::Transformation))[2]), 3);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(SceneField::Parent))[4]), 1);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(2))[1]), 6);
-    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(3))[0]), 2);
+    /* Typeless mapping access by name with a cast later */
+    CORRADE_COMPARE(scene.mapping(SceneField::Transformation).size()[0], 5);
+    CORRADE_COMPARE(scene.mapping(SceneField::Parent).size()[0], 5);
+    CORRADE_COMPARE(scene.mapping(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mapping(3).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableMapping(SceneField::Transformation).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableMapping(SceneField::Parent).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableMapping(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableMapping(3).size()[0], 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(SceneField::Transformation))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(SceneField::Parent))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.mapping(3))[0]), 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(SceneField::Transformation))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(SceneField::Parent))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableMapping(3))[0]), 2);
 
     /* Typeless field access by name with a cast later */
     CORRADE_COMPARE(scene.field(SceneField::Transformation).size()[0], 5);
@@ -1423,23 +1423,23 @@ void SceneDataTest::construct() {
     CORRADE_COMPARE((Containers::arrayCast<1, UnsignedByte>(scene.mutableField(SceneField::Mesh))[1]), 7);
     CORRADE_COMPARE((Containers::arrayCast<1, Vector2>(scene.mutableField(sceneFieldCustom(37)))[0]), (Vector2{37.5f, 1.5f}));
 
-    /* Typed object access by name */
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Transformation).size(), 5);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Parent).size(), 5);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Mesh).size(), 2);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(sceneFieldCustom(37)).size(), 2);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Transformation).size(), 5);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Parent).size(), 5);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Mesh).size(), 2);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(sceneFieldCustom(37)).size(), 2);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Transformation)[2], 3);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Parent)[4], 1);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Mesh)[1], 6);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(sceneFieldCustom(37))[0], 2);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Transformation)[2], 3);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Parent)[4], 1);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Mesh)[1], 6);
-    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(sceneFieldCustom(37))[0], 2);
+    /* Typed mapping access by name */
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(SceneField::Transformation).size(), 5);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(SceneField::Parent).size(), 5);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(SceneField::Mesh).size(), 2);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(sceneFieldCustom(37)).size(), 2);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(SceneField::Transformation).size(), 5);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(SceneField::Parent).size(), 5);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(SceneField::Mesh).size(), 2);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(sceneFieldCustom(37)).size(), 2);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(SceneField::Transformation)[2], 3);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(SceneField::Parent)[4], 1);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(SceneField::Mesh)[1], 6);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(sceneFieldCustom(37))[0], 2);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(SceneField::Transformation)[2], 3);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(SceneField::Parent)[4], 1);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(SceneField::Mesh)[1], 6);
+    CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(sceneFieldCustom(37))[0], 2);
 
     /* Typed field access by name */
     CORRADE_COMPARE(scene.field<Matrix4>(SceneField::Transformation).size(), 5);
@@ -1466,14 +1466,14 @@ void SceneDataTest::construct() {
 
 void SceneDataTest::constructZeroFields() {
     int importerState;
-    SceneData scene{SceneObjectType::UnsignedShort, 37563, nullptr, {}, &importerState};
+    SceneData scene{SceneMappingType::UnsignedShort, 37563, nullptr, {}, &importerState};
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
     CORRADE_VERIFY(scene.fieldData().empty());
     CORRADE_COMPARE(static_cast<const void*>(scene.data()), nullptr);
     CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), nullptr);
     CORRADE_COMPARE(scene.importerState(), &importerState);
-    CORRADE_COMPARE(scene.objectCount(), 37563);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.mappingBound(), 37563);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldCount(), 0);
     CORRADE_VERIFY(!scene.is2D());
     CORRADE_VERIFY(!scene.is3D());
@@ -1481,16 +1481,16 @@ void SceneDataTest::constructZeroFields() {
 
 void SceneDataTest::constructZeroObjects() {
     int importerState;
-    SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials}, &importerState};
+    SceneFieldData meshes{SceneField::Mesh, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
+    SceneData scene{SceneMappingType::UnsignedInt, 0, nullptr, {meshes, materials}, &importerState};
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
     CORRADE_VERIFY(!scene.fieldData().empty());
     CORRADE_COMPARE(static_cast<const void*>(scene.data()), nullptr);
     CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), nullptr);
     CORRADE_COMPARE(scene.importerState(), &importerState);
-    CORRADE_COMPARE(scene.objectCount(), 0);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
+    CORRADE_COMPARE(scene.mappingBound(), 0);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedInt);
     CORRADE_COMPARE(scene.fieldCount(), 2);
 
     /* Field property access by name */
@@ -1498,8 +1498,8 @@ void SceneDataTest::constructZeroObjects() {
     CORRADE_COMPARE(scene.fieldType(SceneField::MeshMaterial), SceneFieldType::Int);
     CORRADE_COMPARE(scene.fieldSize(SceneField::Mesh), 0);
     CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 0);
-    CORRADE_COMPARE(scene.objects(SceneField::Mesh).data(), nullptr);
-    CORRADE_COMPARE(scene.objects(SceneField::MeshMaterial).data(), nullptr);
+    CORRADE_COMPARE(scene.mapping(SceneField::Mesh).data(), nullptr);
+    CORRADE_COMPARE(scene.mapping(SceneField::MeshMaterial).data(), nullptr);
 }
 
 void SceneDataTest::constructSpecialStrides() {
@@ -1516,31 +1516,31 @@ void SceneDataTest::constructSpecialStrides() {
     nonBroadcastedData[2] = 3;
     nonBroadcastedData[3] = 4;
 
-    SceneFieldData broadcastedObjects{sceneFieldCustom(38),
+    SceneFieldData broadcastedMapping{sceneFieldCustom(38),
         broadcastedData.broadcasted<0>(4), nonBroadcastedData};
-    SceneFieldData broadcastedFields{sceneFieldCustom(39),
+    SceneFieldData broadcastedField{sceneFieldCustom(39),
         nonBroadcastedData, broadcastedData.broadcasted<0>(4)};
-    SceneFieldData flippedFields{sceneFieldCustom(40),
+    SceneFieldData flippedField{sceneFieldCustom(40),
         nonBroadcastedData.flipped<0>(), nonBroadcastedData.flipped<0>()};
-    SceneData scene{SceneObjectType::UnsignedShort, 8, std::move(data), {
-        broadcastedObjects, broadcastedFields, flippedFields
+    SceneData scene{SceneMappingType::UnsignedShort, 8, std::move(data), {
+        broadcastedMapping, broadcastedField, flippedField
     }};
 
-    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(0),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedShort>(0),
         Containers::arrayView<UnsignedShort>({15, 15, 15, 15}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedShort>(0),
         Containers::arrayView<UnsignedShort>({1, 2, 3, 4}),
         TestSuite::Compare::Container);
 
-    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(1),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedShort>(1),
         Containers::arrayView<UnsignedShort>({1, 2, 3, 4}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedShort>(1),
         Containers::arrayView<UnsignedShort>({15, 15, 15, 15}),
         TestSuite::Compare::Container);
 
-    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(2),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedShort>(2),
         Containers::arrayView<UnsignedShort>({4, 3, 2, 1}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedShort>(2),
@@ -1565,21 +1565,21 @@ void SceneDataTest::constructNotOwned() {
     SceneFieldData mesh{SceneField::Mesh,
         Containers::stridedArrayView(data).slice(&Data::object),
         Containers::stridedArrayView(data).slice(&Data::mesh)};
-    SceneData scene{SceneObjectType::UnsignedShort, 7, instanceData.dataFlags, Containers::arrayView(data), {mesh}, &importerState};
+    SceneData scene{SceneMappingType::UnsignedShort, 7, instanceData.dataFlags, Containers::arrayView(data), {mesh}, &importerState};
 
     CORRADE_COMPARE(scene.dataFlags(), instanceData.dataFlags);
     CORRADE_COMPARE(static_cast<const void*>(scene.data()), +data);
     if(instanceData.dataFlags & DataFlag::Mutable)
         CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), static_cast<void*>(data));
-    CORRADE_COMPARE(scene.objectCount(), 7);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.mappingBound(), 7);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldCount(), 1);
     CORRADE_COMPARE(scene.importerState(), &importerState);
 
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(0).size(), 3);
-    CORRADE_COMPARE(scene.objects<UnsignedShort>(0)[2], 2);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(0).size(), 3);
+    CORRADE_COMPARE(scene.mapping<UnsignedShort>(0)[2], 2);
     if(instanceData.dataFlags & DataFlag::Mutable)
-        CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(0)[2], 2);
+        CORRADE_COMPARE(scene.mutableMapping<UnsignedShort>(0)[2], 2);
 
     CORRADE_COMPARE(scene.field<UnsignedByte>(0).size(), 3);
     CORRADE_COMPARE(scene.field<UnsignedByte>(0)[2], 0);
@@ -1599,18 +1599,18 @@ void SceneDataTest::constructDeprecated() {
         data.is3D ? std::vector<UnsignedInt>{5, 17, 36, 22} : std::vector<UnsignedInt>{},
         &a};
     CORRADE_IGNORE_DEPRECATED_POP
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedInt);
     if(data.is2D || data.is3D)
-        CORRADE_COMPARE(scene.objectCount(), 37);
+        CORRADE_COMPARE(scene.mappingBound(), 37);
     else
-        CORRADE_COMPARE(scene.objectCount(), 0);
+        CORRADE_COMPARE(scene.mappingBound(), 0);
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Mutable|DataFlag::Owned);
     CORRADE_COMPARE(scene.importerState(), &a);
     CORRADE_COMPARE(scene.fieldCount(), 1);
     CORRADE_COMPARE(scene.fieldName(0), SceneField::Parent);
     CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::Int);
     if(data.is2D || data.is3D) {
-        CORRADE_COMPARE_AS(scene.objects<UnsignedInt>(0),
+        CORRADE_COMPARE_AS(scene.mapping<UnsignedInt>(0),
             Containers::arrayView<UnsignedInt>({5, 17, 36, 22}),
             TestSuite::Compare::Container);
         CORRADE_COMPARE_AS(scene.field<Int>(0),
@@ -1649,13 +1649,13 @@ void SceneDataTest::constructDuplicateField() {
 
     /* Builtin fields are checked using a bitfield, as they have monotonic
        numbering */
-    SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
-    SceneFieldData meshesAgain{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData meshes{SceneField::Mesh, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
+    SceneFieldData meshesAgain{SceneField::Mesh, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials, meshesAgain}};
+    SceneData scene{SceneMappingType::UnsignedInt, 0, nullptr, {meshes, materials, meshesAgain}};
     CORRADE_COMPARE(out.str(), "Trade::SceneData: duplicate field Trade::SceneField::Mesh\n");
 }
 
@@ -1666,31 +1666,31 @@ void SceneDataTest::constructDuplicateCustomField() {
 
     /* These are checked in an O(n^2) way, separately from builtin fields.
        Can't use a bitfield since the field index can be anything. */
-    SceneFieldData customA{sceneFieldCustom(37), SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData customB{sceneFieldCustom(1038576154), SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
-    SceneFieldData customAAgain{sceneFieldCustom(37), SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData customA{sceneFieldCustom(37), SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData customB{sceneFieldCustom(1038576154), SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData customAAgain{sceneFieldCustom(37), SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {customA, customB, customAAgain}};
+    SceneData scene{SceneMappingType::UnsignedInt, 0, nullptr, {customA, customB, customAAgain}};
     CORRADE_COMPARE(out.str(), "Trade::SceneData: duplicate field Trade::SceneField::Custom(37)\n");
 }
 
-void SceneDataTest::constructInconsistentObjectType() {
+void SceneDataTest::constructInconsistentMappingType() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedShort, nullptr, SceneFieldType::Int, nullptr};
+    SceneFieldData meshes{SceneField::Mesh, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneMappingType::UnsignedShort, nullptr, SceneFieldType::Int, nullptr};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials}};
-    CORRADE_COMPARE(out.str(), "Trade::SceneData: inconsistent object type, got Trade::SceneObjectType::UnsignedShort for field 1 but expected Trade::SceneObjectType::UnsignedInt\n");
+    SceneData scene{SceneMappingType::UnsignedInt, 0, nullptr, {meshes, materials}};
+    CORRADE_COMPARE(out.str(), "Trade::SceneData: inconsistent mapping type, got Trade::SceneMappingType::UnsignedShort for field 1 but expected Trade::SceneMappingType::UnsignedInt\n");
 }
 
-void SceneDataTest::constructObjectDataNotContained() {
+void SceneDataTest::constructMappingDataNotContained() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -1703,35 +1703,35 @@ void SceneDataTest::constructObjectDataNotContained() {
     std::ostringstream out;
     Error redirectError{&out};
     /* First a "slightly off" view that exceeds the original by one byte */
-    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+    SceneData{SceneMappingType::UnsignedShort, 5, {}, data, {
         SceneFieldData{SceneField::Mesh, dataSlightlyOut, dataIn}
     }};
     /* Second a view that's in a completely different location */
-    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+    SceneData{SceneMappingType::UnsignedShort, 5, {}, data, {
         SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataOut, dataIn}
     }};
     /* Verify the owning constructor does the checks as well */
-    SceneData{SceneObjectType::UnsignedShort, 5, std::move(data), {
+    SceneData{SceneMappingType::UnsignedShort, 5, std::move(data), {
         SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataOut, dataIn}
     }};
     /* And if we have no data at all, it doesn't try to dereference them but
        still checks properly */
-    SceneData{SceneObjectType::UnsignedShort, 5, nullptr, {
+    SceneData{SceneMappingType::UnsignedShort, 5, nullptr, {
         SceneFieldData{SceneField::Mesh, dataOut, dataIn}
     }};
     /* Finally, offset-only fields with a different message */
-    SceneData{SceneObjectType::UnsignedByte, 6, Containers::Array<char>{24}, {
-        SceneFieldData{SceneField::Mesh, 6, SceneObjectType::UnsignedByte, 4, 4, SceneFieldType::UnsignedByte, 0, 4}
+    SceneData{SceneMappingType::UnsignedByte, 6, Containers::Array<char>{24}, {
+        SceneFieldData{SceneField::Mesh, 6, SceneMappingType::UnsignedByte, 4, 4, SceneFieldType::UnsignedByte, 0, 4}
     }};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData: object data [0xbaddaa:0xbaddb4] of field 0 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
-        "Trade::SceneData: object data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
-        "Trade::SceneData: object data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
-        "Trade::SceneData: object data [0xdead:0xdeb7] of field 0 are not contained in passed data array [0x0:0x0]\n"
+        "Trade::SceneData: mapping data [0xbaddaa:0xbaddb4] of field 0 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: mapping data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: mapping data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: mapping data [0xdead:0xdeb7] of field 0 are not contained in passed data array [0x0:0x0]\n"
 
-        "Trade::SceneData: offset-only object data of field 0 span 25 bytes but passed data array has only 24\n");
+        "Trade::SceneData: offset-only mapping data of field 0 span 25 bytes but passed data array has only 24\n");
 }
 
 void SceneDataTest::constructFieldDataNotContained() {
@@ -1739,7 +1739,7 @@ void SceneDataTest::constructFieldDataNotContained() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    /* Mostly the same as constructObjectDataNotContained() with object and
+    /* Mostly the same as constructMappingDataNotContained() with mapping and
        field views swapped, and added checks for array fields */
 
     Containers::Array<char> data{reinterpret_cast<char*>(0xbadda9), 10, [](char*, std::size_t){}};
@@ -1750,34 +1750,34 @@ void SceneDataTest::constructFieldDataNotContained() {
     std::ostringstream out;
     Error redirectError{&out};
     /* First a "slightly off" view that exceeds the original by one byte */
-    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+    SceneData{SceneMappingType::UnsignedShort, 5, {}, data, {
         SceneFieldData{SceneField::Mesh, dataIn, dataSlightlyOut}
     }};
     /* Second a view that's in a completely different location */
-    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+    SceneData{SceneMappingType::UnsignedShort, 5, {}, data, {
         SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataIn, dataOut}
     }};
     /* Verify array size is taken into account as well. If not, the data would
        span only 7 bytes out of 10 (instead of 12), which is fine. */
-    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+    SceneData{SceneMappingType::UnsignedShort, 5, {}, data, {
         SceneFieldData{sceneFieldCustom(37), dataIn.prefix(2), Containers::StridedArrayView2D<UnsignedByte>{Containers::ArrayView<UnsignedByte>{reinterpret_cast<UnsignedByte*>(0xbadda9), 12}, {2, 6}}}
     }};
     /* Verify the owning constructor does the checks as well */
-    SceneData{SceneObjectType::UnsignedShort, 5, std::move(data), {
+    SceneData{SceneMappingType::UnsignedShort, 5, std::move(data), {
         SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataIn, dataOut}
     }};
-    /* Not checking for nullptr data, since that got checked for object view
+    /* Not checking for nullptr data, since that got checked for mapping view
        already and there's no way to trigger it for fields */
     /* Finally, offset-only fields with a different message */
-    SceneData{SceneObjectType::UnsignedShort, 6, Containers::Array<char>{24}, {
-        SceneFieldData{SceneField::Mesh, 6, SceneObjectType::UnsignedShort, 0, 4, SceneFieldType::UnsignedByte, 4, 4}
+    SceneData{SceneMappingType::UnsignedShort, 6, Containers::Array<char>{24}, {
+        SceneFieldData{SceneField::Mesh, 6, SceneMappingType::UnsignedShort, 0, 4, SceneFieldType::UnsignedByte, 4, 4}
     }};
     /* This again spans 21 bytes if array size isn't taken into account, and 25
        if it is */
-    SceneData{SceneObjectType::UnsignedShort, 5, Containers::Array<char>{24}, {
-        SceneFieldData{sceneFieldCustom(37), 5, SceneObjectType::UnsignedShort, 0, 5, SceneFieldType::UnsignedByte, 0, 5, 5}
+    SceneData{SceneMappingType::UnsignedShort, 5, Containers::Array<char>{24}, {
+        SceneFieldData{sceneFieldCustom(37), 5, SceneMappingType::UnsignedShort, 0, 5, SceneFieldType::UnsignedByte, 0, 5, 5}
     }};
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData: field data [0xbaddaa:0xbaddb4] of field 0 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
@@ -1789,25 +1789,25 @@ void SceneDataTest::constructFieldDataNotContained() {
         "Trade::SceneData: offset-only field data of field 0 span 25 bytes but passed data array has only 24\n");
 }
 
-void SceneDataTest::constructObjectTypeTooSmall() {
+void SceneDataTest::constructMappingTypeTooSmall() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
     /* This is fine */
-    SceneData{SceneObjectType::UnsignedByte, 0xff, nullptr, {}};
-    SceneData{SceneObjectType::UnsignedShort, 0xffff, nullptr, {}};
-    SceneData{SceneObjectType::UnsignedInt, 0xffffffffu, nullptr, {}};
+    SceneData{SceneMappingType::UnsignedByte, 0xff, nullptr, {}};
+    SceneData{SceneMappingType::UnsignedShort, 0xffff, nullptr, {}};
+    SceneData{SceneMappingType::UnsignedInt, 0xffffffffu, nullptr, {}};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData{SceneObjectType::UnsignedByte, 0x100, nullptr, {}};
-    SceneData{SceneObjectType::UnsignedShort, 0x10000, nullptr, {}};
-    SceneData{SceneObjectType::UnsignedInt, 0x100000000ull, nullptr, {}};
+    SceneData{SceneMappingType::UnsignedByte, 0x100, nullptr, {}};
+    SceneData{SceneMappingType::UnsignedShort, 0x10000, nullptr, {}};
+    SceneData{SceneMappingType::UnsignedInt, 0x100000000ull, nullptr, {}};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData: Trade::SceneObjectType::UnsignedByte is too small for 256 objects\n"
-        "Trade::SceneData: Trade::SceneObjectType::UnsignedShort is too small for 65536 objects\n"
-        "Trade::SceneData: Trade::SceneObjectType::UnsignedInt is too small for 4294967296 objects\n");
+        "Trade::SceneData: Trade::SceneMappingType::UnsignedByte is too small for 256 objects\n"
+        "Trade::SceneData: Trade::SceneMappingType::UnsignedShort is too small for 65536 objects\n"
+        "Trade::SceneData: Trade::SceneMappingType::UnsignedInt is too small for 4294967296 objects\n");
 }
 
 void SceneDataTest::constructNotOwnedFlagOwned() {
@@ -1819,7 +1819,7 @@ void SceneDataTest::constructNotOwnedFlagOwned() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData{SceneObjectType::UnsignedByte, 5, DataFlag::Owned, Containers::arrayView(data), {}};
+    SceneData{SceneMappingType::UnsignedByte, 5, DataFlag::Owned, Containers::arrayView(data), {}};
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData: can't construct with non-owned data but Trade::DataFlag::Owned\n");
 }
@@ -1832,41 +1832,41 @@ void SceneDataTest::constructMismatchedTRSViews() {
     Containers::ArrayView<const char> data{reinterpret_cast<char*>(0xcafe0000),
         /* Three entries, each having a 2D TRS and 3 object IDs */
         3*(24 + 12)};
-    Containers::ArrayView<const UnsignedInt> translationObjectData{
+    Containers::ArrayView<const UnsignedInt> translationMappingData{
         reinterpret_cast<const UnsignedInt*>(data.data()), 3};
     Containers::ArrayView<const Vector2> translationFieldData{
         reinterpret_cast<const Vector2*>(data.data() + 0x0c), 3};
-    Containers::ArrayView<const UnsignedInt> rotationObjectData{
+    Containers::ArrayView<const UnsignedInt> rotationMappingData{
         reinterpret_cast<const UnsignedInt*>(data.data() + 0x24), 3};
     Containers::ArrayView<const Complex> rotationFieldData{
         reinterpret_cast<const Complex*>(data.data() + 0x30), 3};
-    Containers::ArrayView<const UnsignedInt> scalingObjectData{
+    Containers::ArrayView<const UnsignedInt> scalingMappingData{
         reinterpret_cast<const UnsignedInt*>(data.data() + 0x48), 3};
     Containers::ArrayView<const Vector2> scalingFieldData{
         reinterpret_cast<const Vector2*>(data.data() + 0x54), 3};
 
-    SceneFieldData translations{SceneField::Translation, translationObjectData, translationFieldData};
-    SceneFieldData rotationsDifferent{SceneField::Rotation, rotationObjectData, rotationFieldData};
-    SceneFieldData scalingsDifferent{SceneField::Scaling, scalingObjectData, scalingFieldData};
-    SceneFieldData rotationsSameButLess{SceneField::Rotation, translationObjectData.except(1), rotationFieldData.except(1)};
-    SceneFieldData scalingsSameButLess{SceneField::Scaling, translationObjectData.except(2), scalingFieldData.except(2)};
+    SceneFieldData translations{SceneField::Translation, translationMappingData, translationFieldData};
+    SceneFieldData rotationsDifferent{SceneField::Rotation, rotationMappingData, rotationFieldData};
+    SceneFieldData scalingsDifferent{SceneField::Scaling, scalingMappingData, scalingFieldData};
+    SceneFieldData rotationsSameButLess{SceneField::Rotation, translationMappingData.except(1), rotationFieldData.except(1)};
+    SceneFieldData scalingsSameButLess{SceneField::Scaling, translationMappingData.except(2), scalingFieldData.except(2)};
 
     /* Test that all pairs get checked */
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, rotationsDifferent}};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, scalingsDifferent}};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {rotationsDifferent, scalingsDifferent}};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, rotationsSameButLess}};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, scalingsSameButLess}};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {rotationsSameButLess, scalingsSameButLess}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {translations, rotationsDifferent}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {translations, scalingsDifferent}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {rotationsDifferent, scalingsDifferent}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {translations, rotationsSameButLess}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {translations, scalingsSameButLess}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {rotationsSameButLess, scalingsSameButLess}};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData: Trade::SceneField::Rotation object data [0xcafe0024:0xcafe0030] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
-        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0048:0xcafe0054] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
-        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0048:0xcafe0054] is different from Trade::SceneField::Rotation object data [0xcafe0024:0xcafe0030]\n"
-        "Trade::SceneData: Trade::SceneField::Rotation object data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
-        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
-        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Rotation object data [0xcafe0000:0xcafe0008]\n");
+        "Trade::SceneData: Trade::SceneField::Rotation mapping data [0xcafe0024:0xcafe0030] is different from Trade::SceneField::Translation mapping data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling mapping data [0xcafe0048:0xcafe0054] is different from Trade::SceneField::Translation mapping data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling mapping data [0xcafe0048:0xcafe0054] is different from Trade::SceneField::Rotation mapping data [0xcafe0024:0xcafe0030]\n"
+        "Trade::SceneData: Trade::SceneField::Rotation mapping data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Translation mapping data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling mapping data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Translation mapping data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling mapping data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Rotation mapping data [0xcafe0000:0xcafe0008]\n");
 }
 
 template<class> struct NameTraits;
@@ -1918,49 +1918,49 @@ template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneFieldData transformationMatrices2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3<T>>::type(), nullptr};
-    SceneFieldData transformationRectangularMatrices2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3x2<T>>::type(), nullptr};
-    SceneFieldData transformations2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualComplex<T>>::type(), nullptr};
-    SceneFieldData transformationMatrices3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4<T>>::type(), nullptr};
-    SceneFieldData transformationRectangularMatrices3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4x3<T>>::type(), nullptr};
-    SceneFieldData transformations3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualQuaternion<T>>::type(), nullptr};
-    SceneFieldData translations2D{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
-    SceneFieldData translations3D{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
-    SceneFieldData rotations2D{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Complex<T>>::type(), nullptr};
-    SceneFieldData rotations3D{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Quaternion<T>>::type(), nullptr};
-    SceneFieldData scalings2D{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
-    SceneFieldData scalings3D{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
+    SceneFieldData transformationMatrices2D{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3<T>>::type(), nullptr};
+    SceneFieldData transformationRectangularMatrices2D{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3x2<T>>::type(), nullptr};
+    SceneFieldData transformations2D{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualComplex<T>>::type(), nullptr};
+    SceneFieldData transformationMatrices3D{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4<T>>::type(), nullptr};
+    SceneFieldData transformationRectangularMatrices3D{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4x3<T>>::type(), nullptr};
+    SceneFieldData transformations3D{SceneField::Transformation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualQuaternion<T>>::type(), nullptr};
+    SceneFieldData translations2D{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
+    SceneFieldData translations3D{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
+    SceneFieldData rotations2D{SceneField::Rotation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Complex<T>>::type(), nullptr};
+    SceneFieldData rotations3D{SceneField::Rotation, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Quaternion<T>>::type(), nullptr};
+    SceneFieldData scalings2D{SceneField::Scaling, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
+    SceneFieldData scalings3D{SceneField::Scaling, SceneMappingType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
 
     /* Test that all pairs get checked */
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, translations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, rotations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, scalings3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, translations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, rotations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, scalings3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationMatrices2D, translations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationMatrices2D, rotations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationMatrices2D, scalings3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, translations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, rotations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, scalings3D}};
 
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, translations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, rotations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, scalings3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations2D, rotations3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations2D, scalings3D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {rotations2D, scalings3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformations2D, translations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformations2D, rotations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformations2D, scalings3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {translations2D, rotations3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {translations2D, scalings3D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {rotations2D, scalings3D}};
 
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, translations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, rotations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, scalings2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, translations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, rotations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, scalings2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationMatrices3D, translations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationMatrices3D, rotations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationMatrices3D, scalings2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, translations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, rotations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, scalings2D}};
 
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, translations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, rotations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, scalings2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations3D, rotations2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations3D, scalings2D}};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {rotations3D, scalings2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformations3D, translations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformations3D, rotations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {transformations3D, scalings2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {translations3D, rotations2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {translations3D, scalings2D}};
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {rotations3D, scalings2D}};
     CORRADE_COMPARE(out.str(), Utility::formatString(
         "Trade::SceneData: expected a 2D translation field but got Trade::SceneFieldType::{0}\n"
         "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
@@ -2003,26 +2003,26 @@ void SceneDataTest::constructMismatchedMeshMaterialView() {
     Containers::ArrayView<const char> data{reinterpret_cast<char*>(0xcafe0000),
         /* Three entries, each having mesh/material ID and 2 object IDs */
         3*(8 + 8)};
-    Containers::ArrayView<const UnsignedInt> meshObjectData{
+    Containers::ArrayView<const UnsignedInt> meshMappingData{
         reinterpret_cast<const UnsignedInt*>(data.data()), 3};
     Containers::ArrayView<const UnsignedInt> meshFieldData{
         reinterpret_cast<const UnsignedInt*>(data.data() + 0x0c), 3};
-    Containers::ArrayView<const UnsignedInt> meshMaterialObjectData{
+    Containers::ArrayView<const UnsignedInt> meshMaterialMappingData{
         reinterpret_cast<const UnsignedInt*>(data.data() + 0x18), 3};
     Containers::ArrayView<const Int> meshMaterialFieldData{
         reinterpret_cast<const Int*>(data.data() + 0x24), 3};
 
-    SceneFieldData meshes{SceneField::Mesh, meshObjectData, meshFieldData};
-    SceneFieldData meshMaterialsDifferent{SceneField::MeshMaterial, meshMaterialObjectData, meshMaterialFieldData};
-    SceneFieldData meshMaterialsSameButLess{SceneField::MeshMaterial, meshObjectData.except(1), meshMaterialFieldData.except(1)};
+    SceneFieldData meshes{SceneField::Mesh, meshMappingData, meshFieldData};
+    SceneFieldData meshMaterialsDifferent{SceneField::MeshMaterial, meshMaterialMappingData, meshMaterialFieldData};
+    SceneFieldData meshMaterialsSameButLess{SceneField::MeshMaterial, meshMappingData.except(1), meshMaterialFieldData.except(1)};
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {meshes, meshMaterialsDifferent}};
-    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {meshes, meshMaterialsSameButLess}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {meshes, meshMaterialsDifferent}};
+    SceneData{SceneMappingType::UnsignedInt, 3, {}, data, {meshes, meshMaterialsSameButLess}};
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData: Trade::SceneField::MeshMaterial object data [0xcafe0018:0xcafe0024] is different from Trade::SceneField::Mesh object data [0xcafe0000:0xcafe000c]\n"
-        "Trade::SceneData: Trade::SceneField::MeshMaterial object data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Mesh object data [0xcafe0000:0xcafe000c]\n");
+        "Trade::SceneData: Trade::SceneField::MeshMaterial mapping data [0xcafe0018:0xcafe0024] is different from Trade::SceneField::Mesh mapping data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::MeshMaterial mapping data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Mesh mapping data [0xcafe0000:0xcafe000c]\n");
 }
 
 void SceneDataTest::constructAmbiguousSkinDimensions() {
@@ -2032,8 +2032,8 @@ void SceneDataTest::constructAmbiguousSkinDimensions() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Skin, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr}
+    SceneData{SceneMappingType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Skin, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr}
     }};
     CORRADE_COMPARE(out.str(), "Trade::SceneData: a skin field requires some transformation field to be present in order to disambiguate between 2D and 3D\n");
 }
@@ -2057,12 +2057,12 @@ void SceneDataTest::constructMove() {
 
     int importerState;
     SceneFieldData meshes{SceneField::Mesh, stridedArrayView(meshData).slice(&Mesh::object), stridedArrayView(meshData).slice(&Mesh::mesh)};
-    SceneData a{SceneObjectType::UnsignedShort, 15, std::move(data), {meshes}, &importerState};
+    SceneData a{SceneMappingType::UnsignedShort, 15, std::move(data), {meshes}, &importerState};
 
     SceneData b{std::move(a)};
     CORRADE_COMPARE(b.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(b.objectCount(), 15);
-    CORRADE_COMPARE(b.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(b.mappingBound(), 15);
+    CORRADE_COMPARE(b.mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_COMPARE(b.fieldCount(), 1);
     CORRADE_COMPARE(b.importerState(), &importerState);
     CORRADE_COMPARE(static_cast<const void*>(b.data()), meshData.data());
@@ -2070,14 +2070,14 @@ void SceneDataTest::constructMove() {
     CORRADE_COMPARE(b.fieldType(0), SceneFieldType::UnsignedInt);
     CORRADE_COMPARE(b.fieldSize(0), 3);
     CORRADE_COMPARE(b.fieldArraySize(0), 0);
-    CORRADE_COMPARE(b.objects<UnsignedShort>(0)[2], 122);
+    CORRADE_COMPARE(b.mapping<UnsignedShort>(0)[2], 122);
     CORRADE_COMPARE(b.field<UnsignedInt>(0)[2], 2);
 
-    SceneData c{SceneObjectType::UnsignedByte, 76, nullptr, {}};
+    SceneData c{SceneMappingType::UnsignedByte, 76, nullptr, {}};
     c = std::move(b);
     CORRADE_COMPARE(c.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(c.objectCount(), 15);
-    CORRADE_COMPARE(c.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(c.mappingBound(), 15);
+    CORRADE_COMPARE(c.mappingType(), SceneMappingType::UnsignedShort);
     CORRADE_COMPARE(c.fieldCount(), 1);
     CORRADE_COMPARE(c.importerState(), &importerState);
     CORRADE_COMPARE(static_cast<const void*>(c.data()), meshData.data());
@@ -2085,7 +2085,7 @@ void SceneDataTest::constructMove() {
     CORRADE_COMPARE(c.fieldType(0), SceneFieldType::UnsignedInt);
     CORRADE_COMPARE(c.fieldSize(0), 3);
     CORRADE_COMPARE(c.fieldArraySize(0), 0);
-    CORRADE_COMPARE(c.objects<UnsignedShort>(0)[2], 122);
+    CORRADE_COMPARE(c.mapping<UnsignedShort>(0)[2], 122);
     CORRADE_COMPARE(c.field<UnsignedInt>(0)[2], 2);
 
     CORRADE_VERIFY(std::is_nothrow_move_constructible<SceneData>::value);
@@ -2093,9 +2093,9 @@ void SceneDataTest::constructMove() {
 }
 
 void SceneDataTest::findFieldId() {
-    SceneData scene{SceneObjectType::UnsignedInt, 0, {}, nullptr, {
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
-        SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedByte, nullptr}
+    SceneData scene{SceneMappingType::UnsignedInt, 0, {}, nullptr, {
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedByte, nullptr}
     }};
 
     CORRADE_COMPARE(scene.findFieldId(SceneField::Parent), 0);
@@ -2127,9 +2127,9 @@ template<class T> void SceneDataTest::findFieldObjectOffset() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{Implementation::sceneObjectTypeFor<T>(), 7, {}, fields, {
+    SceneData scene{Implementation::sceneMappingTypeFor<T>(), 7, {}, fields, {
         /* Test also with a completely empty field */
-        SceneFieldData{SceneField::Parent, Implementation::sceneObjectTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, Implementation::sceneMappingTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
@@ -2184,7 +2184,7 @@ void SceneDataTest::findFieldObjectOffsetInvalidOffset() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
@@ -2218,9 +2218,9 @@ void SceneDataTest::fieldObjectOffsetNotFound() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         /* Test also with a completely empty field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
@@ -2237,7 +2237,7 @@ void SceneDataTest::fieldObjectOffsetNotFound() {
         "Trade::SceneData::fieldObjectOffset(): object 1 not found in field Trade::SceneField::Mesh starting at offset 2\n");
 }
 
-template<class T> void SceneDataTest::objectsAsArrayByIndex() {
+template<class T> void SceneDataTest::mappingAsArrayByIndex() {
     setTestCaseTemplateName(NameTraits<T>::name());
 
     struct Field {
@@ -2251,18 +2251,18 @@ template<class T> void SceneDataTest::objectsAsArrayByIndex() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{Implementation::sceneObjectTypeFor<T>(), 50, {}, fields, {
+    SceneData scene{Implementation::sceneMappingTypeFor<T>(), 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, Implementation::sceneObjectTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, Implementation::sceneMappingTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
-    CORRADE_COMPARE_AS(scene.objectsAsArray(1),
+    CORRADE_COMPARE_AS(scene.mappingAsArray(1),
         Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-template<class T> void SceneDataTest::objectsAsArrayByName() {
+template<class T> void SceneDataTest::mappingAsArrayByName() {
     setTestCaseTemplateName(NameTraits<T>::name());
 
     struct Field {
@@ -2276,18 +2276,18 @@ template<class T> void SceneDataTest::objectsAsArrayByName() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{Implementation::sceneObjectTypeFor<T>(), 50, {}, fields, {
+    SceneData scene{Implementation::sceneMappingTypeFor<T>(), 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, Implementation::sceneObjectTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, Implementation::sceneMappingTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
-    CORRADE_COMPARE_AS(scene.objectsAsArray(SceneField::Mesh),
+    CORRADE_COMPARE_AS(scene.mappingAsArray(SceneField::Mesh),
         Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-void SceneDataTest::objectsIntoArrayByIndex() {
+void SceneDataTest::mappingIntoArrayByIndex() {
     auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
@@ -2306,9 +2306,9 @@ void SceneDataTest::objectsIntoArrayByIndex() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh,
             view.slice(&Field::object),
             view.slice(&Field::mesh)},
@@ -2317,7 +2317,7 @@ void SceneDataTest::objectsIntoArrayByIndex() {
     /* The offset-less overload should give back all data */
     {
         UnsignedInt out[3];
-        scene.objectsInto(1, out);
+        scene.mappingInto(1, out);
         CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
@@ -2325,7 +2325,7 @@ void SceneDataTest::objectsIntoArrayByIndex() {
     /* The offset variant only a subset */
     } {
         Containers::Array<UnsignedInt> out{data.size};
-        CORRADE_COMPARE(scene.objectsInto(1, data.offset, out), data.expectedSize);
+        CORRADE_COMPARE(scene.mappingInto(1, data.offset, out), data.expectedSize);
         CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
@@ -2333,7 +2333,7 @@ void SceneDataTest::objectsIntoArrayByIndex() {
     }
 }
 
-void SceneDataTest::objectsIntoArrayByName() {
+void SceneDataTest::mappingIntoArrayByName() {
     auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
@@ -2352,9 +2352,9 @@ void SceneDataTest::objectsIntoArrayByName() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh,
             view.slice(&Field::object),
             view.slice(&Field::mesh)},
@@ -2363,7 +2363,7 @@ void SceneDataTest::objectsIntoArrayByName() {
     /* The offset-less overload should give back all data */
     {
         UnsignedInt out[3];
-        scene.objectsInto(SceneField::Mesh, out);
+        scene.mappingInto(SceneField::Mesh, out);
         CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
@@ -2371,7 +2371,7 @@ void SceneDataTest::objectsIntoArrayByName() {
     /* The offset variant only a subset */
     } {
         Containers::Array<UnsignedInt> out{data.size};
-        CORRADE_COMPARE(scene.objectsInto(SceneField::Mesh, data.offset, out), data.expectedSize);
+        CORRADE_COMPARE(scene.mappingInto(SceneField::Mesh, data.offset, out), data.expectedSize);
         CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
@@ -2379,7 +2379,7 @@ void SceneDataTest::objectsIntoArrayByName() {
     }
 }
 
-void SceneDataTest::objectsIntoArrayInvalidSizeOrOffset() {
+void SceneDataTest::mappingIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2391,22 +2391,22 @@ void SceneDataTest::objectsIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
     UnsignedInt destination[2];
-    scene.objectsInto(0, destination);
-    scene.objectsInto(SceneField::Mesh, destination);
-    scene.objectsInto(0, 4, destination);
-    scene.objectsInto(SceneField::Mesh, 4, destination);
+    scene.mappingInto(0, destination);
+    scene.mappingInto(SceneField::Mesh, destination);
+    scene.mappingInto(0, 4, destination);
+    scene.mappingInto(SceneField::Mesh, 4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::objectsInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::objectsInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::mappingInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::mappingInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::mappingInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::mappingInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::parentsAsArray() {
@@ -2423,9 +2423,9 @@ template<class T> void SceneDataTest::parentsAsArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::UnsignedInt, nullptr},
+        SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::UnsignedInt, nullptr},
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
 
@@ -2455,9 +2455,9 @@ void SceneDataTest::parentsIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr},
+        SceneFieldData{SceneField::Mesh, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr},
         SceneFieldData{SceneField::Parent,
             view.slice(&Field::object),
             view.slice(&Field::parent)},
@@ -2465,13 +2465,13 @@ void SceneDataTest::parentsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Int field[3];
         scene.parentsInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -2480,13 +2480,13 @@ void SceneDataTest::parentsIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Int> field{data.size};
         CORRADE_COMPARE(scene.parentsInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -2509,25 +2509,25 @@ void SceneDataTest::parentsIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     Int fieldDestinationCorrect[3];
     Int fieldDestination[2];
-    scene.parentsInto(objectDestination, fieldDestinationCorrect);
-    scene.parentsInto(objectDestinationCorrect, fieldDestination);
-    scene.parentsInto(4, objectDestination, fieldDestination);
-    scene.parentsInto(0, objectDestinationCorrect, fieldDestination);
+    scene.parentsInto(mappingDestination, fieldDestinationCorrect);
+    scene.parentsInto(mappingDestinationCorrect, fieldDestination);
+    scene.parentsInto(4, mappingDestination, fieldDestination);
+    scene.parentsInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::parentsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::parentsInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::parentsInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::parentsInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::parentsInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::parentsInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> struct TransformationTypeFor {
@@ -2582,9 +2582,9 @@ template<class T> void SceneDataTest::transformations2DAsArray() {
        for those and error/warn on those, they get just ignored. */
     components[1] = {2, {3.5f, -1.0f}, {1.0f, 1.5f}};
 
-    SceneData scene{SceneObjectType::UnsignedInt, 6, std::move(data), {
+    SceneData scene{SceneMappingType::UnsignedInt, 6, std::move(data), {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Transformation,
             transformations.slice(&Transformation::object),
             transformations.slice(&Transformation::transformation)},
@@ -2646,7 +2646,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
 
     /* Just one of translation / rotation / scaling */
     {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation
         }};
         CORRADE_VERIFY(scene.is2D());
@@ -2666,7 +2666,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             {7, {{1.5f, 2.5f}, {}, Vector2{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             rotation
         }};
         CORRADE_VERIFY(scene.is2D());
@@ -2686,7 +2686,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             {7, {{}, Complex::rotation(-15.0_degf), Vector2{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             scaling
         }};
         CORRADE_VERIFY(scene.is2D());
@@ -2709,7 +2709,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
 
     /* Pairs */
     {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation,
             rotation
         }};
@@ -2730,7 +2730,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             {7, {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), Vector2{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation,
             scaling
         }};
@@ -2751,7 +2751,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             {7, {{1.5f, 2.5f}, {}, {-0.5f, 4.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             rotation,
             scaling
         }};
@@ -2775,7 +2775,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
 
     /* All */
     {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation,
             rotation,
             scaling
@@ -2809,8 +2809,8 @@ void SceneDataTest::transformations2DAsArrayBut3DType() {
        assertion for translations, as those are at offset 0, which would be
        interpreted as an empty view if there were no elements. Thus using
        rotations instead. */
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Quaternion, nullptr}
+    SceneData scene{SceneMappingType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Rotation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Quaternion, nullptr}
     }};
 
     std::ostringstream out;
@@ -2841,9 +2841,9 @@ void SceneDataTest::transformations2DIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Transformation,
             view.slice(&Field::object),
             view.slice(&Field::transformation)},
@@ -2851,13 +2851,13 @@ void SceneDataTest::transformations2DIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Matrix3 field[3];
         scene.transformations2DInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -2866,13 +2866,13 @@ void SceneDataTest::transformations2DIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Matrix3> field{data.size};
         CORRADE_COMPARE(scene.transformations2DInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -2903,9 +2903,9 @@ void SceneDataTest::transformations2DTRSIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Translation,
             view.slice(&Field::object),
             view.slice(&Field::translation)},
@@ -2925,13 +2925,13 @@ void SceneDataTest::transformations2DTRSIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Matrix3 field[3];
         scene.transformations2DInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -2940,13 +2940,13 @@ void SceneDataTest::transformations2DTRSIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Matrix3> field{data.size};
         CORRADE_COMPARE(scene.transformations2DInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -2977,9 +2977,9 @@ void SceneDataTest::transformations2DIntoArrayTRS() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Translation,
             view.slice(&Field::object),
             view.slice(&Field::translation)},
@@ -2993,17 +2993,17 @@ void SceneDataTest::transformations2DIntoArrayTRS() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Vector2 translations[3];
         Complex rotations[3];
         Vector2 scalings[3];
         scene.translationsRotationsScalings2DInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field1 ? Containers::arrayView(translations) : nullptr,
             data.field2 ? Containers::arrayView(rotations) : nullptr,
             data.field3 ? Containers::arrayView(scalings) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field1) CORRADE_COMPARE_AS(Containers::stridedArrayView(translations),
@@ -3018,17 +3018,17 @@ void SceneDataTest::transformations2DIntoArrayTRS() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Vector2> translations{data.size};
         Containers::Array<Complex> rotations{data.size};
         Containers::Array<Vector2> scalings{data.size};
         CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field1 ? arrayView(translations) : nullptr,
             data.field2 ? arrayView(rotations) : nullptr,
             data.field3 ? arrayView(scalings) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3059,25 +3059,25 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Transformation, view.slice(&Field::object), view.slice(&Field::transformation)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     Matrix3 fieldDestinationCorrect[3];
     Matrix3 fieldDestination[2];
-    scene.transformations2DInto(objectDestination, fieldDestinationCorrect);
-    scene.transformations2DInto(objectDestinationCorrect, fieldDestination);
-    scene.transformations2DInto(4, objectDestination, fieldDestination);
-    scene.transformations2DInto(0, objectDestinationCorrect, fieldDestination);
+    scene.transformations2DInto(mappingDestination, fieldDestinationCorrect);
+    scene.transformations2DInto(mappingDestinationCorrect, fieldDestination);
+    scene.transformations2DInto(4, mappingDestination, fieldDestination);
+    scene.transformations2DInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::transformations2DInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::transformations2DInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::transformations2DInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::transformations2DInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::transformations2DInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::transformations2DInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS() {
@@ -3092,40 +3092,40 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     Vector2 translationDestinationCorrect[3];
     Vector2 translationDestination[2];
     Complex rotationDestinationCorrect[3];
     Complex rotationDestination[2];
     Vector2 scalingDestinationCorrect[3];
     Vector2 scalingDestination[2];
-    scene.translationsRotationsScalings2DInto(objectDestination, translationDestinationCorrect, rotationDestinationCorrect, scalingDestinationCorrect);
-    scene.translationsRotationsScalings2DInto(objectDestinationCorrect, translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
-    scene.translationsRotationsScalings2DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
-    scene.translationsRotationsScalings2DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
-    scene.translationsRotationsScalings2DInto(4, objectDestination, translationDestination, rotationDestination, scalingDestination);
-    scene.translationsRotationsScalings2DInto(0, objectDestinationCorrect, translationDestination, nullptr, nullptr);
-    scene.translationsRotationsScalings2DInto(0, objectDestinationCorrect, nullptr, rotationDestination, nullptr);
-    scene.translationsRotationsScalings2DInto(0, objectDestinationCorrect, nullptr, nullptr, scalingDestination);
+    scene.translationsRotationsScalings2DInto(mappingDestination, translationDestinationCorrect, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(mappingDestinationCorrect, translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(mappingDestinationCorrect, translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(mappingDestinationCorrect, translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings2DInto(4, mappingDestination, translationDestination, rotationDestination, scalingDestination);
+    scene.translationsRotationsScalings2DInto(0, mappingDestinationCorrect, translationDestination, nullptr, nullptr);
+    scene.translationsRotationsScalings2DInto(0, mappingDestinationCorrect, nullptr, rotationDestination, nullptr);
+    scene.translationsRotationsScalings2DInto(0, mappingDestinationCorrect, nullptr, nullptr, scalingDestination);
     scene.translationsRotationsScalings2DInto(0, nullptr, translationDestinationCorrect, rotationDestination, nullptr);
     scene.translationsRotationsScalings2DInto(0, nullptr, translationDestinationCorrect, nullptr, scalingDestination);
     scene.translationsRotationsScalings2DInto(0, nullptr, nullptr, rotationDestinationCorrect, scalingDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::translationsRotationsScalings2DInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected translation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected rotation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected scaling destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::translationsRotationsScalings2DInto(): object and translation destination views have different size, 3 vs 2\n"
-        "Trade::SceneData::translationsRotationsScalings2DInto(): object and rotation destination views have different size, 3 vs 2\n"
-        "Trade::SceneData::translationsRotationsScalings2DInto(): object and scaling destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): mapping and translation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): mapping and rotation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): mapping and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): translation and rotation destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): translation and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): rotation and scaling destination views have different size, 3 vs 2\n");
@@ -3176,9 +3176,9 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
        for those and error/warn on those, they get just ignored. */
     components[1] = {2, {3.5f, -1.0f, 2.2f}, {1.0f, 1.5f, 1.0f}};
 
-    SceneData scene{SceneObjectType::UnsignedInt, 6, std::move(data), {
+    SceneData scene{SceneMappingType::UnsignedInt, 6, std::move(data), {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Transformation,
             transformations.slice(&Transformation::object),
             transformations.slice(&Transformation::transformation)},
@@ -3240,7 +3240,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
 
     /* Just one of translation / rotation / scaling */
     {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation
         }};
         CORRADE_VERIFY(!scene.is2D());
@@ -3260,7 +3260,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             {7, {{1.5f, 2.5f, 3.5f}, {}, Vector3{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             rotation
         }};
         CORRADE_VERIFY(!scene.is2D());
@@ -3280,7 +3280,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             {7, {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             scaling
         }};
         CORRADE_VERIFY(!scene.is2D());
@@ -3303,7 +3303,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
 
     /* Pairs */
     {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation,
             rotation
         }};
@@ -3324,7 +3324,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             {7, {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation,
             scaling
         }};
@@ -3345,7 +3345,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             {7, {{1.5f, 2.5f, 3.5f}, {}, {-0.5f, 4.0f, -16.0f}}},
         })), TestSuite::Compare::Container);
     } {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             rotation,
             scaling
         }};
@@ -3369,7 +3369,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
 
     /* All */
     {
-        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedInt, 8, {}, fields, {
             translation,
             rotation,
             scaling
@@ -3403,8 +3403,8 @@ void SceneDataTest::transformations3DAsArrayBut2DType() {
        assertion for translations, as those are at offset 0, which would be
        interpreted as an empty view if there were no elements. Thus using
        rotations instead. */
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Complex, nullptr}
+    SceneData scene{SceneMappingType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Rotation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Complex, nullptr}
     }};
 
     std::ostringstream out;
@@ -3435,9 +3435,9 @@ void SceneDataTest::transformations3DIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Transformation,
             view.slice(&Field::object),
             view.slice(&Field::transformation)},
@@ -3445,13 +3445,13 @@ void SceneDataTest::transformations3DIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Matrix4 field[3];
         scene.transformations3DInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -3460,13 +3460,13 @@ void SceneDataTest::transformations3DIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Matrix4> field{data.size};
         CORRADE_COMPARE(scene.transformations3DInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3497,9 +3497,9 @@ void SceneDataTest::transformations3DTRSIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Translation,
             view.slice(&Field::object),
             view.slice(&Field::translation)},
@@ -3519,13 +3519,13 @@ void SceneDataTest::transformations3DTRSIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Matrix4 field[3];
         scene.transformations3DInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -3534,13 +3534,13 @@ void SceneDataTest::transformations3DTRSIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Matrix4> field{data.size};
         CORRADE_COMPARE(scene.transformations3DInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3571,9 +3571,9 @@ void SceneDataTest::transformations3DIntoArrayTRS() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Translation,
             view.slice(&Field::object),
             view.slice(&Field::translation)},
@@ -3587,17 +3587,17 @@ void SceneDataTest::transformations3DIntoArrayTRS() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         Vector3 translations[3];
         Quaternion rotations[3];
         Vector3 scalings[3];
         scene.translationsRotationsScalings3DInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field1 ? Containers::arrayView(translations) : nullptr,
             data.field2 ? Containers::arrayView(rotations) : nullptr,
             data.field3 ? Containers::arrayView(scalings) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field1) CORRADE_COMPARE_AS(Containers::stridedArrayView(translations),
@@ -3612,17 +3612,17 @@ void SceneDataTest::transformations3DIntoArrayTRS() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<Vector3> translations{data.size};
         Containers::Array<Quaternion> rotations{data.size};
         Containers::Array<Vector3> scalings{data.size};
         CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field1 ? arrayView(translations) : nullptr,
             data.field2 ? arrayView(rotations) : nullptr,
             data.field3 ? arrayView(scalings) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3653,25 +3653,25 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Transformation, view.slice(&Field::object), view.slice(&Field::transformation)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     Matrix4 fieldDestinationCorrect[3];
     Matrix4 fieldDestination[2];
-    scene.transformations3DInto(objectDestination, fieldDestinationCorrect);
-    scene.transformations3DInto(objectDestinationCorrect, fieldDestination);
-    scene.transformations3DInto(4, objectDestination, fieldDestination);
-    scene.transformations3DInto(0, objectDestinationCorrect, fieldDestination);
+    scene.transformations3DInto(mappingDestination, fieldDestinationCorrect);
+    scene.transformations3DInto(mappingDestinationCorrect, fieldDestination);
+    scene.transformations3DInto(4, mappingDestination, fieldDestination);
+    scene.transformations3DInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::transformations3DInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::transformations3DInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::transformations3DInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::transformations3DInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::transformations3DInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::transformations3DInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS() {
@@ -3686,40 +3686,40 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     Vector3 translationDestinationCorrect[3];
     Vector3 translationDestination[2];
     Quaternion rotationDestinationCorrect[3];
     Quaternion rotationDestination[2];
     Vector3 scalingDestinationCorrect[3];
     Vector3 scalingDestination[2];
-    scene.translationsRotationsScalings3DInto(objectDestination, translationDestinationCorrect, rotationDestinationCorrect, scalingDestinationCorrect);
-    scene.translationsRotationsScalings3DInto(objectDestinationCorrect, translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
-    scene.translationsRotationsScalings3DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
-    scene.translationsRotationsScalings3DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
-    scene.translationsRotationsScalings3DInto(4, objectDestination, translationDestination, rotationDestination, scalingDestination);
-    scene.translationsRotationsScalings3DInto(0, objectDestinationCorrect, translationDestination, nullptr, nullptr);
-    scene.translationsRotationsScalings3DInto(0, objectDestinationCorrect, nullptr, rotationDestination, nullptr);
-    scene.translationsRotationsScalings3DInto(0, objectDestinationCorrect, nullptr, nullptr, scalingDestination);
+    scene.translationsRotationsScalings3DInto(mappingDestination, translationDestinationCorrect, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(mappingDestinationCorrect, translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(mappingDestinationCorrect, translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(mappingDestinationCorrect, translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings3DInto(4, mappingDestination, translationDestination, rotationDestination, scalingDestination);
+    scene.translationsRotationsScalings3DInto(0, mappingDestinationCorrect, translationDestination, nullptr, nullptr);
+    scene.translationsRotationsScalings3DInto(0, mappingDestinationCorrect, nullptr, rotationDestination, nullptr);
+    scene.translationsRotationsScalings3DInto(0, mappingDestinationCorrect, nullptr, nullptr, scalingDestination);
     scene.translationsRotationsScalings3DInto(0, nullptr, translationDestinationCorrect, rotationDestination, nullptr);
     scene.translationsRotationsScalings3DInto(0, nullptr, translationDestinationCorrect, nullptr, scalingDestination);
     scene.translationsRotationsScalings3DInto(0, nullptr, nullptr, rotationDestinationCorrect, scalingDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::translationsRotationsScalings3DInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected translation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected rotation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected scaling destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::translationsRotationsScalings3DInto(): object and translation destination views have different size, 3 vs 2\n"
-        "Trade::SceneData::translationsRotationsScalings3DInto(): object and rotation destination views have different size, 3 vs 2\n"
-        "Trade::SceneData::translationsRotationsScalings3DInto(): object and scaling destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): mapping and translation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): mapping and rotation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): mapping and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): translation and rotation destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): translation and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): rotation and scaling destination views have different size, 3 vs 2\n");
@@ -3749,9 +3749,9 @@ template<class T, class U> void SceneDataTest::meshesMaterialsAsArray() {
 
     /* Both meshes and materials */
     {
-        SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
             /* To verify it isn't just picking the first ever field */
-            SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+            SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
             meshes,
             meshMaterials
         }};
@@ -3764,7 +3764,7 @@ template<class T, class U> void SceneDataTest::meshesMaterialsAsArray() {
 
     /* Only meshes */
     } {
-        SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
             meshes
         }};
 
@@ -3796,9 +3796,9 @@ void SceneDataTest::meshesMaterialsIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh,
             view.slice(&Field::object),
             view.slice(&Field::mesh)},
@@ -3809,15 +3809,15 @@ void SceneDataTest::meshesMaterialsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         UnsignedInt meshes[3];
         Int meshMaterials[3];
         scene.meshesMaterialsInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field1 ? Containers::arrayView(meshes) : nullptr,
             data.field2 ? Containers::arrayView(meshMaterials) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field1) CORRADE_COMPARE_AS(Containers::stridedArrayView(meshes),
@@ -3829,15 +3829,15 @@ void SceneDataTest::meshesMaterialsIntoArray() {
 
     /* The offset variant should give back only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<UnsignedInt> meshes{data.size};
         Containers::Array<Int> meshMaterials{data.size};
         CORRADE_COMPARE(scene.meshesMaterialsInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field1 ? arrayView(meshes) : nullptr,
             data.field2 ? arrayView(meshMaterials) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3864,32 +3864,32 @@ void SceneDataTest::meshesMaterialsIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     UnsignedInt meshDestinationCorrect[3];
     UnsignedInt meshDestination[2];
     Int meshMaterialDestinationCorrect[3];
     Int meshMaterialDestination[2];
-    scene.meshesMaterialsInto(objectDestination, meshDestinationCorrect, meshMaterialDestinationCorrect);
-    scene.meshesMaterialsInto(objectDestinationCorrect, meshDestination, meshMaterialDestinationCorrect);
-    scene.meshesMaterialsInto(objectDestinationCorrect, meshDestinationCorrect, meshMaterialDestination);
-    scene.meshesMaterialsInto(4, objectDestination, meshDestination, meshMaterialDestination);
-    scene.meshesMaterialsInto(0, objectDestinationCorrect, meshDestination, nullptr);
-    scene.meshesMaterialsInto(0, objectDestinationCorrect, nullptr, meshMaterialDestination);
+    scene.meshesMaterialsInto(mappingDestination, meshDestinationCorrect, meshMaterialDestinationCorrect);
+    scene.meshesMaterialsInto(mappingDestinationCorrect, meshDestination, meshMaterialDestinationCorrect);
+    scene.meshesMaterialsInto(mappingDestinationCorrect, meshDestinationCorrect, meshMaterialDestination);
+    scene.meshesMaterialsInto(4, mappingDestination, meshDestination, meshMaterialDestination);
+    scene.meshesMaterialsInto(0, mappingDestinationCorrect, meshDestination, nullptr);
+    scene.meshesMaterialsInto(0, mappingDestinationCorrect, nullptr, meshMaterialDestination);
     scene.meshesMaterialsInto(0, nullptr, meshDestinationCorrect, meshMaterialDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::meshesMaterialsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::meshesMaterialsInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::meshesMaterialsInto(): expected mesh destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::meshesMaterialsInto(): expected mesh material destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::meshesMaterialsInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::meshesMaterialsInto(): object and mesh destination views have different size, 3 vs 2\n"
-        "Trade::SceneData::meshesMaterialsInto(): object and mesh material destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::meshesMaterialsInto(): mapping and mesh destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::meshesMaterialsInto(): mapping and mesh material destination views have different size, 3 vs 2\n"
         "Trade::SceneData::meshesMaterialsInto(): mesh and mesh material destination views have different size, 3 vs 2\n");
 }
 
@@ -3907,9 +3907,9 @@ template<class T> void SceneDataTest::lightsAsArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
     }};
 
@@ -3939,9 +3939,9 @@ void SceneDataTest::lightsIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Light,
             view.slice(&Field::object),
             view.slice(&Field::light)},
@@ -3949,13 +3949,13 @@ void SceneDataTest::lightsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         UnsignedInt field[3];
         scene.lightsInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -3964,13 +3964,13 @@ void SceneDataTest::lightsIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<UnsignedInt> field{data.size};
         CORRADE_COMPARE(scene.lightsInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3993,25 +3993,25 @@ void SceneDataTest::lightsIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     UnsignedInt fieldDestinationCorrect[3];
     UnsignedInt fieldDestination[2];
-    scene.lightsInto(objectDestination, fieldDestinationCorrect);
-    scene.lightsInto(objectDestinationCorrect, fieldDestination);
-    scene.lightsInto(4, objectDestination, fieldDestination);
-    scene.lightsInto(0, objectDestinationCorrect, fieldDestination);
+    scene.lightsInto(mappingDestination, fieldDestinationCorrect);
+    scene.lightsInto(mappingDestinationCorrect, fieldDestination);
+    scene.lightsInto(4, mappingDestination, fieldDestination);
+    scene.lightsInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::lightsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::lightsInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::lightsInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::lightsInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::lightsInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::lightsInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::camerasAsArray() {
@@ -4028,9 +4028,9 @@ template<class T> void SceneDataTest::camerasAsArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
     }};
 
@@ -4060,9 +4060,9 @@ void SceneDataTest::camerasIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Camera,
             view.slice(&Field::object),
             view.slice(&Field::camera)},
@@ -4070,13 +4070,13 @@ void SceneDataTest::camerasIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         UnsignedInt field[3];
         scene.camerasInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -4085,13 +4085,13 @@ void SceneDataTest::camerasIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<UnsignedInt> field{data.size};
         CORRADE_COMPARE(scene.camerasInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -4114,25 +4114,25 @@ void SceneDataTest::camerasIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     UnsignedInt fieldDestinationCorrect[3];
     UnsignedInt fieldDestination[2];
-    scene.camerasInto(objectDestination, fieldDestinationCorrect);
-    scene.camerasInto(objectDestinationCorrect, fieldDestination);
-    scene.camerasInto(4, objectDestination, fieldDestination);
-    scene.camerasInto(0, objectDestinationCorrect, fieldDestination);
+    scene.camerasInto(mappingDestination, fieldDestinationCorrect);
+    scene.camerasInto(mappingDestinationCorrect, fieldDestination);
+    scene.camerasInto(4, mappingDestination, fieldDestination);
+    scene.camerasInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::camerasInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::camerasInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::camerasInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::camerasInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::camerasInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::camerasInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::skinsAsArray() {
@@ -4149,11 +4149,11 @@ template<class T> void SceneDataTest::skinsAsArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field; also to
            satisfy the requirement of having a transformation field to
            disambiguate the dimensionality */
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Vector3, nullptr},
+        SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
@@ -4183,11 +4183,11 @@ void SceneDataTest::skinsIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field; also to
            satisfy the requirement of having a transformation field to
            disambiguate the dimensionality */
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
+        SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin,
             view.slice(&Field::object),
             view.slice(&Field::skin)},
@@ -4195,13 +4195,13 @@ void SceneDataTest::skinsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         UnsignedInt field[3];
         scene.skinsInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -4210,13 +4210,13 @@ void SceneDataTest::skinsIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<UnsignedInt> field{data.size};
         CORRADE_COMPARE(scene.skinsInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -4239,28 +4239,28 @@ void SceneDataTest::skinsIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To satisfy the requirement of having a transformation field to
            disambiguate the dimensionality */
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
+        SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     UnsignedInt fieldDestinationCorrect[3];
     UnsignedInt fieldDestination[2];
-    scene.skinsInto(objectDestination, fieldDestinationCorrect);
-    scene.skinsInto(objectDestinationCorrect, fieldDestination);
-    scene.skinsInto(4, objectDestination, fieldDestination);
-    scene.skinsInto(0, objectDestinationCorrect, fieldDestination);
+    scene.skinsInto(mappingDestination, fieldDestinationCorrect);
+    scene.skinsInto(mappingDestinationCorrect, fieldDestination);
+    scene.skinsInto(4, mappingDestination, fieldDestination);
+    scene.skinsInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::skinsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::skinsInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::skinsInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::skinsInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::skinsInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::skinsInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::importerStateAsArray() {
@@ -4279,9 +4279,9 @@ template<class T> void SceneDataTest::importerStateAsArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedByte, 50, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::ImporterState, view.slice(&Field::object), view.slice(&Field::importerState)}
     }};
 
@@ -4313,9 +4313,9 @@ void SceneDataTest::importerStateIntoArray() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         /* To verify it isn't just picking the first ever field */
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::ImporterState,
             view.slice(&Field::object),
             view.slice(&Field::importerState)},
@@ -4323,13 +4323,13 @@ void SceneDataTest::importerStateIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt objects[3];
+        UnsignedInt mapping[3];
         const void* field[3];
         scene.importerStateInto(
-            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.mapping ? Containers::arrayView(mapping) : nullptr,
             data.field ? Containers::arrayView(field) : nullptr
         );
-        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+        if(data.mapping) CORRADE_COMPARE_AS(Containers::stridedArrayView(mapping),
             view.slice(&Field::object),
             TestSuite::Compare::Container);
         if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
@@ -4338,13 +4338,13 @@ void SceneDataTest::importerStateIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> mapping{data.size};
         Containers::Array<const void*> field{data.size};
         CORRADE_COMPARE(scene.importerStateInto(data.offset,
-            data.objects ? arrayView(objects) : nullptr,
+            data.mapping ? arrayView(mapping) : nullptr,
             data.field ? arrayView(field) : nullptr
         ), data.expectedSize);
-        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+        if(data.mapping) CORRADE_COMPARE_AS(mapping.prefix(data.expectedSize),
             view.slice(&Field::object)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -4367,25 +4367,25 @@ void SceneDataTest::importerStateIntoArrayInvalidSizeOrOffset() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{SceneField::ImporterState, view.slice(&Field::object), view.slice(&Field::importerState)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt objectDestinationCorrect[3];
-    UnsignedInt objectDestination[2];
+    UnsignedInt mappingDestinationCorrect[3];
+    UnsignedInt mappingDestination[2];
     const void* fieldDestinationCorrect[3];
     const void* fieldDestination[2];
-    scene.importerStateInto(objectDestination, fieldDestinationCorrect);
-    scene.importerStateInto(objectDestinationCorrect, fieldDestination);
-    scene.importerStateInto(4, objectDestination, fieldDestination);
-    scene.importerStateInto(0, objectDestinationCorrect, fieldDestination);
+    scene.importerStateInto(mappingDestination, fieldDestinationCorrect);
+    scene.importerStateInto(mappingDestinationCorrect, fieldDestination);
+    scene.importerStateInto(4, mappingDestination, fieldDestination);
+    scene.importerStateInto(0, mappingDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::importerStateInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::importerStateInto(): expected mapping destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::importerStateInto(): expected field destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::importerStateInto(): offset 4 out of bounds for a field of size 3\n"
-        "Trade::SceneData::importerStateInto(): object and field destination views have different size, 3 vs 2\n");
+        "Trade::SceneData::importerStateInto(): mapping and field destination views have different size, 3 vs 2\n");
 }
 
 void SceneDataTest::mutableAccessNotAllowed() {
@@ -4401,7 +4401,7 @@ void SceneDataTest::mutableAccessNotAllowed() {
 
     Containers::StridedArrayView1D<const Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, {}, fields, {
         SceneFieldData{sceneFieldCustom(35),
             view.slice(&Field::object),
             view.slice(&Field::foobar)},
@@ -4413,10 +4413,10 @@ void SceneDataTest::mutableAccessNotAllowed() {
     std::ostringstream out;
     Error redirectError{&out};
     scene.mutableData();
-    scene.mutableObjects(0);
-    scene.mutableObjects<UnsignedInt>(0);
-    scene.mutableObjects(SceneField::Mesh);
-    scene.mutableObjects<UnsignedInt>(SceneField::Mesh);
+    scene.mutableMapping(0);
+    scene.mutableMapping<UnsignedInt>(0);
+    scene.mutableMapping(SceneField::Mesh);
+    scene.mutableMapping<UnsignedInt>(SceneField::Mesh);
     scene.mutableField(0);
     scene.mutableField<UnsignedInt>(0);
     scene.mutableField<UnsignedInt[]>(1);
@@ -4425,10 +4425,10 @@ void SceneDataTest::mutableAccessNotAllowed() {
     scene.mutableField<UnsignedInt[]>(sceneFieldCustom(35));
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData::mutableData(): data not mutable\n"
-        "Trade::SceneData::mutableObjects(): data not mutable\n"
-        "Trade::SceneData::mutableObjects(): data not mutable\n"
-        "Trade::SceneData::mutableObjects(): data not mutable\n"
-        "Trade::SceneData::mutableObjects(): data not mutable\n"
+        "Trade::SceneData::mutableMapping(): data not mutable\n"
+        "Trade::SceneData::mutableMapping(): data not mutable\n"
+        "Trade::SceneData::mutableMapping(): data not mutable\n"
+        "Trade::SceneData::mutableMapping(): data not mutable\n"
         "Trade::SceneData::mutableField(): data not mutable\n"
         "Trade::SceneData::mutableField(): data not mutable\n"
         "Trade::SceneData::mutableField(): data not mutable\n"
@@ -4437,7 +4437,7 @@ void SceneDataTest::mutableAccessNotAllowed() {
         "Trade::SceneData::mutableField(): data not mutable\n");
 }
 
-void SceneDataTest::objectsNotFound() {
+void SceneDataTest::mappingNotFound() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -4450,39 +4450,39 @@ void SceneDataTest::objectsNotFound() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, DataFlag::Mutable, fields, {
         SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::foobar)},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    scene.objects(2);
-    scene.objects<UnsignedInt>(2);
-    scene.mutableObjects(2);
-    scene.mutableObjects<UnsignedInt>(2);
-    scene.objects(sceneFieldCustom(666));
-    scene.objects<UnsignedInt>(sceneFieldCustom(666));
-    scene.mutableObjects(sceneFieldCustom(666));
-    scene.mutableObjects<UnsignedInt>(sceneFieldCustom(666));
+    scene.mapping(2);
+    scene.mapping<UnsignedInt>(2);
+    scene.mutableMapping(2);
+    scene.mutableMapping<UnsignedInt>(2);
+    scene.mapping(sceneFieldCustom(666));
+    scene.mapping<UnsignedInt>(sceneFieldCustom(666));
+    scene.mutableMapping(sceneFieldCustom(666));
+    scene.mutableMapping<UnsignedInt>(sceneFieldCustom(666));
 
-    scene.objectsAsArray(2);
-    scene.objectsAsArray(sceneFieldCustom(666));
+    scene.mappingAsArray(2);
+    scene.mappingAsArray(sceneFieldCustom(666));
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::objects(): index 2 out of range for 2 fields\n"
-        "Trade::SceneData::objects(): index 2 out of range for 2 fields\n"
-        "Trade::SceneData::mutableObjects(): index 2 out of range for 2 fields\n"
-        "Trade::SceneData::mutableObjects(): index 2 out of range for 2 fields\n"
-        "Trade::SceneData::objects(): field Trade::SceneField::Custom(666) not found\n"
-        "Trade::SceneData::objects(): field Trade::SceneField::Custom(666) not found\n"
-        "Trade::SceneData::mutableObjects(): field Trade::SceneField::Custom(666) not found\n"
-        "Trade::SceneData::mutableObjects(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mapping(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mapping(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableMapping(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableMapping(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mapping(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mapping(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableMapping(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableMapping(): field Trade::SceneField::Custom(666) not found\n"
 
-        "Trade::SceneData::objectsInto(): index 2 out of range for 2 fields\n"
-        "Trade::SceneData::objectsInto(): field Trade::SceneField::Custom(666) not found\n");
+        "Trade::SceneData::mappingInto(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mappingInto(): field Trade::SceneField::Custom(666) not found\n");
 }
 
-void SceneDataTest::objectsWrongType() {
+void SceneDataTest::mappingWrongType() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -4495,22 +4495,22 @@ void SceneDataTest::objectsWrongType() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedShort, 5, DataFlag::Mutable, fields, {
+    SceneData scene{SceneMappingType::UnsignedShort, 5, DataFlag::Mutable, fields, {
         SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::foobar)},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    scene.objects<UnsignedByte>(1);
-    scene.mutableObjects<UnsignedByte>(1);
-    scene.objects<UnsignedByte>(SceneField::Mesh);
-    scene.mutableObjects<UnsignedByte>(SceneField::Mesh);
+    scene.mapping<UnsignedByte>(1);
+    scene.mutableMapping<UnsignedByte>(1);
+    scene.mapping<UnsignedByte>(SceneField::Mesh);
+    scene.mutableMapping<UnsignedByte>(SceneField::Mesh);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::objects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n"
-        "Trade::SceneData::mutableObjects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n"
-        "Trade::SceneData::objects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n"
-        "Trade::SceneData::mutableObjects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n");
+        "Trade::SceneData::mapping(): mapping is Trade::SceneMappingType::UnsignedShort but requested Trade::SceneMappingType::UnsignedByte\n"
+        "Trade::SceneData::mutableMapping(): mapping is Trade::SceneMappingType::UnsignedShort but requested Trade::SceneMappingType::UnsignedByte\n"
+        "Trade::SceneData::mapping(): mapping is Trade::SceneMappingType::UnsignedShort but requested Trade::SceneMappingType::UnsignedByte\n"
+        "Trade::SceneData::mutableMapping(): mapping is Trade::SceneMappingType::UnsignedShort but requested Trade::SceneMappingType::UnsignedByte\n");
 }
 
 void SceneDataTest::fieldNotFound() {
@@ -4525,7 +4525,7 @@ void SceneDataTest::fieldNotFound() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, DataFlag::Mutable, fields, {
         SceneFieldData{sceneFieldCustom(34), view.slice(&Field::object), view.slice(&Field::foo)},
         SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::bar)},
     }};
@@ -4669,7 +4669,7 @@ void SceneDataTest::fieldWrongType() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, DataFlag::Mutable, fields, {
         SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::foobar)},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
     }};
@@ -4707,7 +4707,7 @@ void SceneDataTest::fieldWrongPointerType() {
     } things[2];
     Containers::StridedArrayView1D<Thing> view = things;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, things, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, DataFlag::Mutable, things, {
         SceneFieldData{sceneFieldCustom(35), view.slice(&Thing::object), Containers::arrayCast<2, Int*>(view.slice(&Thing::foobar))},
         SceneFieldData{SceneField::ImporterState, view.slice(&Thing::object), view.slice(&Thing::importerState)},
     }};
@@ -4780,7 +4780,7 @@ void SceneDataTest::fieldWrongArrayAccess() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 5, DataFlag::Mutable, fields, {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
         SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), Containers::arrayCast<2, UnsignedInt>(view.slice(&Field::foobar))},
     }};
@@ -4818,7 +4818,7 @@ void SceneDataTest::parentFor() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
 
@@ -4843,7 +4843,7 @@ void SceneDataTest::parentForTrivialParent() {
         {3, 4, 2, 4 /* duplicate, ignored */}, {-1}
     }};
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Parent,
             Containers::stridedArrayView(fields->object), Containers::stridedArrayView(fields->parent).broadcasted<0>(4)}
     }};
@@ -4873,7 +4873,7 @@ void SceneDataTest::childrenFor() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
 
@@ -4905,15 +4905,15 @@ void SceneDataTest::childrenForTrivialParent() {
     /* Going a bit overboard with the arrays, it makes the view creation below
        easier tho */
     struct Field {
-        UnsignedInt object[4];
+        UnsignedInt mapping[4];
         Int parent[1];
     } fields[]{{
         {3, 4, 2, 4 /* duplicate, gets put to the output */}, {-1}
     }};
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Parent,
-            Containers::stridedArrayView(fields->object), Containers::stridedArrayView(fields->parent).broadcasted<0>(4)}
+            Containers::stridedArrayView(fields->mapping), Containers::stridedArrayView(fields->parent).broadcasted<0>(4)}
     }};
 
     /* Trivial children */
@@ -4944,7 +4944,7 @@ void SceneDataTest::transformation2DFor() {
     };
     Containers::StridedArrayView1D<const Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Transformation, view.slice(&Field::object), view.slice(&Field::transformation)}
     }};
 
@@ -4977,7 +4977,7 @@ void SceneDataTest::transformation2DForTRS() {
     };
     Containers::StridedArrayView1D<const Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)},
         SceneFieldData{SceneField::Rotation, view.slice(&Field::object), view.slice(&Field::rotation)},
         SceneFieldData{SceneField::Scaling, view.slice(&Field::object), view.slice(&Field::scaling)}
@@ -5011,8 +5011,8 @@ void SceneDataTest::transformation2DForBut3DType() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneData scene{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr}
+    SceneData scene{SceneMappingType::UnsignedInt, 1, nullptr, {
+        SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr}
     }};
 
     std::ostringstream out;
@@ -5036,7 +5036,7 @@ void SceneDataTest::transformation3DFor() {
     };
     Containers::StridedArrayView1D<const Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Transformation, view.slice(&Field::object), view.slice(&Field::transformation)}
     }};
 
@@ -5069,7 +5069,7 @@ void SceneDataTest::transformation3DForTRS() {
     };
     Containers::StridedArrayView1D<const Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)},
         SceneFieldData{SceneField::Rotation, view.slice(&Field::object), view.slice(&Field::rotation)},
         SceneFieldData{SceneField::Scaling, view.slice(&Field::object), view.slice(&Field::scaling)}
@@ -5103,8 +5103,8 @@ void SceneDataTest::transformation3DForBut2DType() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneData scene{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector2, nullptr}
+    SceneData scene{SceneMappingType::UnsignedInt, 1, nullptr, {
+        SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector2, nullptr}
     }};
 
     std::ostringstream out;
@@ -5130,7 +5130,7 @@ void SceneDataTest::meshesMaterialsFor() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
         SceneFieldData{SceneField::MeshMaterial, view.slice(&Field::object), view.slice(&Field::meshMaterial)}
     }};
@@ -5167,7 +5167,7 @@ void SceneDataTest::lightsFor() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
     }};
 
@@ -5203,7 +5203,7 @@ void SceneDataTest::camerasFor() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
     }};
 
@@ -5239,10 +5239,10 @@ void SceneDataTest::skinsFor() {
     };
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         /* To satisfy the requirement of having a transformation field to
            disambiguate the dimensionality */
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
+        SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr},
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
@@ -5281,7 +5281,7 @@ void SceneDataTest::importerStateFor() {
 
     Containers::StridedArrayView1D<Field> view = fields;
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, {}, fields, {
+    SceneData scene{SceneMappingType::UnsignedInt, 7, {}, fields, {
         SceneFieldData{SceneField::ImporterState, view.slice(&Field::object), view.slice(&Field::importerState)}
     }};
 
@@ -5318,11 +5318,11 @@ void SceneDataTest::childrenDeprecated() {
     if(!data.skipParent)
         arrayAppend(fieldData, SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)});
     if(data.is2D)
-        arrayAppend(fieldData, SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Vector2, nullptr});
+        arrayAppend(fieldData, SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Vector2, nullptr});
     if(data.is3D)
-        arrayAppend(fieldData, SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Vector3, nullptr});
+        arrayAppend(fieldData, SceneFieldData{SceneField::Translation, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Vector3, nullptr});
 
-    SceneData scene{SceneObjectType::UnsignedByte, 25, {}, fields, std::move(fieldData)};
+    SceneData scene{SceneMappingType::UnsignedByte, 25, {}, fields, std::move(fieldData)};
 
     if(!data.skipParent) {
         CORRADE_IGNORE_DEPRECATED_PUSH
@@ -5351,7 +5351,7 @@ void SceneDataTest::childrenDeprecated() {
 #endif
 
 void SceneDataTest::fieldForFieldMissing() {
-    SceneData scene{SceneObjectType::UnsignedInt, 7, nullptr, {}};
+    SceneData scene{SceneMappingType::UnsignedInt, 7, nullptr, {}};
 
     CORRADE_COMPARE(scene.parentFor(6), Containers::NullOpt);
     CORRADE_COMPARE_AS(scene.childrenFor(6),
@@ -5380,8 +5380,8 @@ void SceneDataTest::findFieldObjectOffsetInvalidObject() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneData scene{SceneObjectType::UnsignedInt, 7, nullptr, {
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+    SceneData scene{SceneMappingType::UnsignedInt, 7, nullptr, {
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
     }};
 
     std::ostringstream out;
@@ -5433,12 +5433,12 @@ void SceneDataTest::releaseFieldData() {
     Containers::StridedArrayView1D<Field> view = Containers::arrayCast<Field>(data);
 
     auto fields = Containers::array({
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     });
     SceneFieldData* originalFields = fields;
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, std::move(data), std::move(fields)};
+    SceneData scene{SceneMappingType::UnsignedByte, 50, std::move(data), std::move(fields)};
 
     Containers::Array<SceneFieldData> released = scene.releaseFieldData();
     CORRADE_COMPARE(released.data(), originalFields);
@@ -5451,8 +5451,8 @@ void SceneDataTest::releaseFieldData() {
     /* Data stays untouched, object count and type as well, as it con't result
        in any dangling data access */
     CORRADE_COMPARE(scene.data(), view.data());
-    CORRADE_COMPARE(scene.objectCount(), 50);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(scene.mappingBound(), 50);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedByte);
 }
 
 void SceneDataTest::releaseData() {
@@ -5464,8 +5464,8 @@ void SceneDataTest::releaseData() {
     Containers::Array<char> data{NoInit, 3*sizeof(Field)};
     Containers::StridedArrayView1D<Field> view = Containers::arrayCast<Field>(data);
 
-    SceneData scene{SceneObjectType::UnsignedByte, 50, std::move(data), {
-        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+    SceneData scene{SceneMappingType::UnsignedByte, 50, std::move(data), {
+        SceneFieldData{SceneField::Parent, SceneMappingType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
@@ -5480,8 +5480,8 @@ void SceneDataTest::releaseData() {
 
     /* Object count and type stays untouched, as it con't result in any
        dangling data access */
-    CORRADE_COMPARE(scene.objectCount(), 50);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(scene.mappingBound(), 50);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedByte);
 }
 
 }}}}

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -96,6 +96,7 @@ struct SceneDataTest: TestSuite::Tester {
     void constructObjectTypeTooSmall();
     void constructNotOwnedFlagOwned();
     void constructMismatchedTRSViews();
+    template<class T> void constructMismatchedTRSDimensionality();
     void constructMismatchedMeshMaterialView();
 
     void constructCopy();
@@ -115,16 +116,14 @@ struct SceneDataTest: TestSuite::Tester {
     void parentsIntoArrayInvalidSizeOrOffset();
     template<class T> void transformations2DAsArray();
     template<class T, class U, class V> void transformations2DAsArrayTRS();
-    template<class T> void transformations2DAsArrayBut3DType();
-    template<class T> void transformations2DAsArrayBut3DTypeTRS();
+    void transformations2DAsArrayBut3DType();
     void transformations2DIntoArray();
     void transformations2DIntoArrayTRS();
     void transformations2DIntoArrayInvalidSizeOrOffset();
     void transformations2DIntoArrayInvalidSizeOrOffsetTRS();
     template<class T> void transformations3DAsArray();
     template<class T, class U, class V> void transformations3DAsArrayTRS();
-    template<class T> void transformations3DAsArrayBut2DType();
-    template<class T> void transformations3DAsArrayBut2DTypeTRS();
+    void transformations3DAsArrayBut2DType();
     void transformations3DIntoArray();
     void transformations3DIntoArrayTRS();
     void transformations3DIntoArrayInvalidSizeOrOffset();
@@ -161,12 +160,10 @@ struct SceneDataTest: TestSuite::Tester {
     void childrenFor();
     void transformation2DFor();
     void transformation2DForTRS();
-    template<class T> void transformation2DForBut3DType();
-    template<class T> void transformation2DForBut3DTypeTRS();
+    void transformation2DForBut3DType();
     void transformation3DFor();
     void transformation3DForTRS();
-    template<class T> void transformation3DForBut2DType();
-    template<class T> void transformation3DForBut2DTypeTRS();
+    void transformation3DForBut2DType();
     void meshesMaterialsFor();
     void lightsFor();
     void camerasFor();
@@ -253,6 +250,8 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::constructObjectTypeTooSmall,
               &SceneDataTest::constructNotOwnedFlagOwned,
               &SceneDataTest::constructMismatchedTRSViews,
+              &SceneDataTest::constructMismatchedTRSDimensionality<Float>,
+              &SceneDataTest::constructMismatchedTRSDimensionality<Double>,
               &SceneDataTest::constructMismatchedMeshMaterialView,
 
               &SceneDataTest::constructCopy,
@@ -292,12 +291,7 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations2DAsArray<DualComplexd>,
               &SceneDataTest::transformations2DAsArrayTRS<Float, Float, Double>,
               &SceneDataTest::transformations2DAsArrayTRS<Double, Double, Float>,
-              &SceneDataTest::transformations2DAsArrayBut3DType<Matrix4x4>,
-              &SceneDataTest::transformations2DAsArrayBut3DType<Matrix4x4d>,
-              &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaternion>,
-              &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaterniond>,
-              &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Float>,
-              &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Double>});
+              &SceneDataTest::transformations2DAsArrayBut3DType});
 
     addInstancedTests({&SceneDataTest::transformations2DIntoArray,
                        &SceneDataTest::transformations2DIntoArrayTRS},
@@ -311,12 +305,7 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations3DAsArray<DualQuaterniond>,
               &SceneDataTest::transformations3DAsArrayTRS<Float, Double, Double>,
               &SceneDataTest::transformations3DAsArrayTRS<Double, Float, Float>,
-              &SceneDataTest::transformations3DAsArrayBut2DType<Matrix3x3>,
-              &SceneDataTest::transformations3DAsArrayBut2DType<Matrix3x3d>,
-              &SceneDataTest::transformations3DAsArrayBut2DType<DualComplex>,
-              &SceneDataTest::transformations3DAsArrayBut2DType<DualComplexd>,
-              &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Float>,
-              &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Double>});
+              &SceneDataTest::transformations3DAsArrayBut2DType});
 
     addInstancedTests({&SceneDataTest::transformations3DIntoArray,
                        &SceneDataTest::transformations3DIntoArrayTRS},
@@ -381,20 +370,10 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::childrenFor,
               &SceneDataTest::transformation2DFor,
               &SceneDataTest::transformation2DForTRS,
-              &SceneDataTest::transformation2DForBut3DType<Matrix4x4>,
-              &SceneDataTest::transformation2DForBut3DType<Matrix4x4d>,
-              &SceneDataTest::transformation2DForBut3DType<DualQuaternion>,
-              &SceneDataTest::transformation2DForBut3DType<DualQuaterniond>,
-              &SceneDataTest::transformation2DForBut3DTypeTRS<Float>,
-              &SceneDataTest::transformation2DForBut3DTypeTRS<Double>,
+              &SceneDataTest::transformation2DForBut3DType,
               &SceneDataTest::transformation3DFor,
               &SceneDataTest::transformation3DForTRS,
-              &SceneDataTest::transformation3DForBut2DType<Matrix3x3>,
-              &SceneDataTest::transformation3DForBut2DType<Matrix3x3d>,
-              &SceneDataTest::transformation3DForBut2DType<DualComplex>,
-              &SceneDataTest::transformation3DForBut2DType<DualComplex>,
-              &SceneDataTest::transformation3DForBut2DTypeTRS<Float>,
-              &SceneDataTest::transformation3DForBut2DTypeTRS<Double>,
+              &SceneDataTest::transformation3DForBut2DType,
               &SceneDataTest::meshesMaterialsFor,
               &SceneDataTest::lightsFor,
               &SceneDataTest::camerasFor,
@@ -1136,6 +1115,9 @@ void SceneDataTest::construct() {
     CORRADE_COMPARE(scene.fieldCount(), 4);
     CORRADE_COMPARE(scene.importerState(), &importerState);
 
+    /* is2D() / is3D() exhaustively tested in transformations*DAsArray[TRS]()
+       and constructZeroFields() */
+
     /* Field property access by ID */
     CORRADE_COMPARE(scene.fieldName(0), SceneField::Transformation);
     CORRADE_COMPARE(scene.fieldName(1), SceneField::Parent);
@@ -1369,6 +1351,8 @@ void SceneDataTest::constructZeroFields() {
     CORRADE_COMPARE(scene.objectCount(), 37563);
     CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldCount(), 0);
+    CORRADE_VERIFY(!scene.is2D());
+    CORRADE_VERIFY(!scene.is3D());
 }
 
 void SceneDataTest::constructZeroObjects() {
@@ -1660,6 +1644,110 @@ void SceneDataTest::constructMismatchedTRSViews() {
         "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Rotation object data [0xcafe0000:0xcafe0008]\n");
 }
 
+template<class> struct NameTraits;
+#define _c(format) template<> struct NameTraits<format> {                   \
+        static const char* name() { return #format; }                       \
+    };
+_c(UnsignedByte)
+_c(Byte)
+_c(UnsignedShort)
+_c(Short)
+_c(UnsignedInt)
+_c(Int)
+_c(UnsignedLong)
+_c(Long)
+_c(Float)
+_c(Double)
+_c(Vector2)
+_c(Vector2d)
+_c(Vector3)
+_c(Vector3d)
+_c(Matrix3)
+_c(Matrix3d)
+_c(Matrix4)
+_c(Matrix4d)
+_c(Complex)
+_c(Complexd)
+_c(Quaternion)
+_c(Quaterniond)
+_c(DualComplex)
+_c(DualComplexd)
+_c(DualQuaternion)
+_c(DualQuaterniond)
+template<class T> struct NameTraits<const T*> {
+    static const char* name() { return "Pointer"; }
+};
+template<class T> struct NameTraits<T*> {
+    static const char* name() { return "MutablePointer"; }
+};
+#undef _c
+
+template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    SceneFieldData transformationMatrices2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3<T>>::type(), nullptr};
+    SceneFieldData transformations2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualComplex<T>>::type(), nullptr};
+    SceneFieldData transformationMatrices3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4<T>>::type(), nullptr};
+    SceneFieldData transformations3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualQuaternion<T>>::type(), nullptr};
+    SceneFieldData translations2D{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
+    SceneFieldData translations3D{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
+    SceneFieldData rotations2D{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Complex<T>>::type(), nullptr};
+    SceneFieldData rotations3D{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Quaternion<T>>::type(), nullptr};
+    SceneFieldData scalings2D{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
+    SceneFieldData scalings3D{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
+
+    /* Test that all pairs get checked */
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, translations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, rotations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, scalings3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, translations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, rotations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, scalings3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations2D, rotations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations2D, scalings3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {rotations2D, scalings3D}};
+
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, translations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, rotations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, scalings2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, translations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, rotations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, scalings2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations3D, rotations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {translations3D, scalings2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {rotations3D, scalings2D}};
+    CORRADE_COMPARE(out.str(), Utility::formatString(
+        "Trade::SceneData: expected a 2D translation field but got Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData: expected a 2D translation field but got Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
+
+        "Trade::SceneData: expected a 3D translation field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D rotation field but got Trade::SceneFieldType::{3}\n"
+        "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D translation field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D rotation field but got Trade::SceneFieldType::{3}\n"
+        "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D rotation field but got Trade::SceneFieldType::{3}\n"
+        "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n",
+        NameTraits<Math::Vector3<T>>::name(),
+        NameTraits<Math::Quaternion<T>>::name(),
+        NameTraits<Math::Vector2<T>>::name(),
+        NameTraits<Math::Complex<T>>::name()));
+}
+
 void SceneDataTest::constructMismatchedMeshMaterialView() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
@@ -1743,48 +1831,6 @@ void SceneDataTest::constructMove() {
     CORRADE_VERIFY(std::is_nothrow_move_constructible<SceneData>::value);
     CORRADE_VERIFY(std::is_nothrow_move_assignable<SceneData>::value);
 }
-
-template<class> struct NameTraits;
-#define _c(format) template<> struct NameTraits<format> {                   \
-        static const char* name() { return #format; }                       \
-    };
-_c(UnsignedByte)
-_c(Byte)
-_c(UnsignedShort)
-_c(Short)
-_c(UnsignedInt)
-_c(Int)
-_c(UnsignedLong)
-_c(Long)
-_c(Float)
-_c(Double)
-_c(Vector2)
-_c(Vector2d)
-_c(Vector3)
-_c(Vector3d)
-_c(Matrix3)
-_c(Matrix3x3)
-_c(Matrix3d)
-_c(Matrix3x3d)
-_c(Matrix4)
-_c(Matrix4x4)
-_c(Matrix4d)
-_c(Matrix4x4d)
-_c(Complex)
-_c(Complexd)
-_c(Quaternion)
-_c(Quaterniond)
-_c(DualComplex)
-_c(DualComplexd)
-_c(DualQuaternion)
-_c(DualQuaterniond)
-template<class T> struct NameTraits<const T*> {
-    static const char* name() { return "Pointer"; }
-};
-template<class T> struct NameTraits<T*> {
-    static const char* name() { return "MutablePointer"; }
-};
-#undef _c
 
 template<class T> void SceneDataTest::objectsAsArrayByIndex() {
     setTestCaseTemplateName(NameTraits<T>::name());
@@ -2165,6 +2211,8 @@ template<class T> void SceneDataTest::transformations2DAsArray() {
             components.slice(&Component::scaling)},
     }};
 
+    CORRADE_VERIFY(scene.is2D());
+    CORRADE_VERIFY(!scene.is3D());
     CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView({
         Matrix3::translation({3.0f, 2.0f}),
         Matrix3::rotation(35.0_degf),
@@ -2216,6 +2264,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             translation
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3::translation({3.0f, 2.0f}),
             Matrix3{Math::IdentityInit},
@@ -2234,6 +2284,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             rotation
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3{Math::IdentityInit},
             Matrix3::rotation(35.0_degf),
@@ -2252,6 +2304,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             scaling
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3{Math::IdentityInit},
             Matrix3{Math::IdentityInit},
@@ -2274,6 +2328,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             translation,
             rotation
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3::translation({3.0f, 2.0f}),
             Matrix3::rotation(35.0_degf),
@@ -2293,6 +2349,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             translation,
             scaling
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3::translation({3.0f, 2.0f}),
             Matrix3{Math::IdentityInit},
@@ -2312,6 +2370,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             rotation,
             scaling
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3{Math::IdentityInit},
             Matrix3::rotation(35.0_degf),
@@ -2335,6 +2395,8 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             rotation,
             scaling
         }};
+        CORRADE_VERIFY(scene.is2D());
+        CORRADE_VERIFY(!scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
             Matrix3::translation({3.0f, 2.0f}),
             Matrix3::rotation(35.0_degf),
@@ -2352,27 +2414,7 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
     }
 }
 
-template<class T> void SceneDataTest::transformations2DAsArrayBut3DType() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
-    #ifdef CORRADE_NO_ASSERT
-    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
-    #endif
-
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<T>::type(), nullptr}
-    }};
-
-    std::ostringstream out;
-    Error redirectError{&out};
-    scene.transformations2DAsArray();
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformations2DInto(): field has a 3D transformation type Trade::SceneFieldType::{}\n", NameTraits<T>::name()));
-}
-
-template<class T> void SceneDataTest::transformations2DAsArrayBut3DTypeTRS() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
+void SceneDataTest::transformations2DAsArrayBut3DType() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2380,40 +2422,19 @@ template<class T> void SceneDataTest::transformations2DAsArrayBut3DTypeTRS() {
     /* Because TRSAsArray() allocates an Array<Triple> and then calls
        TRSInto(), which skips views that are nullptr, we wouldn't get the
        assertion for translations, as those are at offset 0, which would be
-       interpreted as an empty view if there were no elements. So we have to
-       supply at least one element to make all assertions trigger. */
-    struct Field {
-        UnsignedInt object;
-        Math::Vector3<T> translation;
-        Math::Quaternion<T> rotation;
-        Math::Vector3<T> scaling;
-    } data[1];
-    Containers::StridedArrayView1D<Field> view = data;
-    SceneData translation{SceneObjectType::UnsignedInt, 1, {}, data, {
-        SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
-    }};
-    SceneData rotation{SceneObjectType::UnsignedInt, 1, {}, data, {
-        SceneFieldData{SceneField::Rotation, view.slice(&Field::object), view.slice(&Field::rotation)}
-    }};
-    SceneData scaling{SceneObjectType::UnsignedInt, 1, {}, data, {
-        SceneFieldData{SceneField::Scaling, view.slice(&Field::object), view.slice(&Field::scaling)}
+       interpreted as an empty view if there were no elements. Thus using
+       rotations instead. */
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Quaternion, nullptr}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    translation.transformations2DAsArray();
-    translation.translationsRotationsScalings2DAsArray();
-    rotation.transformations2DAsArray();
-    rotation.translationsRotationsScalings2DAsArray();
-    scaling.transformations2DAsArray();
-    scaling.translationsRotationsScalings2DAsArray();
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformations2DInto(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationsRotationsScalings2DInto(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::transformations2DInto(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::translationsRotationsScalings2DInto(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::transformations2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationsRotationsScalings2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector3<T>>::name(), NameTraits<Math::Quaternion<T>>::name()));
+    scene.transformations2DAsArray();
+    scene.translationsRotationsScalings2DAsArray();
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::transformations2DInto(): scene has a 3D transformation type\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): scene has a 3D transformation type\n");
 }
 
 void SceneDataTest::transformations2DIntoArray() {
@@ -2740,6 +2761,8 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
             components.slice(&Component::scaling)},
     }};
 
+    CORRADE_VERIFY(!scene.is2D());
+    CORRADE_VERIFY(scene.is3D());
     CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView({
         Matrix4::translation({3.0f, 2.0f, -0.5f}),
         Matrix4::rotationY(35.0_degf),
@@ -2791,6 +2814,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             translation
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4::translation({3.0f, 2.0, 1.0f}),
             Matrix4{Math::IdentityInit},
@@ -2809,6 +2834,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             rotation
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4{Math::IdentityInit},
             Matrix4::rotationY(35.0_degf),
@@ -2827,6 +2854,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             scaling
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4{Math::IdentityInit},
             Matrix4{Math::IdentityInit},
@@ -2849,6 +2878,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             translation,
             rotation
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4::translation({3.0f, 2.0, 1.0f}),
             Matrix4::rotationY(35.0_degf),
@@ -2868,6 +2899,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             translation,
             scaling
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4::translation({3.0f, 2.0, 1.0f}),
             Matrix4{Math::IdentityInit},
@@ -2887,6 +2920,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             rotation,
             scaling
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4{Math::IdentityInit},
             Matrix4::rotationY(35.0_degf),
@@ -2910,6 +2945,8 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             rotation,
             scaling
         }};
+        CORRADE_VERIFY(!scene.is2D());
+        CORRADE_VERIFY(scene.is3D());
         CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
             Matrix4::translation({3.0f, 2.0, 1.0f}),
             Matrix4::rotationY(35.0_degf),
@@ -2927,27 +2964,7 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
     }
 }
 
-template<class T> void SceneDataTest::transformations3DAsArrayBut2DType() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
-    #ifdef CORRADE_NO_ASSERT
-    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
-    #endif
-
-    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<T>::type(), nullptr}
-    }};
-
-    std::ostringstream out;
-    Error redirectError{&out};
-    scene.transformations3DAsArray();
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformations3DInto(): field has a 2D transformation type Trade::SceneFieldType::{}\n", NameTraits<T>::name()));
-}
-
-template<class T> void SceneDataTest::transformations3DAsArrayBut2DTypeTRS() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
+void SceneDataTest::transformations3DAsArrayBut2DType() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2955,40 +2972,19 @@ template<class T> void SceneDataTest::transformations3DAsArrayBut2DTypeTRS() {
     /* Because TRSAsArray() allocates an Array<Triple> and then calls
        TRSInto(), which skips views that are nullptr, we wouldn't get the
        assertion for translations, as those are at offset 0, which would be
-       interpreted as an empty view if there were no elements. So we have to
-       supply at least one element to make all assertions trigger. */
-    struct Field {
-        UnsignedInt object;
-        Math::Vector2<T> translation;
-        Math::Complex<T> rotation;
-        Math::Vector2<T> scaling;
-    } data[1];
-    Containers::StridedArrayView1D<Field> view = data;
-    SceneData translation{SceneObjectType::UnsignedInt, 1, {}, data, {
-        SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
-    }};
-    SceneData rotation{SceneObjectType::UnsignedInt, 1, {}, data, {
-        SceneFieldData{SceneField::Rotation, view.slice(&Field::object), view.slice(&Field::rotation)}
-    }};
-    SceneData scaling{SceneObjectType::UnsignedInt, 1, {}, data, {
-        SceneFieldData{SceneField::Scaling, view.slice(&Field::object), view.slice(&Field::scaling)}
+       interpreted as an empty view if there were no elements. Thus using
+       rotations instead. */
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Complex, nullptr}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
-    translation.transformations3DAsArray();
-    translation.translationsRotationsScalings3DAsArray();
-    rotation.transformations3DAsArray();
-    rotation.translationsRotationsScalings3DAsArray();
-    scaling.transformations3DAsArray();
-    scaling.translationsRotationsScalings3DAsArray();
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformations3DInto(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationsRotationsScalings3DInto(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::transformations3DInto(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::translationsRotationsScalings3DInto(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::transformations3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationsRotationsScalings3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector2<T>>::name(), NameTraits<Math::Complex<T>>::name()));
+    scene.transformations3DAsArray();
+    scene.translationsRotationsScalings3DAsArray();
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::transformations3DInto(): scene has a 2D transformation type\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): scene has a 2D transformation type\n");
 }
 
 void SceneDataTest::transformations3DIntoArray() {
@@ -4387,56 +4383,22 @@ void SceneDataTest::transformation2DForTRS() {
         Containers::NullOpt);
 }
 
-template<class T> void SceneDataTest::transformation2DForBut3DType() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
+void SceneDataTest::transformation2DForBut3DType() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
     SceneData scene{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<T>::type(), nullptr}
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector3, nullptr}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
     scene.transformation2DFor(0);
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformation2DFor(): field has a 3D transformation type Trade::SceneFieldType::{}\n", NameTraits<T>::name()));
-}
-
-template<class T> void SceneDataTest::transformation2DForBut3DTypeTRS() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
-    #ifdef CORRADE_NO_ASSERT
-    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
-    #endif
-
-    SceneData translation{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr}
-    }};
-    SceneData rotation{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Quaternion<T>>::type(), nullptr}
-    }};
-    SceneData scaling{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr}
-    }};
-
-    std::ostringstream out;
-    Error redirectError{&out};
-    translation.transformation2DFor(0);
-    translation.translationRotationScaling2DFor(0);
-    rotation.transformation2DFor(0);
-    rotation.translationRotationScaling2DFor(0);
-    scaling.transformation2DFor(0);
-    scaling.translationRotationScaling2DFor(0);
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformation2DFor(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationRotationScaling2DFor(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::transformation2DFor(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::translationRotationScaling2DFor(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::transformation2DFor(): field has a 3D scaling type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationRotationScaling2DFor(): field has a 3D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector3<T>>::name(), NameTraits<Math::Quaternion<T>>::name()));
+    scene.translationRotationScaling2DFor(0);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::transformation2DFor(): scene has a 3D transformation type\n"
+        "Trade::SceneData::translationRotationScaling2DFor(): scene has a 3D transformation type\n");
 }
 
 void SceneDataTest::transformation3DFor() {
@@ -4513,56 +4475,22 @@ void SceneDataTest::transformation3DForTRS() {
         Containers::NullOpt);
 }
 
-template<class T> void SceneDataTest::transformation3DForBut2DType() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
+void SceneDataTest::transformation3DForBut2DType() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
     SceneData scene{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<T>::type(), nullptr}
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Vector2, nullptr}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
     scene.transformation3DFor(0);
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformation3DFor(): field has a 2D transformation type Trade::SceneFieldType::{}\n", NameTraits<T>::name()));
-}
-
-template<class T> void SceneDataTest::transformation3DForBut2DTypeTRS() {
-    setTestCaseTemplateName(NameTraits<T>::name());
-
-    #ifdef CORRADE_NO_ASSERT
-    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
-    #endif
-
-    SceneData translation{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr}
-    }};
-    SceneData rotation{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Complex<T>>::type(), nullptr}
-    }};
-    SceneData scaling{SceneObjectType::UnsignedInt, 1, nullptr, {
-        SceneFieldData{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr}
-    }};
-
-    std::ostringstream out;
-    Error redirectError{&out};
-    translation.transformation3DFor(0);
-    translation.translationRotationScaling3DFor(0);
-    rotation.transformation3DFor(0);
-    rotation.translationRotationScaling3DFor(0);
-    scaling.transformation3DFor(0);
-    scaling.translationRotationScaling3DFor(0);
-    CORRADE_COMPARE(out.str(), Utility::formatString(
-        "Trade::SceneData::transformation3DFor(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationRotationScaling3DFor(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::transformation3DFor(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::translationRotationScaling3DFor(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::transformation3DFor(): field has a 2D scaling type Trade::SceneFieldType::{0}\n"
-        "Trade::SceneData::translationRotationScaling3DFor(): field has a 2D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector2<T>>::name(), NameTraits<Math::Complex<T>>::name()));
+    scene.translationRotationScaling3DFor(0);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::transformation3DFor(): scene has a 2D transformation type\n"
+        "Trade::SceneData::translationRotationScaling3DFor(): scene has a 2D transformation type\n");
 }
 
 void SceneDataTest::meshesMaterialsFor() {

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -122,6 +122,7 @@ struct SceneDataTest: TestSuite::Tester {
     void objectsIntoArrayByIndex();
     void objectsIntoArrayByName();
     void objectsIntoArrayInvalidSizeOrOffset();
+
     template<class T> void parentsAsArray();
     void parentsIntoArray();
     void parentsIntoArrayInvalidSizeOrOffset();
@@ -129,6 +130,7 @@ struct SceneDataTest: TestSuite::Tester {
     template<class T, class U, class V> void transformations2DAsArrayTRS();
     void transformations2DAsArrayBut3DType();
     void transformations2DIntoArray();
+    void transformations2DTRSIntoArray();
     void transformations2DIntoArrayTRS();
     void transformations2DIntoArrayInvalidSizeOrOffset();
     void transformations2DIntoArrayInvalidSizeOrOffsetTRS();
@@ -136,6 +138,7 @@ struct SceneDataTest: TestSuite::Tester {
     template<class T, class U, class V> void transformations3DAsArrayTRS();
     void transformations3DAsArrayBut2DType();
     void transformations3DIntoArray();
+    void transformations3DTRSIntoArray();
     void transformations3DIntoArrayTRS();
     void transformations3DIntoArrayInvalidSizeOrOffset();
     void transformations3DIntoArrayInvalidSizeOrOffsetTRS();
@@ -210,6 +213,59 @@ const struct {
     {"one element in the middle", 1, 1, 1},
     {"suffix to a larger array", 2, 10, 1},
     {"offset at the end", 3, 10, 0}
+};
+
+const struct {
+    const char* name;
+    std::size_t offset;
+    std::size_t size;
+    std::size_t expectedSize;
+    bool objects, field;
+} IntoArrayOffset1Data[]{
+    {"whole", 0, 3, 3, true, true},
+    {"one element in the middle", 1, 1, 1, true, true},
+    {"suffix to a larger array", 2, 10, 1, true, true},
+    {"offset at the end", 3, 10, 0, true, true},
+    {"only objects", 0, 3, 3, true, false},
+    {"only field", 0, 3, 3, false, true},
+    {"neither", 0, 3, 0, false, false}
+};
+
+const struct {
+    const char* name;
+    std::size_t offset;
+    std::size_t size;
+    std::size_t expectedSize;
+    bool objects, field1, field2;
+} IntoArrayOffset2Data[]{
+    {"whole", 0, 3, 3, true, true, true},
+    {"one element in the middle", 1, 1, 1, true, true, true},
+    {"suffix to a larger array", 2, 10, 1, true, true, true},
+    {"offset at the end", 3, 10, 0, true, true, true},
+    {"only objects", 0, 3, 3, true, false, false},
+    {"only fields", 0, 3, 3, false, true, true},
+    {"only first field", 0, 3, 3, false, true, false},
+    {"only second field", 0, 3, 3, false, false, true},
+    {"none", 0, 3, 0, false, false, false}
+};
+
+const struct {
+    const char* name;
+    std::size_t offset;
+    std::size_t size;
+    std::size_t expectedSize;
+    bool objects, field1, field2, field3;
+} IntoArrayOffset3Data[]{
+    {"whole", 0, 3, 3, true, true, true, true},
+    {"one element in the middle", 1, 1, 1, true, true, true, true},
+    {"suffix to a larger array", 2, 10, 1, true, true, true, true},
+    {"offset at the end", 3, 10, 0, true, true, true, true},
+    {"only objects", 0, 3, 3, true, false, false, true},
+    {"only fields", 0, 3, 3, false, true, true, true},
+    {"only first field", 0, 3, 3, false, true, false, false},
+    {"only second field", 0, 3, 3, false, false, true, false},
+    {"only third field", 0, 3, 3, false, false, false, true},
+    {"none", 0, 3, 0, false, false, false, false}
 };
 
 #ifdef MAGNUM_BUILD_DEPRECATED
@@ -319,13 +375,14 @@ SceneDataTest::SceneDataTest() {
         Containers::arraySize(IntoArrayOffsetData));
 
     addTests({&SceneDataTest::objectsIntoArrayInvalidSizeOrOffset,
+
               &SceneDataTest::parentsAsArray<Byte>,
               &SceneDataTest::parentsAsArray<Short>,
               &SceneDataTest::parentsAsArray<Int>,
               &SceneDataTest::parentsAsArray<Long>});
 
     addInstancedTests({&SceneDataTest::parentsIntoArray},
-        Containers::arraySize(IntoArrayOffsetData));
+        Containers::arraySize(IntoArrayOffset1Data));
 
     addTests({&SceneDataTest::parentsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::transformations2DAsArray<Matrix3>,
@@ -339,8 +396,11 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations2DAsArrayBut3DType});
 
     addInstancedTests({&SceneDataTest::transformations2DIntoArray,
-                       &SceneDataTest::transformations2DIntoArrayTRS},
-        Containers::arraySize(IntoArrayOffsetData));
+                       &SceneDataTest::transformations2DTRSIntoArray},
+        Containers::arraySize(IntoArrayOffset1Data));
+
+    addInstancedTests({&SceneDataTest::transformations2DIntoArrayTRS},
+        Containers::arraySize(IntoArrayOffset3Data));
 
     addTests({&SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS,
@@ -355,8 +415,11 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations3DAsArrayBut2DType});
 
     addInstancedTests({&SceneDataTest::transformations3DIntoArray,
-                       &SceneDataTest::transformations3DIntoArrayTRS},
-        Containers::arraySize(IntoArrayOffsetData));
+                       &SceneDataTest::transformations3DTRSIntoArray},
+        Containers::arraySize(IntoArrayOffset1Data));
+
+    addInstancedTests({&SceneDataTest::transformations3DIntoArrayTRS},
+        Containers::arraySize(IntoArrayOffset3Data));
 
     addTests({&SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS,
@@ -365,7 +428,7 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::meshesMaterialsAsArray<UnsignedInt, Short>});
 
     addInstancedTests({&SceneDataTest::meshesMaterialsIntoArray},
-        Containers::arraySize(IntoArrayOffsetData));
+        Containers::arraySize(IntoArrayOffset2Data));
 
     addTests({&SceneDataTest::meshesMaterialsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::lightsAsArray<UnsignedByte>,
@@ -373,7 +436,7 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::lightsAsArray<UnsignedInt>});
 
     addInstancedTests({&SceneDataTest::lightsIntoArray},
-        Containers::arraySize(IntoArrayOffsetData));
+        Containers::arraySize(IntoArrayOffset1Data));
 
     addTests({&SceneDataTest::lightsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::camerasAsArray<UnsignedByte>,
@@ -381,7 +444,7 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::camerasAsArray<UnsignedInt>});
 
     addInstancedTests({&SceneDataTest::camerasIntoArray},
-        Containers::arraySize(IntoArrayOffsetData));
+        Containers::arraySize(IntoArrayOffset1Data));
 
     addTests({&SceneDataTest::camerasIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::skinsAsArray<UnsignedByte>,
@@ -389,14 +452,14 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::skinsAsArray<UnsignedInt>});
 
     addInstancedTests({&SceneDataTest::skinsIntoArray},
-        Containers::arraySize(IntoArrayOffsetData));
+        Containers::arraySize(IntoArrayOffset1Data));
 
     addTests({&SceneDataTest::skinsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::importerStateAsArray<const void*>,
               &SceneDataTest::importerStateAsArray<void*>});
 
     addInstancedTests({&SceneDataTest::importerStateIntoArray},
-        Containers::arraySize(IntoArrayOffsetData));
+        Containers::arraySize(IntoArrayOffset1Data));
 
     addTests({&SceneDataTest::importerStateIntoArrayInvalidSizeOrOffset,
 
@@ -2366,13 +2429,15 @@ template<class T> void SceneDataTest::parentsAsArray() {
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
 
-    CORRADE_COMPARE_AS(scene.parentsAsArray(),
-        Containers::arrayView({15, -1, 44}),
-        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.parentsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({
+        {0, 15},
+        {1, -1},
+        {15, 44}
+    })), TestSuite::Compare::Container);
 }
 
 void SceneDataTest::parentsIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -2400,17 +2465,32 @@ void SceneDataTest::parentsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        Int out[3];
-        scene.parentsInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        Int field[3];
+        scene.parentsInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::parent),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<Int> out{data.size};
-        CORRADE_COMPARE(scene.parentsInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Int> field{data.size};
+        CORRADE_COMPARE(scene.parentsInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::parent)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -2435,12 +2515,19 @@ void SceneDataTest::parentsIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    Int destination[2];
-    scene.parentsInto(destination);
-    scene.parentsInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    Int fieldDestinationCorrect[3];
+    Int fieldDestination[2];
+    scene.parentsInto(objectDestination, fieldDestinationCorrect);
+    scene.parentsInto(objectDestinationCorrect, fieldDestination);
+    scene.parentsInto(4, objectDestination, fieldDestination);
+    scene.parentsInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::parentsInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::parentsInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::parentsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::parentsInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::parentsInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::parentsInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> struct TransformationTypeFor {
@@ -2511,12 +2598,12 @@ template<class T> void SceneDataTest::transformations2DAsArray() {
 
     CORRADE_VERIFY(scene.is2D());
     CORRADE_VERIFY(!scene.is3D());
-    CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView({
-        Matrix3::translation({3.0f, 2.0f}),
-        Matrix3::rotation(35.0_degf),
-        Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation(-15.0_degf),
-        Matrix3::rotation(-15.0_degf)*Matrix3::translation({1.5f, 2.5f})
-    }), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+        {1, Matrix3::translation({3.0f, 2.0f})},
+        {0, Matrix3::rotation(35.0_degf)},
+        {4, Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation(-15.0_degf)},
+        {5, Matrix3::rotation(-15.0_degf)*Matrix3::translation({1.5f, 2.5f})}
+    })), TestSuite::Compare::Container);
 }
 
 template<class T, class U, class V> void SceneDataTest::transformations2DAsArrayTRS() {
@@ -2564,19 +2651,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3::translation({3.0f, 2.0f}),
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3::translation({1.5f, 2.5f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{1.5f, 2.5f}, {}, Vector2{1.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3::translation({3.0f, 2.0f})},
+            {0, Matrix3{Math::IdentityInit}},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3{Math::IdentityInit}},
+            {7, Matrix3::translation({1.5f, 2.5f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{3.0f, 2.0f}, {}, Vector2{1.0f}}},
+            {0, {{}, {}, Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, Vector2{1.0f}}},
+            {7, {{1.5f, 2.5f}, {}, Vector2{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -2584,19 +2671,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3{Math::IdentityInit},
-            Matrix3::rotation(35.0_degf),
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3::rotation(-15.0_degf)
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{}, {}, Vector2{1.0f}},
-            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, Complex::rotation(-15.0_degf), Vector2{1.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3{Math::IdentityInit}},
+            {0, Matrix3::rotation(35.0_degf)},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3{Math::IdentityInit}},
+            {7, Matrix3::rotation(-15.0_degf)}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{}, {}, Vector2{1.0f}}},
+            {0, {{}, Complex::rotation(35.0_degf), Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, Vector2{1.0f}}},
+            {7, {{}, Complex::rotation(-15.0_degf), Vector2{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -2604,19 +2691,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3::scaling({2.0f, 1.0f}),
-            Matrix3::scaling({-0.5f, 4.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, {2.0f, 1.0f}},
-            {{}, {}, {-0.5f, 4.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3{Math::IdentityInit}},
+            {0, Matrix3{Math::IdentityInit}},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3::scaling({2.0f, 1.0f})},
+            {7, Matrix3::scaling({-0.5f, 4.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{}, {}, Vector2{1.0f}}},
+            {0, {{}, {}, Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f}}},
+            {7, {{}, {}, {-0.5f, 4.0f}}},
         })), TestSuite::Compare::Container);
     }
 
@@ -2628,19 +2715,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3::translation({3.0f, 2.0f}),
-            Matrix3::rotation(35.0_degf),
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
-            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), Vector2{1.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3::translation({3.0f, 2.0f})},
+            {0, Matrix3::rotation(35.0_degf)},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3{Math::IdentityInit}},
+            {7, Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{3.0f, 2.0f}, {}, Vector2{1.0f}}},
+            {0, {{}, Complex::rotation(35.0_degf), Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, Vector2{1.0f}}},
+            {7, {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), Vector2{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -2649,19 +2736,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3::translation({3.0f, 2.0f}),
-            Matrix3{Math::IdentityInit},
-            Matrix3{Math::IdentityInit},
-            Matrix3::scaling({2.0f, 1.0f}),
-            Matrix3::translation({1.5f, 2.5f})*Matrix3::scaling({-0.5f, 4.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, {2.0f, 1.0f}},
-            {{1.5f, 2.5f}, {}, {-0.5f, 4.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3::translation({3.0f, 2.0f})},
+            {0, Matrix3{Math::IdentityInit}},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3::scaling({2.0f, 1.0f})},
+            {7, Matrix3::translation({1.5f, 2.5f})*Matrix3::scaling({-0.5f, 4.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{3.0f, 2.0f}, {}, Vector2{1.0f}}},
+            {0, {{}, {}, Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f}}},
+            {7, {{1.5f, 2.5f}, {}, {-0.5f, 4.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -2670,19 +2757,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3{Math::IdentityInit},
-            Matrix3::rotation(35.0_degf),
-            Matrix3{Math::IdentityInit},
-            Matrix3::scaling({2.0f, 1.0f}),
-            Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{}, {}, Vector2{1.0f}},
-            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, {2.0f, 1.0f}},
-            {{}, Complex::rotation(-15.0_degf), {-0.5f, 4.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3{Math::IdentityInit}},
+            {0, Matrix3::rotation(35.0_degf)},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3::scaling({2.0f, 1.0f})},
+            {7, Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{}, {}, Vector2{1.0f}}},
+            {0, {{}, Complex::rotation(35.0_degf), Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f}}},
+            {7, {{}, Complex::rotation(-15.0_degf), {-0.5f, 4.0f}}},
         })), TestSuite::Compare::Container);
     }
 
@@ -2695,19 +2782,19 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
         }};
         CORRADE_VERIFY(scene.is2D());
         CORRADE_VERIFY(!scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
-            Matrix3::translation({3.0f, 2.0f}),
-            Matrix3::rotation(35.0_degf),
-            Matrix3{Math::IdentityInit},
-            Matrix3::scaling({2.0f, 1.0f}),
-            Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
-            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
-            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
-            {{}, {}, Vector2{1.0f}},
-            {{}, {}, {2.0f, 1.0f}},
-            {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), {-0.5f, 4.0f}},
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix3>>({
+            {1, Matrix3::translation({3.0f, 2.0f})},
+            {0, Matrix3::rotation(35.0_degf)},
+            {2, Matrix3{Math::IdentityInit}},
+            {4, Matrix3::scaling({2.0f, 1.0f})},
+            {7, Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector2, Complex, Vector2>>>({
+            {1, {{3.0f, 2.0f}, {}, Vector2{1.0f}}},
+            {0, {{}, Complex::rotation(35.0_degf), Vector2{1.0f}}},
+            {2, {{}, {}, Vector2{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f}}},
+            {7, {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), {-0.5f, 4.0f}}},
         })), TestSuite::Compare::Container);
     }
 }
@@ -2736,7 +2823,7 @@ void SceneDataTest::transformations2DAsArrayBut3DType() {
 }
 
 void SceneDataTest::transformations2DIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -2764,30 +2851,44 @@ void SceneDataTest::transformations2DIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        Matrix3 out[3];
-        scene.transformations2DInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        Matrix3 field[3];
+        scene.transformations2DInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::transformation),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<Matrix3> out{data.size};
-        CORRADE_COMPARE(scene.transformations2DInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Matrix3> field{data.size};
+        CORRADE_COMPARE(scene.transformations2DInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::transformation)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
     }
 }
 
-void SceneDataTest::transformations2DIntoArrayTRS() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+void SceneDataTest::transformations2DTRSIntoArray() {
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
-    /* Both AsArray() and Into() share a common helper. The AsArray() test
-       above verified handling of various data types and this checks the
-       offset/size parameters of the Into() variant. */
+    /* Same APIs tested as in transformations2DIntoArray(), but with a TRS
+       input */
 
     struct Field {
         UnsignedInt object;
@@ -2824,113 +2925,125 @@ void SceneDataTest::transformations2DIntoArrayTRS() {
 
     /* The offset-less overload should give back all data */
     {
-        Matrix3 out[3];
-        scene.transformations2DInto(out);
-        CORRADE_COMPARE_AS(Containers::arrayView(out),
+        UnsignedInt objects[3];
+        Matrix3 field[3];
+        scene.transformations2DInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             Containers::arrayView(expected),
             TestSuite::Compare::Container);
 
-    /* Variant with TRS components */
+    /* The offset variant only a subset */
     } {
-        Vector2 translationsOut[3];
-        Complex rotationsOut[3];
-        Vector2 scalingsOut[3];
-        scene.translationsRotationsScalings2DInto(translationsOut, rotationsOut, scalingsOut);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Matrix3> field{data.size};
+        CORRADE_COMPARE(scene.transformations2DInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
+            Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::transformations2DIntoArrayTRS() {
+    auto&& data = IntoArrayOffset3Data[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Vector2 translation;
+        Complex rotation;
+        Vector2 scaling;
+    } fields[] {
+        {1, {3.0f, 2.0f}, {}, {1.5f, 2.0f}},
+        {0, {}, Complex::rotation(35.0_degf), {1.0f, 1.0f}},
+        {4, {3.0f, 2.0f}, Complex::rotation(35.0_degf), {1.0f, 1.0f}}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Translation,
+            view.slice(&Field::object),
+            view.slice(&Field::translation)},
+        SceneFieldData{SceneField::Rotation,
+            view.slice(&Field::object),
+            view.slice(&Field::rotation)},
+        SceneFieldData{SceneField::Scaling,
+            view.slice(&Field::object),
+            view.slice(&Field::scaling)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt objects[3];
+        Vector2 translations[3];
+        Complex rotations[3];
+        Vector2 scalings[3];
+        scene.translationsRotationsScalings2DInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field1 ? Containers::arrayView(translations) : nullptr,
+            data.field2 ? Containers::arrayView(rotations) : nullptr,
+            data.field3 ? Containers::arrayView(scalings) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field1) CORRADE_COMPARE_AS(Containers::stridedArrayView(translations),
             view.slice(&Field::translation),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
+        if(data.field2) CORRADE_COMPARE_AS(Containers::stridedArrayView(rotations),
             view.slice(&Field::rotation),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
+        if(data.field3) CORRADE_COMPARE_AS(Containers::stridedArrayView(scalings),
             view.slice(&Field::scaling),
             TestSuite::Compare::Container);
-
-    /* Variant with just translations */
-    } {
-        Vector2 translationsOut[3];
-        scene.translationsRotationsScalings2DInto(translationsOut, nullptr, nullptr);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
-            view.slice(&Field::translation),
-            TestSuite::Compare::Container);
-
-    /* Variant with just rotations */
-    } {
-        Complex rotationsOut[3];
-        scene.translationsRotationsScalings2DInto(nullptr, rotationsOut, nullptr);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
-            view.slice(&Field::rotation),
-            TestSuite::Compare::Container);
-
-    /* Variant with just scalings */
-    } {
-        Vector2 scalingsOut[3];
-        scene.translationsRotationsScalings2DInto(nullptr, nullptr, scalingsOut);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
-            view.slice(&Field::scaling),
-            TestSuite::Compare::Container);
-
-    /* Variant with neither is stupid, but should work too */
-    } {
-        scene.translationsRotationsScalings2DInto(nullptr, nullptr, nullptr);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<Matrix3> out{data.size};
-        CORRADE_COMPARE(scene.transformations2DInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
-            Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Vector2> translations{data.size};
+        Containers::Array<Complex> rotations{data.size};
+        Containers::Array<Vector2> scalings{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field1 ? arrayView(translations) : nullptr,
+            data.field2 ? arrayView(rotations) : nullptr,
+            data.field3 ? arrayView(scalings) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-
-    /* Variant with TRS components */
-    } {
-        Containers::Array<Vector2> translationsOut{data.size};
-        Containers::Array<Complex> rotationsOut{data.size};
-        Containers::Array<Vector2> scalingsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, translationsOut, rotationsOut, scalingsOut), data.expectedSize);
-        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
+        if(data.field1) CORRADE_COMPARE_AS(translations.prefix(data.expectedSize),
             view.slice(&Field::translation)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
+        if(data.field2) CORRADE_COMPARE_AS(rotations.prefix(data.expectedSize),
             view.slice(&Field::rotation)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
+        if(data.field3) CORRADE_COMPARE_AS(scalings.prefix(data.expectedSize),
             view.slice(&Field::scaling)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-
-    /* Variant with just translations */
-    } {
-        Containers::Array<Vector2> translationsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, translationsOut, nullptr, nullptr), data.expectedSize);
-        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
-            view.slice(&Field::translation)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with just rotations */
-    } {
-        Containers::Array<Complex> rotationsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, nullptr, rotationsOut, nullptr), data.expectedSize);
-        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
-            view.slice(&Field::rotation)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with just scalings */
-    } {
-        Containers::Array<Vector2> scalingsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, nullptr, nullptr, scalingsOut), data.expectedSize);
-        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
-            view.slice(&Field::scaling)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with neither is stupid, but should work too */
-    } {
-        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, nullptr, nullptr, nullptr), 0);
     }
 }
 
@@ -2952,12 +3065,19 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    Matrix3 destination[2];
-    scene.transformations2DInto(destination);
-    scene.transformations2DInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    Matrix3 fieldDestinationCorrect[3];
+    Matrix3 fieldDestination[2];
+    scene.transformations2DInto(objectDestination, fieldDestinationCorrect);
+    scene.transformations2DInto(objectDestinationCorrect, fieldDestination);
+    scene.transformations2DInto(4, objectDestination, fieldDestination);
+    scene.transformations2DInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::transformations2DInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::transformations2DInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::transformations2DInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::transformations2DInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::transformations2DInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::transformations2DInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS() {
@@ -2978,24 +3098,34 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS() {
 
     std::ostringstream out;
     Error redirectError{&out};
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
     Vector2 translationDestinationCorrect[3];
     Vector2 translationDestination[2];
     Complex rotationDestinationCorrect[3];
     Complex rotationDestination[2];
     Vector2 scalingDestinationCorrect[3];
     Vector2 scalingDestination[2];
-    scene.translationsRotationsScalings2DInto(translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
-    scene.translationsRotationsScalings2DInto(translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
-    scene.translationsRotationsScalings2DInto(translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
-    scene.translationsRotationsScalings2DInto(4, translationDestination, rotationDestination, scalingDestination);
-    scene.translationsRotationsScalings2DInto(0, translationDestinationCorrect, rotationDestination, nullptr);
-    scene.translationsRotationsScalings2DInto(0, translationDestinationCorrect, nullptr, scalingDestination);
-    scene.translationsRotationsScalings2DInto(0, nullptr, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings2DInto(objectDestination, translationDestinationCorrect, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(objectDestinationCorrect, translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings2DInto(4, objectDestination, translationDestination, rotationDestination, scalingDestination);
+    scene.translationsRotationsScalings2DInto(0, objectDestinationCorrect, translationDestination, nullptr, nullptr);
+    scene.translationsRotationsScalings2DInto(0, objectDestinationCorrect, nullptr, rotationDestination, nullptr);
+    scene.translationsRotationsScalings2DInto(0, objectDestinationCorrect, nullptr, nullptr, scalingDestination);
+    scene.translationsRotationsScalings2DInto(0, nullptr, translationDestinationCorrect, rotationDestination, nullptr);
+    scene.translationsRotationsScalings2DInto(0, nullptr, translationDestinationCorrect, nullptr, scalingDestination);
+    scene.translationsRotationsScalings2DInto(0, nullptr, nullptr, rotationDestinationCorrect, scalingDestination);
     CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::translationsRotationsScalings2DInto(): expected object destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected translation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected rotation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): expected scaling destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): object and translation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): object and rotation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): object and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): translation and rotation destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): translation and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings2DInto(): rotation and scaling destination views have different size, 3 vs 2\n");
@@ -3062,12 +3192,12 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
 
     CORRADE_VERIFY(!scene.is2D());
     CORRADE_VERIFY(scene.is3D());
-    CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView({
-        Matrix4::translation({3.0f, 2.0f, -0.5f}),
-        Matrix4::rotationY(35.0_degf),
-        Matrix4::translation({1.5f, 2.5f, 0.75f})*Matrix4::rotationX(-15.0_degf),
-        Matrix4::rotationX(-15.0_degf)*Matrix4::translation({1.5f, 2.5f, 0.75f})
-    }), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+        {1, Matrix4::translation({3.0f, 2.0f, -0.5f})},
+        {0, Matrix4::rotationY(35.0_degf)},
+        {4, Matrix4::translation({1.5f, 2.5f, 0.75f})*Matrix4::rotationX(-15.0_degf)},
+        {5, Matrix4::rotationX(-15.0_degf)*Matrix4::translation({1.5f, 2.5f, 0.75f})}
+    })), TestSuite::Compare::Container);
 }
 
 template<class T, class U, class V> void SceneDataTest::transformations3DAsArrayTRS() {
@@ -3115,19 +3245,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4::translation({3.0f, 2.0, 1.0f}),
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4::translation({1.5f, 2.5f, 3.5f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{1.5f, 2.5f, 3.5f}, {}, Vector3{1.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4::translation({3.0f, 2.0, 1.0f})},
+            {0, Matrix4{Math::IdentityInit}},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4{Math::IdentityInit}},
+            {7, Matrix4::translation({1.5f, 2.5f, 3.5f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}}},
+            {0, {{}, {}, Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, Vector3{1.0f}}},
+            {7, {{1.5f, 2.5f, 3.5f}, {}, Vector3{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -3135,19 +3265,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4{Math::IdentityInit},
-            Matrix4::rotationY(35.0_degf),
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4::rotationX(-15.0_degf)
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{}, {}, Vector3{1.0f}},
-            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4{Math::IdentityInit}},
+            {0, Matrix4::rotationY(35.0_degf)},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4{Math::IdentityInit}},
+            {7, Matrix4::rotationX(-15.0_degf)}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{}, {}, Vector3{1.0f}}},
+            {0, {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, Vector3{1.0f}}},
+            {7, {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -3155,19 +3285,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
-            Matrix4::scaling({-0.5f, 4.0f, -16.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, {2.0f, 1.0f, 0.0f}},
-            {{}, {}, {-0.5f, 4.0f, -16.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4{Math::IdentityInit}},
+            {0, Matrix4{Math::IdentityInit}},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4::scaling({2.0f, 1.0f, 0.0f})},
+            {7, Matrix4::scaling({-0.5f, 4.0f, -16.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{}, {}, Vector3{1.0f}}},
+            {0, {{}, {}, Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f, 0.0f}}},
+            {7, {{}, {}, {-0.5f, 4.0f, -16.0f}}},
         })), TestSuite::Compare::Container);
     }
 
@@ -3179,19 +3309,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4::translation({3.0f, 2.0, 1.0f}),
-            Matrix4::rotationY(35.0_degf),
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX(-15.0_degf)
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
-            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4::translation({3.0f, 2.0, 1.0f})},
+            {0, Matrix4::rotationY(35.0_degf)},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4{Math::IdentityInit}},
+            {7, Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX(-15.0_degf)}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}}},
+            {0, {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, Vector3{1.0f}}},
+            {7, {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -3200,19 +3330,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4::translation({3.0f, 2.0, 1.0f}),
-            Matrix4{Math::IdentityInit},
-            Matrix4{Math::IdentityInit},
-            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
-            Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, {2.0f, 1.0f, 0.0f}},
-            {{1.5f, 2.5f, 3.5f}, {}, {-0.5f, 4.0f, -16.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4::translation({3.0f, 2.0, 1.0f})},
+            {0, Matrix4{Math::IdentityInit}},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4::scaling({2.0f, 1.0f, 0.0f})},
+            {7, Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}}},
+            {0, {{}, {}, Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f, 0.0f}}},
+            {7, {{1.5f, 2.5f, 3.5f}, {}, {-0.5f, 4.0f, -16.0f}}},
         })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
@@ -3221,19 +3351,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4{Math::IdentityInit},
-            Matrix4::rotationY(35.0_degf),
-            Matrix4{Math::IdentityInit},
-            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
-            Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{}, {}, Vector3{1.0f}},
-            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, {2.0f, 1.0f, 0.0f}},
-            {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), {-0.5f, 4.0f, -16.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4{Math::IdentityInit}},
+            {0, Matrix4::rotationY(35.0_degf)},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4::scaling({2.0f, 1.0f, 0.0f})},
+            {7, Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{}, {}, Vector3{1.0f}}},
+            {0, {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f, 0.0f}}},
+            {7, {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), {-0.5f, 4.0f, -16.0f}}},
         })), TestSuite::Compare::Container);
     }
 
@@ -3246,19 +3376,19 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
         }};
         CORRADE_VERIFY(!scene.is2D());
         CORRADE_VERIFY(scene.is3D());
-        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
-            Matrix4::translation({3.0f, 2.0, 1.0f}),
-            Matrix4::rotationY(35.0_degf),
-            Matrix4{Math::IdentityInit},
-            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
-            Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
-        }), TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
-            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
-            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
-            {{}, {}, Vector3{1.0f}},
-            {{}, {}, {2.0f, 1.0f, 0.0f}},
-            {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), {-0.5f, 4.0f, -16.0f}},
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Matrix4>>({
+            {1, Matrix4::translation({3.0f, 2.0, 1.0f})},
+            {0, Matrix4::rotationY(35.0_degf)},
+            {2, Matrix4{Math::IdentityInit}},
+            {4, Matrix4::scaling({2.0f, 1.0f, 0.0f})},
+            {7, Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})}
+        })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Triple<Vector3, Quaternion, Vector3>>>({
+            {1, {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}}},
+            {0, {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}}},
+            {2, {{}, {}, Vector3{1.0f}}},
+            {4, {{}, {}, {2.0f, 1.0f, 0.0f}}},
+            {7, {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), {-0.5f, 4.0f, -16.0f}}},
         })), TestSuite::Compare::Container);
     }
 }
@@ -3287,7 +3417,7 @@ void SceneDataTest::transformations3DAsArrayBut2DType() {
 }
 
 void SceneDataTest::transformations3DIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -3315,30 +3445,44 @@ void SceneDataTest::transformations3DIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        Matrix4 out[3];
-        scene.transformations3DInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        Matrix4 field[3];
+        scene.transformations3DInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::transformation),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<Matrix4> out{data.size};
-        CORRADE_COMPARE(scene.transformations3DInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Matrix4> field{data.size};
+        CORRADE_COMPARE(scene.transformations3DInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::transformation)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
     }
 }
 
-void SceneDataTest::transformations3DIntoArrayTRS() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+void SceneDataTest::transformations3DTRSIntoArray() {
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
-    /* Both AsArray() and Into() share a common helper. The AsArray() test
-       above verified handling of various data types and this checks the
-       offset/size parameters of the Into() variant. */
+    /* Same APIs tested as in transformations3DIntoArray(), but with a TRS
+       input */
 
     struct Field {
         UnsignedInt object;
@@ -3375,113 +3519,125 @@ void SceneDataTest::transformations3DIntoArrayTRS() {
 
     /* The offset-less overload should give back all data */
     {
-        Matrix4 out[3];
-        scene.transformations3DInto(out);
-        CORRADE_COMPARE_AS(Containers::arrayView(out),
+        UnsignedInt objects[3];
+        Matrix4 field[3];
+        scene.transformations3DInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             Containers::arrayView(expected),
             TestSuite::Compare::Container);
 
-    /* Variant with TRS components */
+    /* The offset variant only a subset */
     } {
-        Vector3 translationsOut[3];
-        Quaternion rotationsOut[3];
-        Vector3 scalingsOut[3];
-        scene.translationsRotationsScalings3DInto(translationsOut, rotationsOut, scalingsOut);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Matrix4> field{data.size};
+        CORRADE_COMPARE(scene.transformations3DInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
+            Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::transformations3DIntoArrayTRS() {
+    auto&& data = IntoArrayOffset3Data[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Vector3 translation;
+        Quaternion rotation;
+        Vector3 scaling;
+    } fields[] {
+        {1, {3.0f, 2.0f, 1.0f}, {}, {1.5f, 2.0f, 4.5f}},
+        {0, {}, Quaternion::rotation(35.0_degf, Vector3::xAxis()), {1.0f, 1.0f, 1.0f}},
+        {4, {3.0f, 2.0f, 1.0f}, Quaternion::rotation(35.0_degf, Vector3::xAxis()), {1.0f, 1.0f, 1.0f}}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Translation,
+            view.slice(&Field::object),
+            view.slice(&Field::translation)},
+        SceneFieldData{SceneField::Rotation,
+            view.slice(&Field::object),
+            view.slice(&Field::rotation)},
+        SceneFieldData{SceneField::Scaling,
+            view.slice(&Field::object),
+            view.slice(&Field::scaling)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt objects[3];
+        Vector3 translations[3];
+        Quaternion rotations[3];
+        Vector3 scalings[3];
+        scene.translationsRotationsScalings3DInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field1 ? Containers::arrayView(translations) : nullptr,
+            data.field2 ? Containers::arrayView(rotations) : nullptr,
+            data.field3 ? Containers::arrayView(scalings) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field1) CORRADE_COMPARE_AS(Containers::stridedArrayView(translations),
             view.slice(&Field::translation),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
+        if(data.field2) CORRADE_COMPARE_AS(Containers::stridedArrayView(rotations),
             view.slice(&Field::rotation),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
+        if(data.field3) CORRADE_COMPARE_AS(Containers::stridedArrayView(scalings),
             view.slice(&Field::scaling),
             TestSuite::Compare::Container);
-
-    /* Variant with just translations */
-    } {
-        Vector3 translationsOut[3];
-        scene.translationsRotationsScalings3DInto(translationsOut, nullptr, nullptr);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
-            view.slice(&Field::translation),
-            TestSuite::Compare::Container);
-
-    /* Variant with just rotations */
-    } {
-        Quaternion rotationsOut[3];
-        scene.translationsRotationsScalings3DInto(nullptr, rotationsOut, nullptr);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
-            view.slice(&Field::rotation),
-            TestSuite::Compare::Container);
-
-    /* Variant with just scalings */
-    } {
-        Vector3 scalingsOut[3];
-        scene.translationsRotationsScalings3DInto(nullptr, nullptr, scalingsOut);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
-            view.slice(&Field::scaling),
-            TestSuite::Compare::Container);
-
-    /* Variant with neither is stupid, but should work too */
-    } {
-        scene.translationsRotationsScalings3DInto(nullptr, nullptr, nullptr);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<Matrix4> out{data.size};
-        CORRADE_COMPARE(scene.transformations3DInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
-            Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<Vector3> translations{data.size};
+        Containers::Array<Quaternion> rotations{data.size};
+        Containers::Array<Vector3> scalings{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field1 ? arrayView(translations) : nullptr,
+            data.field2 ? arrayView(rotations) : nullptr,
+            data.field3 ? arrayView(scalings) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-
-    /* Variant with TRS components */
-    } {
-        Containers::Array<Vector3> translationsOut{data.size};
-        Containers::Array<Quaternion> rotationsOut{data.size};
-        Containers::Array<Vector3> scalingsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, translationsOut, rotationsOut, scalingsOut), data.expectedSize);
-        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
+        if(data.field1) CORRADE_COMPARE_AS(translations.prefix(data.expectedSize),
             view.slice(&Field::translation)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
+        if(data.field2) CORRADE_COMPARE_AS(rotations.prefix(data.expectedSize),
             view.slice(&Field::rotation)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
+        if(data.field3) CORRADE_COMPARE_AS(scalings.prefix(data.expectedSize),
             view.slice(&Field::scaling)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-
-    /* Variant with just translations */
-    } {
-        Containers::Array<Vector3> translationsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, translationsOut, nullptr, nullptr), data.expectedSize);
-        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
-            view.slice(&Field::translation)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with just rotations */
-    } {
-        Containers::Array<Quaternion> rotationsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, nullptr, rotationsOut, nullptr), data.expectedSize);
-        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
-            view.slice(&Field::rotation)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with just scalings */
-    } {
-        Containers::Array<Vector3> scalingsOut{data.size};
-        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, nullptr, nullptr, scalingsOut), data.expectedSize);
-        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
-            view.slice(&Field::scaling)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with neither is stupid, but should work too */
-    } {
-        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, nullptr, nullptr, nullptr), 0);
     }
 }
 
@@ -3503,12 +3659,19 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    Matrix4 destination[2];
-    scene.transformations3DInto(destination);
-    scene.transformations3DInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    Matrix4 fieldDestinationCorrect[3];
+    Matrix4 fieldDestination[2];
+    scene.transformations3DInto(objectDestination, fieldDestinationCorrect);
+    scene.transformations3DInto(objectDestinationCorrect, fieldDestination);
+    scene.transformations3DInto(4, objectDestination, fieldDestination);
+    scene.transformations3DInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::transformations3DInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::transformations3DInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::transformations3DInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::transformations3DInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::transformations3DInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::transformations3DInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS() {
@@ -3529,24 +3692,34 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS() {
 
     std::ostringstream out;
     Error redirectError{&out};
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
     Vector3 translationDestinationCorrect[3];
     Vector3 translationDestination[2];
     Quaternion rotationDestinationCorrect[3];
     Quaternion rotationDestination[2];
     Vector3 scalingDestinationCorrect[3];
     Vector3 scalingDestination[2];
-    scene.translationsRotationsScalings3DInto(translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
-    scene.translationsRotationsScalings3DInto(translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
-    scene.translationsRotationsScalings3DInto(translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
-    scene.translationsRotationsScalings3DInto(4, translationDestination, rotationDestination, scalingDestination);
-    scene.translationsRotationsScalings3DInto(0, translationDestinationCorrect, rotationDestination, nullptr);
-    scene.translationsRotationsScalings3DInto(0, translationDestinationCorrect, nullptr, scalingDestination);
-    scene.translationsRotationsScalings3DInto(0, nullptr, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings3DInto(objectDestination, translationDestinationCorrect, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(objectDestinationCorrect, translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(objectDestinationCorrect, translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings3DInto(4, objectDestination, translationDestination, rotationDestination, scalingDestination);
+    scene.translationsRotationsScalings3DInto(0, objectDestinationCorrect, translationDestination, nullptr, nullptr);
+    scene.translationsRotationsScalings3DInto(0, objectDestinationCorrect, nullptr, rotationDestination, nullptr);
+    scene.translationsRotationsScalings3DInto(0, objectDestinationCorrect, nullptr, nullptr, scalingDestination);
+    scene.translationsRotationsScalings3DInto(0, nullptr, translationDestinationCorrect, rotationDestination, nullptr);
+    scene.translationsRotationsScalings3DInto(0, nullptr, translationDestinationCorrect, nullptr, scalingDestination);
+    scene.translationsRotationsScalings3DInto(0, nullptr, nullptr, rotationDestinationCorrect, scalingDestination);
     CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::translationsRotationsScalings3DInto(): expected object destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected translation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected rotation destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): expected scaling destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): object and translation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): object and rotation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): object and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): translation and rotation destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): translation and scaling destination views have different size, 3 vs 2\n"
         "Trade::SceneData::translationsRotationsScalings3DInto(): rotation and scaling destination views have different size, 3 vs 2\n");
@@ -3583,12 +3756,11 @@ template<class T, class U> void SceneDataTest::meshesMaterialsAsArray() {
             meshMaterials
         }};
 
-        CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(),
-            (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({
-                {15, 3},
-                {37, -1},
-                {44, 25}
-            })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>>({
+            {0, {15, 3}},
+            {1, {37, -1}},
+            {15, {44, 25}}
+        })), TestSuite::Compare::Container);
 
     /* Only meshes */
     } {
@@ -3596,17 +3768,16 @@ template<class T, class U> void SceneDataTest::meshesMaterialsAsArray() {
             meshes
         }};
 
-        CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(),
-            (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({
-                {15, -1},
-                {37, -1},
-                {44, -1}
-            })), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>>({
+            {0, {15, -1}},
+            {1, {37, -1}},
+            {15, {44, -1}}
+        })), TestSuite::Compare::Container);
     }
 }
 
 void SceneDataTest::meshesMaterialsIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset2Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -3638,71 +3809,46 @@ void SceneDataTest::meshesMaterialsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt meshesOut[3];
-        Int meshMaterialsOut[3];
-        scene.meshesMaterialsInto(meshesOut, meshMaterialsOut);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(meshesOut),
+        UnsignedInt objects[3];
+        UnsignedInt meshes[3];
+        Int meshMaterials[3];
+        scene.meshesMaterialsInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field1 ? Containers::arrayView(meshes) : nullptr,
+            data.field2 ? Containers::arrayView(meshMaterials) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field1) CORRADE_COMPARE_AS(Containers::stridedArrayView(meshes),
             view.slice(&Field::mesh),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(meshMaterialsOut),
+        if(data.field2) CORRADE_COMPARE_AS(Containers::stridedArrayView(meshMaterials),
             view.slice(&Field::meshMaterial),
             TestSuite::Compare::Container);
-
-    /* Variant with just meshes */
-    } {
-        UnsignedInt meshesOut[3];
-        scene.meshesMaterialsInto(meshesOut, nullptr);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(meshesOut),
-            view.slice(&Field::mesh),
-            TestSuite::Compare::Container);
-
-    /* Variant with just materials */
-    } {
-        Int meshMaterialsOut[3];
-        scene.meshesMaterialsInto(nullptr, meshMaterialsOut);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(meshMaterialsOut),
-            view.slice(&Field::meshMaterial),
-            TestSuite::Compare::Container);
-
-    /* Variant with neither is stupid, but should work too */
-    } {
-        scene.meshesMaterialsInto(nullptr, nullptr);
 
     /* The offset variant should give back only a subset */
     } {
-        Containers::Array<UnsignedInt> meshesOut{data.size};
-        Containers::Array<Int> meshMaterialsOut{data.size};
-        CORRADE_COMPARE(scene.meshesMaterialsInto(data.offset, meshesOut, meshMaterialsOut), data.expectedSize);
-        CORRADE_COMPARE_AS(meshesOut.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> meshes{data.size};
+        Containers::Array<Int> meshMaterials{data.size};
+        CORRADE_COMPARE(scene.meshesMaterialsInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field1 ? arrayView(meshes) : nullptr,
+            data.field2 ? arrayView(meshMaterials) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field1) CORRADE_COMPARE_AS(meshes.prefix(data.expectedSize),
             view.slice(&Field::mesh)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-        CORRADE_COMPARE_AS(meshMaterialsOut.prefix(data.expectedSize),
+        if(data.field2) CORRADE_COMPARE_AS(meshMaterials.prefix(data.expectedSize),
             view.slice(&Field::meshMaterial)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
-
-    /* Variant with just meshes */
-    } {
-        Containers::Array<UnsignedInt> meshesOut{data.size};
-        CORRADE_COMPARE(scene.meshesMaterialsInto(data.offset, meshesOut, nullptr), data.expectedSize);
-        CORRADE_COMPARE_AS(meshesOut.prefix(data.expectedSize),
-            view.slice(&Field::mesh)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with just materials */
-    } {
-        Containers::Array<Int> meshMaterialsOut{data.size};
-        CORRADE_COMPARE(scene.meshesMaterialsInto(data.offset, nullptr, meshMaterialsOut), data.expectedSize);
-        CORRADE_COMPARE_AS(meshMaterialsOut.prefix(data.expectedSize),
-            view.slice(&Field::meshMaterial)
-                .slice(data.offset, data.offset + data.expectedSize),
-            TestSuite::Compare::Container);
-
-    /* Variant with neither is stupid, but should work too */
-    } {
-        CORRADE_COMPARE(scene.meshesMaterialsInto(data.offset, nullptr, nullptr), 0);
     }
 }
 
@@ -3724,18 +3870,26 @@ void SceneDataTest::meshesMaterialsIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
     UnsignedInt meshDestinationCorrect[3];
     UnsignedInt meshDestination[2];
     Int meshMaterialDestinationCorrect[3];
     Int meshMaterialDestination[2];
-    scene.meshesMaterialsInto(meshDestination, meshMaterialDestinationCorrect);
-    scene.meshesMaterialsInto(meshDestinationCorrect, meshMaterialDestination);
-    scene.meshesMaterialsInto(4, meshDestination, meshMaterialDestination);
-    scene.meshesMaterialsInto(0, meshDestinationCorrect, meshMaterialDestination);
+    scene.meshesMaterialsInto(objectDestination, meshDestinationCorrect, meshMaterialDestinationCorrect);
+    scene.meshesMaterialsInto(objectDestinationCorrect, meshDestination, meshMaterialDestinationCorrect);
+    scene.meshesMaterialsInto(objectDestinationCorrect, meshDestinationCorrect, meshMaterialDestination);
+    scene.meshesMaterialsInto(4, objectDestination, meshDestination, meshMaterialDestination);
+    scene.meshesMaterialsInto(0, objectDestinationCorrect, meshDestination, nullptr);
+    scene.meshesMaterialsInto(0, objectDestinationCorrect, nullptr, meshMaterialDestination);
+    scene.meshesMaterialsInto(0, nullptr, meshDestinationCorrect, meshMaterialDestination);
     CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::meshesMaterialsInto(): expected object destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::meshesMaterialsInto(): expected mesh destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::meshesMaterialsInto(): expected mesh material destination view either empty or with 3 elements but got 2\n"
         "Trade::SceneData::meshesMaterialsInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::meshesMaterialsInto(): object and mesh destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::meshesMaterialsInto(): object and mesh material destination views have different size, 3 vs 2\n"
         "Trade::SceneData::meshesMaterialsInto(): mesh and mesh material destination views have different size, 3 vs 2\n");
 }
 
@@ -3759,13 +3913,15 @@ template<class T> void SceneDataTest::lightsAsArray() {
         SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
     }};
 
-    CORRADE_COMPARE_AS(scene.lightsAsArray(),
-        Containers::arrayView<UnsignedInt>({15, 37, 44}),
-        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.lightsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, UnsignedInt>>({
+        {0, 15},
+        {1, 37},
+        {15, 44}
+    })), TestSuite::Compare::Container);
 }
 
 void SceneDataTest::lightsIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -3793,17 +3949,32 @@ void SceneDataTest::lightsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt out[3];
-        scene.lightsInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        UnsignedInt field[3];
+        scene.lightsInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::light),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> out{data.size};
-        CORRADE_COMPARE(scene.lightsInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> field{data.size};
+        CORRADE_COMPARE(scene.lightsInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::light)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3828,12 +3999,19 @@ void SceneDataTest::lightsIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt destination[2];
-    scene.lightsInto(destination);
-    scene.lightsInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    UnsignedInt fieldDestinationCorrect[3];
+    UnsignedInt fieldDestination[2];
+    scene.lightsInto(objectDestination, fieldDestinationCorrect);
+    scene.lightsInto(objectDestinationCorrect, fieldDestination);
+    scene.lightsInto(4, objectDestination, fieldDestination);
+    scene.lightsInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::lightsInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::lightsInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::lightsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::lightsInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::lightsInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::lightsInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::camerasAsArray() {
@@ -3856,13 +4034,15 @@ template<class T> void SceneDataTest::camerasAsArray() {
         SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
     }};
 
-    CORRADE_COMPARE_AS(scene.camerasAsArray(),
-        Containers::arrayView<UnsignedInt>({15, 37, 44}),
-        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.camerasAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, UnsignedInt>>({
+        {0, 15},
+        {1, 37},
+        {15, 44}
+    })), TestSuite::Compare::Container);
 }
 
 void SceneDataTest::camerasIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -3890,17 +4070,32 @@ void SceneDataTest::camerasIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt out[3];
-        scene.camerasInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        UnsignedInt field[3];
+        scene.camerasInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::camera),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> out{data.size};
-        CORRADE_COMPARE(scene.camerasInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> field{data.size};
+        CORRADE_COMPARE(scene.camerasInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::camera)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -3925,12 +4120,19 @@ void SceneDataTest::camerasIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt destination[2];
-    scene.camerasInto(destination);
-    scene.camerasInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    UnsignedInt fieldDestinationCorrect[3];
+    UnsignedInt fieldDestination[2];
+    scene.camerasInto(objectDestination, fieldDestinationCorrect);
+    scene.camerasInto(objectDestinationCorrect, fieldDestination);
+    scene.camerasInto(4, objectDestination, fieldDestination);
+    scene.camerasInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::camerasInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::camerasInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::camerasInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::camerasInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::camerasInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::camerasInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::skinsAsArray() {
@@ -3955,13 +4157,15 @@ template<class T> void SceneDataTest::skinsAsArray() {
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
-    CORRADE_COMPARE_AS(scene.skinsAsArray(),
-        Containers::arrayView<UnsignedInt>({15, 37, 44}),
-        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.skinsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, UnsignedInt>>({
+        {0, 15},
+        {1, 37},
+        {15, 44}
+    })), TestSuite::Compare::Container);
 }
 
 void SceneDataTest::skinsIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -3991,17 +4195,32 @@ void SceneDataTest::skinsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt out[3];
-        scene.skinsInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        UnsignedInt field[3];
+        scene.skinsInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::skin),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> out{data.size};
-        CORRADE_COMPARE(scene.skinsInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<UnsignedInt> field{data.size};
+        CORRADE_COMPARE(scene.skinsInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::skin)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -4029,12 +4248,19 @@ void SceneDataTest::skinsIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt destination[2];
-    scene.skinsInto(destination);
-    scene.skinsInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    UnsignedInt fieldDestinationCorrect[3];
+    UnsignedInt fieldDestination[2];
+    scene.skinsInto(objectDestination, fieldDestinationCorrect);
+    scene.skinsInto(objectDestinationCorrect, fieldDestination);
+    scene.skinsInto(4, objectDestination, fieldDestination);
+    scene.skinsInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::skinsInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::skinsInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::skinsInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::skinsInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::skinsInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::skinsInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::importerStateAsArray() {
@@ -4059,13 +4285,15 @@ template<class T> void SceneDataTest::importerStateAsArray() {
         SceneFieldData{SceneField::ImporterState, view.slice(&Field::object), view.slice(&Field::importerState)}
     }};
 
-    CORRADE_COMPARE_AS(scene.importerStateAsArray(),
-        Containers::arrayView<const void*>({&a, nullptr, &b}),
-        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.importerStateAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, const void*>>({
+        {0, &a},
+        {1, nullptr},
+        {15, &b}
+    })), TestSuite::Compare::Container);
 }
 
 void SceneDataTest::importerStateIntoArray() {
-    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    auto&& data = IntoArrayOffset1Data[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
     /* Both AsArray() and Into() share a common helper. The AsArray() test
@@ -4095,17 +4323,32 @@ void SceneDataTest::importerStateIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        const void* out[3];
-        scene.importerStateInto(out);
-        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+        UnsignedInt objects[3];
+        const void* field[3];
+        scene.importerStateInto(
+            data.objects ? Containers::arrayView(objects) : nullptr,
+            data.field ? Containers::arrayView(field) : nullptr
+        );
+        if(data.objects) CORRADE_COMPARE_AS(Containers::stridedArrayView(objects),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(Containers::stridedArrayView(field),
             view.slice(&Field::importerState),
             TestSuite::Compare::Container);
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<const void*> out{data.size};
-        CORRADE_COMPARE(scene.importerStateInto(data.offset, out), data.expectedSize);
-        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+        Containers::Array<UnsignedInt> objects{data.size};
+        Containers::Array<const void*> field{data.size};
+        CORRADE_COMPARE(scene.importerStateInto(data.offset,
+            data.objects ? arrayView(objects) : nullptr,
+            data.field ? arrayView(field) : nullptr
+        ), data.expectedSize);
+        if(data.objects) CORRADE_COMPARE_AS(objects.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        if(data.field) CORRADE_COMPARE_AS(field.prefix(data.expectedSize),
             view.slice(&Field::importerState)
                 .slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
@@ -4130,12 +4373,19 @@ void SceneDataTest::importerStateIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    const void* destination[2];
-    scene.importerStateInto(destination);
-    scene.importerStateInto(4, destination);
+    UnsignedInt objectDestinationCorrect[3];
+    UnsignedInt objectDestination[2];
+    const void* fieldDestinationCorrect[3];
+    const void* fieldDestination[2];
+    scene.importerStateInto(objectDestination, fieldDestinationCorrect);
+    scene.importerStateInto(objectDestinationCorrect, fieldDestination);
+    scene.importerStateInto(4, objectDestination, fieldDestination);
+    scene.importerStateInto(0, objectDestinationCorrect, fieldDestination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::importerStateInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::importerStateInto(): offset 4 out of bounds for a field of size 3\n");
+        "Trade::SceneData::importerStateInto(): expected object destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::importerStateInto(): expected field destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::importerStateInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::importerStateInto(): object and field destination views have different size, 3 vs 2\n");
 }
 
 void SceneDataTest::mutableAccessNotAllowed() {
@@ -4312,35 +4562,35 @@ void SceneDataTest::fieldNotFound() {
     scene.mutableField<UnsignedInt[]>(sceneFieldCustom(666));
 
     scene.parentsAsArray();
-    scene.parentsInto(nullptr);
-    scene.parentsInto(0, nullptr);
+    scene.parentsInto(nullptr, nullptr);
+    scene.parentsInto(0, nullptr, nullptr);
     scene.transformations2DAsArray();
-    scene.transformations2DInto(nullptr);
-    scene.transformations2DInto(0, nullptr);
+    scene.transformations2DInto(nullptr, nullptr);
+    scene.transformations2DInto(0, nullptr, nullptr);
     scene.translationsRotationsScalings2DAsArray();
-    scene.translationsRotationsScalings2DInto(nullptr, nullptr, nullptr);
-    scene.translationsRotationsScalings2DInto(0, nullptr, nullptr, nullptr);
+    scene.translationsRotationsScalings2DInto(nullptr, nullptr, nullptr, nullptr);
+    scene.translationsRotationsScalings2DInto(0, nullptr, nullptr, nullptr, nullptr);
     scene.transformations3DAsArray();
-    scene.transformations3DInto(nullptr);
-    scene.transformations3DInto(0, nullptr);
+    scene.transformations3DInto(nullptr, nullptr);
+    scene.transformations3DInto(0, nullptr, nullptr);
     scene.translationsRotationsScalings3DAsArray();
-    scene.translationsRotationsScalings3DInto(nullptr, nullptr, nullptr);
-    scene.translationsRotationsScalings3DInto(0, nullptr, nullptr, nullptr);
+    scene.translationsRotationsScalings3DInto(nullptr, nullptr, nullptr, nullptr);
+    scene.translationsRotationsScalings3DInto(0, nullptr, nullptr, nullptr, nullptr);
     scene.meshesMaterialsAsArray();
-    scene.meshesMaterialsInto(nullptr, nullptr);
-    scene.meshesMaterialsInto(0, nullptr, nullptr);
+    scene.meshesMaterialsInto(nullptr, nullptr, nullptr);
+    scene.meshesMaterialsInto(0, nullptr, nullptr, nullptr);
     scene.lightsAsArray();
-    scene.lightsInto(nullptr);
-    scene.lightsInto(0, nullptr);
+    scene.lightsInto(nullptr, nullptr);
+    scene.lightsInto(0, nullptr, nullptr);
     scene.camerasAsArray();
-    scene.camerasInto(nullptr);
-    scene.camerasInto(0, nullptr);
+    scene.camerasInto(nullptr, nullptr);
+    scene.camerasInto(0, nullptr, nullptr);
     scene.skinsAsArray();
-    scene.skinsInto(nullptr);
-    scene.skinsInto(0, nullptr);
+    scene.skinsInto(nullptr, nullptr);
+    scene.skinsInto(0, nullptr, nullptr);
     scene.importerStateAsArray();
-    scene.importerStateInto(nullptr);
-    scene.importerStateInto(0, nullptr);
+    scene.importerStateInto(nullptr, nullptr);
+    scene.importerStateInto(0, nullptr, nullptr);
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData::findFieldObjectOffset(): index 2 out of range for 2 fields\n"
         "Trade::SceneData::fieldObjectOffset(): index 2 out of range for 2 fields\n"

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -23,9 +23,18 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#include <sstream>
+#include <Corrade/Containers/ArrayTuple.h>
 #include <Corrade/TestSuite/Tester.h>
+#include <Corrade/TestSuite/Compare/Container.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/FormatStl.h>
 
 #include "Magnum/Magnum.h"
+#include "Magnum/Math/Half.h"
+#include "Magnum/Math/DualComplex.h"
+#include "Magnum/Math/DualQuaternion.h"
+#include "Magnum/Math/Range.h"
 #include "Magnum/Trade/SceneData.h"
 
 namespace Magnum { namespace Trade { namespace Test { namespace {
@@ -33,24 +42,1526 @@ namespace Magnum { namespace Trade { namespace Test { namespace {
 struct SceneDataTest: TestSuite::Tester {
     explicit SceneDataTest();
 
+    void objectTypeSize();
+    void objectTypeSizeInvalid();
+    void debugObjectType();
+
+    void customFieldName();
+    void customFieldNameTooLarge();
+    void customFieldNameNotCustom();
+    void debugFieldName();
+
+    void fieldTypeSize();
+    void fieldTypeSizeInvalid();
+    void debugFieldType();
+
+    void constructField();
+    void constructFieldDefault();
+    void constructFieldCustom();
+    void constructField2D();
+    void constructFieldTypeErased();
+    void constructFieldNonOwningArray();
+    void constructFieldOffsetOnly();
+    void constructFieldArray();
+    void constructFieldArray2D();
+    void constructFieldArrayTypeErased();
+    void constructFieldArrayOffsetOnly();
+
+    void constructFieldWrongType();
+    void constructFieldInconsistentViewSize();
+    void constructFieldTooLargeObjectStride();
+    void constructFieldTooLargeFieldStride();
+    void constructFieldWrongDataAccess();
+    void constructField2DWrongSize();
+    void constructField2DNonContiguous();
+    void constructFieldArrayNonContiguous();
+    void constructFieldArrayNotAllowed();
+    void constructFieldArray2DWrongSize();
+    void constructFieldArray2DNonContiguous();
+
     void construct();
+    void constructZeroFields();
+    void constructZeroObjects();
+
+    void constructNotOwned();
+
+    void constructDuplicateField();
+    void constructDuplicateCustomField();
+    void constructInconsistentObjectType();
+    void constructObjectDataNotContained();
+    void constructFieldDataNotContained();
+    void constructObjectTypeTooSmall();
+    void constructNotOwnedFlagOwned();
+    void constructMismatchedTRSViews();
+    void constructMismatchedMeshMaterialView();
+
     void constructCopy();
     void constructMove();
+
+    template<class T> void objectsAsArrayByIndex();
+    template<class T> void objectsAsArrayByName();
+    void objectsAsArrayLongType();
+    void objectsIntoArrayInvalidSize();
+    template<class T> void parentsAsArray();
+    #ifndef CORRADE_TARGET_32BIT
+    void parentsAsArrayLongType();
+    #endif
+    void parentsIntoArrayInvalidSize();
+    template<class T> void transformations2DAsArray();
+    template<class T> void transformations2DAsArrayTRS();
+    template<class T> void transformations2DAsArrayBut3DType();
+    template<class T> void transformations2DAsArrayBut3DTypeTRS();
+    void transformations2DIntoArrayInvalidSize();
+    template<class T> void transformations3DAsArray();
+    template<class T> void transformations3DAsArrayTRS();
+    template<class T> void transformations3DAsArrayBut2DType();
+    template<class T> void transformations3DAsArrayBut2DTypeTRS();
+    void transformations3DIntoArrayInvalidSize();
+    template<class T> void meshesAsArray();
+    void meshesIntoArrayInvalidSize();
+    template<class T> void meshMaterialsAsArray();
+    void meshMaterialsIntoArrayInvalidSize();
+    template<class T> void lightsAsArray();
+    void lightsIntoArrayInvalidSize();
+    template<class T> void camerasAsArray();
+    void camerasIntoArrayInvalidSize();
+    template<class T> void skinsAsArray();
+    void skinsIntoArrayInvalidSize();
+
+    void mutableAccessNotAllowed();
+
+    void objectsNotFound();
+    void objectsWrongType();
+
+    void fieldNotFound();
+    void fieldWrongType();
+    void fieldWrongArrayAccess();
+
+    void releaseFieldData();
+    void releaseData();
+};
+
+const struct {
+    const char* name;
+    DataFlags dataFlags;
+} NotOwnedData[]{
+    {"", {}},
+    {"mutable", DataFlag::Mutable}
 };
 
 SceneDataTest::SceneDataTest() {
-    addTests({&SceneDataTest::construct,
+    addTests({&SceneDataTest::objectTypeSize,
+              &SceneDataTest::objectTypeSizeInvalid,
+              &SceneDataTest::debugObjectType,
+
+              &SceneDataTest::customFieldName,
+              &SceneDataTest::customFieldNameTooLarge,
+              &SceneDataTest::customFieldNameNotCustom,
+              &SceneDataTest::debugFieldName,
+
+              &SceneDataTest::fieldTypeSize,
+              &SceneDataTest::fieldTypeSizeInvalid,
+              &SceneDataTest::debugFieldType,
+
+              &SceneDataTest::constructField,
+              &SceneDataTest::constructFieldDefault,
+              &SceneDataTest::constructFieldCustom,
+              &SceneDataTest::constructField2D,
+              &SceneDataTest::constructFieldTypeErased,
+              &SceneDataTest::constructFieldNonOwningArray,
+              &SceneDataTest::constructFieldOffsetOnly,
+              &SceneDataTest::constructFieldArray,
+              &SceneDataTest::constructFieldArray2D,
+              &SceneDataTest::constructFieldArrayTypeErased,
+              &SceneDataTest::constructFieldArrayOffsetOnly,
+
+              &SceneDataTest::constructFieldWrongType,
+              &SceneDataTest::constructFieldInconsistentViewSize,
+              &SceneDataTest::constructFieldTooLargeObjectStride,
+              &SceneDataTest::constructFieldTooLargeFieldStride,
+              &SceneDataTest::constructFieldWrongDataAccess,
+              &SceneDataTest::constructField2DWrongSize,
+              &SceneDataTest::constructField2DNonContiguous,
+              &SceneDataTest::constructFieldArrayNonContiguous,
+              &SceneDataTest::constructFieldArrayNotAllowed,
+              &SceneDataTest::constructFieldArray2DWrongSize,
+              &SceneDataTest::constructFieldArray2DNonContiguous,
+
+              &SceneDataTest::construct,
+              &SceneDataTest::constructZeroFields,
+              &SceneDataTest::constructZeroObjects});
+
+    addInstancedTests({&SceneDataTest::constructNotOwned},
+        Containers::arraySize(NotOwnedData));
+
+    addTests({&SceneDataTest::constructDuplicateField,
+              &SceneDataTest::constructDuplicateCustomField,
+              &SceneDataTest::constructInconsistentObjectType,
+              &SceneDataTest::constructObjectDataNotContained,
+              &SceneDataTest::constructFieldDataNotContained,
+              &SceneDataTest::constructObjectTypeTooSmall,
+              &SceneDataTest::constructNotOwnedFlagOwned,
+              &SceneDataTest::constructMismatchedTRSViews,
+              &SceneDataTest::constructMismatchedMeshMaterialView,
+
               &SceneDataTest::constructCopy,
-              &SceneDataTest::constructMove});
+              &SceneDataTest::constructMove,
+
+              &SceneDataTest::objectsAsArrayByIndex<UnsignedByte>,
+              &SceneDataTest::objectsAsArrayByIndex<UnsignedShort>,
+              &SceneDataTest::objectsAsArrayByIndex<UnsignedInt>,
+              &SceneDataTest::objectsAsArrayByIndex<UnsignedLong>,
+              &SceneDataTest::objectsAsArrayByName<UnsignedByte>,
+              &SceneDataTest::objectsAsArrayByName<UnsignedShort>,
+              &SceneDataTest::objectsAsArrayByName<UnsignedInt>,
+              &SceneDataTest::objectsAsArrayByName<UnsignedLong>,
+              &SceneDataTest::objectsAsArrayLongType,
+              &SceneDataTest::objectsIntoArrayInvalidSize,
+              &SceneDataTest::parentsAsArray<Byte>,
+              &SceneDataTest::parentsAsArray<Short>,
+              &SceneDataTest::parentsAsArray<Int>,
+              &SceneDataTest::parentsAsArray<Long>,
+              #ifndef CORRADE_TARGET_32BIT
+              &SceneDataTest::parentsAsArrayLongType,
+              #endif
+              &SceneDataTest::parentsIntoArrayInvalidSize,
+              &SceneDataTest::transformations2DAsArray<Matrix3>,
+              &SceneDataTest::transformations2DAsArray<Matrix3d>,
+              &SceneDataTest::transformations2DAsArray<DualComplex>,
+              &SceneDataTest::transformations2DAsArray<DualComplexd>,
+              &SceneDataTest::transformations2DAsArrayTRS<Float>,
+              &SceneDataTest::transformations2DAsArrayTRS<Double>,
+              &SceneDataTest::transformations2DAsArrayBut3DType<Matrix4x4>,
+              &SceneDataTest::transformations2DAsArrayBut3DType<Matrix4x4d>,
+              &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaternion>,
+              &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaterniond>,
+              &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Float>,
+              &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Double>,
+              &SceneDataTest::transformations2DIntoArrayInvalidSize,
+              &SceneDataTest::transformations3DAsArray<Matrix4>,
+              &SceneDataTest::transformations3DAsArray<Matrix4d>,
+              &SceneDataTest::transformations3DAsArray<DualQuaternion>,
+              &SceneDataTest::transformations3DAsArray<DualQuaterniond>,
+              &SceneDataTest::transformations3DAsArrayTRS<Float>,
+              &SceneDataTest::transformations3DAsArrayTRS<Double>,
+              &SceneDataTest::transformations3DAsArrayBut2DType<Matrix3x3>,
+              &SceneDataTest::transformations3DAsArrayBut2DType<Matrix3x3d>,
+              &SceneDataTest::transformations3DAsArrayBut2DType<DualComplex>,
+              &SceneDataTest::transformations3DAsArrayBut2DType<DualComplexd>,
+              &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Float>,
+              &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Double>,
+              &SceneDataTest::transformations3DIntoArrayInvalidSize,
+              &SceneDataTest::meshesAsArray<UnsignedByte>,
+              &SceneDataTest::meshesAsArray<UnsignedShort>,
+              &SceneDataTest::meshesAsArray<UnsignedInt>,
+              &SceneDataTest::meshesIntoArrayInvalidSize,
+              &SceneDataTest::meshMaterialsAsArray<UnsignedByte>,
+              &SceneDataTest::meshMaterialsAsArray<UnsignedShort>,
+              &SceneDataTest::meshMaterialsAsArray<UnsignedInt>,
+              &SceneDataTest::meshMaterialsIntoArrayInvalidSize,
+              &SceneDataTest::lightsAsArray<UnsignedByte>,
+              &SceneDataTest::lightsAsArray<UnsignedShort>,
+              &SceneDataTest::lightsAsArray<UnsignedInt>,
+              &SceneDataTest::lightsIntoArrayInvalidSize,
+              &SceneDataTest::camerasAsArray<UnsignedByte>,
+              &SceneDataTest::camerasAsArray<UnsignedShort>,
+              &SceneDataTest::camerasAsArray<UnsignedInt>,
+              &SceneDataTest::camerasIntoArrayInvalidSize,
+              &SceneDataTest::skinsAsArray<UnsignedByte>,
+              &SceneDataTest::skinsAsArray<UnsignedShort>,
+              &SceneDataTest::skinsAsArray<UnsignedInt>,
+              &SceneDataTest::skinsIntoArrayInvalidSize,
+
+              &SceneDataTest::mutableAccessNotAllowed,
+
+              &SceneDataTest::objectsNotFound,
+              &SceneDataTest::objectsWrongType,
+
+              &SceneDataTest::fieldNotFound,
+              &SceneDataTest::fieldWrongType,
+              &SceneDataTest::fieldWrongArrayAccess,
+
+              &SceneDataTest::releaseFieldData,
+              &SceneDataTest::releaseData});
+}
+
+using namespace Math::Literals;
+
+void SceneDataTest::objectTypeSize() {
+    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedByte), 1);
+    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedShort), 2);
+    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedInt), 4);
+    CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedLong), 8);
+}
+
+void SceneDataTest::objectTypeSizeInvalid() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    std::ostringstream out;
+    Error redirectError{&out};
+
+    sceneObjectTypeSize(SceneObjectType{});
+    sceneObjectTypeSize(SceneObjectType(0x73));
+
+    CORRADE_COMPARE(out.str(),
+        "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x0)\n"
+        "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x73)\n");
+}
+
+void SceneDataTest::debugObjectType() {
+    std::ostringstream out;
+    Debug{&out} << SceneObjectType::UnsignedLong << SceneObjectType(0x73);
+    CORRADE_COMPARE(out.str(), "Trade::SceneObjectType::UnsignedLong Trade::SceneObjectType(0x73)\n");
+}
+
+void SceneDataTest::customFieldName() {
+    CORRADE_VERIFY(!isSceneFieldCustom(SceneField::Rotation));
+    CORRADE_VERIFY(!isSceneFieldCustom(SceneField(0x0fffffffu)));
+    CORRADE_VERIFY(isSceneFieldCustom(SceneField::Custom));
+    CORRADE_VERIFY(isSceneFieldCustom(SceneField(0x80000000u)));
+
+    CORRADE_COMPARE(UnsignedInt(sceneFieldCustom(0)), 0x80000000u);
+    CORRADE_COMPARE(UnsignedInt(sceneFieldCustom(0xabcd)), 0x8000abcdu);
+    CORRADE_COMPARE(UnsignedInt(sceneFieldCustom(0x7fffffff)), 0xffffffffu);
+
+    CORRADE_COMPARE(sceneFieldCustom(SceneField::Custom), 0);
+    CORRADE_COMPARE(sceneFieldCustom(SceneField(0x8000abcdu)), 0xabcd);
+    CORRADE_COMPARE(sceneFieldCustom(SceneField(0xffffffffu)), 0x7fffffffu);
+
+    constexpr bool is = isSceneFieldCustom(SceneField(0x8000abcdu));
+    CORRADE_VERIFY(is);
+    constexpr SceneField a = sceneFieldCustom(0xabcd);
+    CORRADE_COMPARE(UnsignedInt(a), 0x8000abcdu);
+    constexpr UnsignedInt b = sceneFieldCustom(a);
+    CORRADE_COMPARE(b, 0xabcd);
+}
+
+void SceneDataTest::customFieldNameTooLarge() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    sceneFieldCustom(1u << 31);
+    CORRADE_COMPARE(out.str(), "Trade::sceneFieldCustom(): index 2147483648 too large\n");
+}
+
+void SceneDataTest::customFieldNameNotCustom() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    sceneFieldCustom(SceneField::Transformation);
+    CORRADE_COMPARE(out.str(), "Trade::sceneFieldCustom(): Trade::SceneField::Transformation is not custom\n");
+}
+
+void SceneDataTest::debugFieldName() {
+    std::ostringstream out;
+    Debug{&out} << SceneField::Transformation << sceneFieldCustom(73) << SceneField(0xdeadda7);
+    CORRADE_COMPARE(out.str(), "Trade::SceneField::Transformation Trade::SceneField::Custom(73) Trade::SceneField(0xdeadda7)\n");
+}
+
+void SceneDataTest::fieldTypeSize() {
+    /* Test at least one of every size */
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Byte), sizeof(Byte));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Degh), sizeof(Degh));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Vector3ub), sizeof(Vector3ub));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Range1Dh), sizeof(Range1Dh));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Vector3s), sizeof(Vector3s));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Long), sizeof(Long));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x2h), sizeof(Matrix3x2h));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix4x2h), sizeof(Matrix4x2h));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x3h), sizeof(Matrix3x3h));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Range3Di), sizeof(Range3Di));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::DualQuaternion), sizeof(DualQuaternion));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x3), sizeof(Matrix3x3));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x2d), sizeof(Matrix3x2d));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::DualQuaterniond), sizeof(DualQuaterniond));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x3d), sizeof(Matrix3x3d));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x4d), sizeof(Matrix3x4d));
+    CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix4x4d), sizeof(Matrix4x4d));
+}
+
+void SceneDataTest::fieldTypeSizeInvalid() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    std::ostringstream out;
+    Error redirectError{&out};
+
+    sceneFieldTypeSize(SceneFieldType{});
+    sceneFieldTypeSize(SceneFieldType(0xdead));
+
+    CORRADE_COMPARE(out.str(),
+        "Trade::sceneFieldTypeSize(): invalid type Trade::SceneFieldType(0x0)\n"
+        "Trade::sceneFieldTypeSize(): invalid type Trade::SceneFieldType(0xdead)\n");
+}
+
+void SceneDataTest::debugFieldType() {
+    std::ostringstream out;
+    Debug{&out} << SceneFieldType::Matrix3x4h << SceneFieldType(0xdead);
+    CORRADE_COMPARE(out.str(), "Trade::SceneFieldType::Matrix3x4h Trade::SceneFieldType(0xdead)\n");
+}
+
+constexpr Complexd Rotations2D[3] {
+    Complexd{Constantsd::sqrtHalf(), Constantsd::sqrtHalf()}, /* 45° */
+    Complexd{1.0, 0.0}, /* 0° */
+    Complexd{0.0, 1.0}, /* 90° */
+};
+const UnsignedShort RotationObjects2D[3] {
+    17,
+    35,
+    98
+};
+
+void SceneDataTest::constructField() {
+    const UnsignedShort rotationObjectData[3]{};
+    const Complexd rotationFieldData[3];
+
+    SceneFieldData rotations{SceneField::Rotation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
+    CORRADE_VERIFY(!rotations.isOffsetOnly());
+    CORRADE_COMPARE(rotations.name(), SceneField::Rotation);
+    CORRADE_COMPARE(rotations.size(), 3);
+    CORRADE_COMPARE(rotations.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(rotations.objectData().size(), 3);
+    CORRADE_COMPARE(rotations.objectData().stride(), sizeof(UnsignedShort));
+    CORRADE_VERIFY(rotations.objectData().data() == rotationObjectData);
+    CORRADE_COMPARE(rotations.fieldType(), SceneFieldType::Complexd);
+    CORRADE_COMPARE(rotations.fieldArraySize(), 0);
+    CORRADE_COMPARE(rotations.fieldData().size(), 3);
+    CORRADE_COMPARE(rotations.fieldData().stride(), sizeof(Complexd));
+    CORRADE_VERIFY(rotations.fieldData().data() == rotationFieldData);
+
+    /* This is allowed too for simplicity, the parameter has to be large enough
+       tho */
+    char someArray[3*sizeof(Complexd)];
+    CORRADE_COMPARE(rotations.fieldData(someArray).size(), 3);
+    CORRADE_COMPARE(rotations.fieldData(someArray).stride(), sizeof(Complexd));
+    CORRADE_VERIFY(rotations.fieldData(someArray).data() == rotationFieldData);
+    CORRADE_COMPARE(rotations.objectData(someArray).size(), 3);
+    CORRADE_COMPARE(rotations.objectData(someArray).stride(), sizeof(UnsignedShort));
+    CORRADE_VERIFY(rotations.objectData(someArray).data() == rotationObjectData);
+
+    constexpr SceneFieldData crotations{SceneField::Rotation, Containers::arrayView(RotationObjects2D), Containers::arrayView(Rotations2D)};
+    constexpr bool isOffsetOnly = crotations.isOffsetOnly();
+    constexpr SceneField name = crotations.name();
+    constexpr SceneObjectType objectType = crotations.objectType();
+    constexpr Containers::StridedArrayView1D<const void> objectData = crotations.objectData();
+    constexpr SceneFieldType fieldType = crotations.fieldType();
+    constexpr UnsignedShort fieldArraySize = crotations.fieldArraySize();
+    constexpr Containers::StridedArrayView1D<const void> fieldData = crotations.fieldData();
+    CORRADE_VERIFY(!isOffsetOnly);
+    CORRADE_COMPARE(name, SceneField::Rotation);
+    CORRADE_COMPARE(objectType, SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(objectData.size(), 3);
+    CORRADE_COMPARE(objectData.stride(), sizeof(UnsignedShort));
+    CORRADE_COMPARE(objectData.data(), RotationObjects2D);
+    CORRADE_COMPARE(fieldType, SceneFieldType::Complexd);
+    CORRADE_COMPARE(fieldArraySize, 0);
+    CORRADE_COMPARE(fieldData.size(), 3);
+    CORRADE_COMPARE(fieldData.stride(), sizeof(Complexd));
+    CORRADE_COMPARE(fieldData.data(), Rotations2D);
+}
+
+void SceneDataTest::constructFieldDefault() {
+    SceneFieldData data;
+    CORRADE_COMPARE(data.name(), SceneField{});
+    CORRADE_COMPARE(data.fieldType(), SceneFieldType{});
+    CORRADE_COMPARE(data.objectType(), SceneObjectType{});
+
+    constexpr SceneFieldData cdata;
+    CORRADE_COMPARE(cdata.name(), SceneField{});
+    CORRADE_COMPARE(cdata.fieldType(), SceneFieldType{});
+    CORRADE_COMPARE(cdata.objectType(), SceneObjectType{});
+}
+
+void SceneDataTest::constructFieldCustom() {
+    /* Verifying it doesn't hit any assertion about disallowed type for given
+       attribute */
+
+    const UnsignedByte rangeObjectData[3]{};
+    const Range2Dh rangeFieldData[3];
+    SceneFieldData ranges{sceneFieldCustom(13), Containers::arrayView(rangeObjectData), Containers::arrayView(rangeFieldData)};
+    CORRADE_COMPARE(ranges.name(), sceneFieldCustom(13));
+    CORRADE_COMPARE(ranges.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_VERIFY(ranges.objectData().data() == rangeObjectData);
+    CORRADE_COMPARE(ranges.fieldType(), SceneFieldType::Range2Dh);
+    CORRADE_VERIFY(ranges.fieldData().data() == rangeFieldData);
+}
+
+void SceneDataTest::constructField2D() {
+    char rotationObjectData[6*sizeof(UnsignedShort)];
+    char rotationFieldData[6*sizeof(Complexd)];
+    auto rotationObjectView = Containers::StridedArrayView2D<char>{rotationObjectData, {6, sizeof(UnsignedShort)}}.every(2);
+    auto rotationFieldView = Containers::StridedArrayView2D<char>{rotationFieldData, {6, sizeof(Complexd)}}.every(2);
+
+    SceneFieldData rotations{SceneField::Rotation, rotationObjectView, SceneFieldType::Complexd, rotationFieldView};
+    CORRADE_VERIFY(!rotations.isOffsetOnly());
+    CORRADE_COMPARE(rotations.name(), SceneField::Rotation);
+    CORRADE_COMPARE(rotations.size(), 3);
+    CORRADE_COMPARE(rotations.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(rotations.objectData().size(), 3);
+    CORRADE_COMPARE(rotations.objectData().stride(), 2*sizeof(UnsignedShort));
+    CORRADE_COMPARE(rotations.objectData().data(), rotationObjectView.data());
+    CORRADE_COMPARE(rotations.fieldType(), SceneFieldType::Complexd);
+    CORRADE_COMPARE(rotations.fieldArraySize(), 0);
+    CORRADE_COMPARE(rotations.fieldData().size(), 3);
+    CORRADE_COMPARE(rotations.fieldData().stride(), 2*sizeof(Complexd));
+    CORRADE_COMPARE(rotations.fieldData().data(), rotationFieldView.data());
+}
+
+void SceneDataTest::constructFieldTypeErased() {
+    const UnsignedLong scalingObjectData[3]{};
+    const Vector3 scalingFieldData[3];
+    SceneFieldData scalings{SceneField::Scaling, SceneObjectType::UnsignedLong, Containers::arrayCast<const char>(Containers::stridedArrayView(scalingObjectData)), SceneFieldType::Vector3, Containers::arrayCast<const char>(Containers::stridedArrayView(scalingFieldData))};
+    CORRADE_VERIFY(!scalings.isOffsetOnly());
+    CORRADE_COMPARE(scalings.name(), SceneField::Scaling);
+    CORRADE_COMPARE(scalings.size(), 3);
+    CORRADE_COMPARE(scalings.objectType(), SceneObjectType::UnsignedLong);
+    CORRADE_COMPARE(scalings.objectData().size(), 3);
+    CORRADE_COMPARE(scalings.objectData().stride(), sizeof(UnsignedLong));
+    CORRADE_COMPARE(scalings.objectData().data(), scalingObjectData);
+    CORRADE_COMPARE(scalings.fieldType(), SceneFieldType::Vector3);
+    CORRADE_COMPARE(scalings.fieldArraySize(), 0);
+    CORRADE_COMPARE(scalings.fieldData().size(), 3);
+    CORRADE_COMPARE(scalings.fieldData().stride(), sizeof(Vector3));
+    CORRADE_COMPARE(scalings.fieldData().data(), scalingFieldData);
+}
+
+void SceneDataTest::constructFieldNonOwningArray() {
+    const SceneFieldData data[3];
+    Containers::Array<SceneFieldData> array = sceneFieldDataNonOwningArray(data);
+    CORRADE_COMPARE(array.size(), 3);
+    CORRADE_COMPARE(static_cast<const void*>(array.data()), data);
+}
+
+void SceneDataTest::constructFieldOffsetOnly() {
+    struct Data {
+        Byte parent;
+        UnsignedShort object;
+        Vector2 translation;
+    } data[] {
+        {0, 2, {2.0f, 3.0f}},
+        {0, 15, {67.0f, -1.1f}}
+    };
+
+    SceneFieldData a{SceneField::Translation, 2, SceneObjectType::UnsignedShort, offsetof(Data, object), sizeof(Data), SceneFieldType::Vector2, offsetof(Data, translation), sizeof(Data)};
+    CORRADE_VERIFY(a.isOffsetOnly());
+    CORRADE_COMPARE(a.name(), SceneField::Translation);
+    CORRADE_COMPARE(a.size(), 2);
+    CORRADE_COMPARE(a.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(a.objectData(data).size(), 2);
+    CORRADE_COMPARE(a.objectData(data).stride(), sizeof(Data));
+    CORRADE_COMPARE_AS(Containers::arrayCast<const UnsignedShort>(a.objectData(data)),
+        Containers::arrayView<UnsignedShort>({2, 15}),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE(a.fieldType(), SceneFieldType::Vector2);
+    CORRADE_COMPARE(a.fieldArraySize(), 0);
+    CORRADE_COMPARE(a.fieldData(data).size(), 2);
+    CORRADE_COMPARE(a.fieldData(data).stride(), sizeof(Data));
+    CORRADE_COMPARE_AS(Containers::arrayCast<const Vector2>(a.fieldData(data)),
+        Containers::arrayView<Vector2>({{2.0f, 3.0f}, {67.0f, -1.1f}}),
+        TestSuite::Compare::Container);
+}
+
+constexpr UnsignedByte ArrayOffsetObjectData[3]{};
+constexpr Int ArrayOffsetFieldData[3*4]{};
+
+void SceneDataTest::constructFieldArray() {
+    UnsignedByte offsetObjectData[3];
+    Int offsetFieldData[3*4];
+    SceneFieldData data{sceneFieldCustom(34), Containers::arrayView(offsetObjectData), Containers::StridedArrayView2D<Int>{offsetFieldData, {3, 4}}};
+    CORRADE_VERIFY(!data.isOffsetOnly());
+    CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
+    CORRADE_COMPARE(data.size(), 3);
+    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(data.objectData().size(), 3);
+    CORRADE_COMPARE(data.objectData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(data.objectData().data() == offsetObjectData);
+    CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(data.fieldArraySize(), 4);
+    CORRADE_COMPARE(data.fieldData().size(), 3);
+    CORRADE_COMPARE(data.fieldData().stride(), 4*sizeof(Int));
+    CORRADE_VERIFY(data.fieldData().data() == offsetFieldData);
+
+    constexpr SceneFieldData cdata{sceneFieldCustom(34), Containers::arrayView(ArrayOffsetObjectData), Containers::StridedArrayView2D<const Int>{ArrayOffsetFieldData, {3, 4}}};
+    CORRADE_VERIFY(!cdata.isOffsetOnly());
+    CORRADE_COMPARE(cdata.name(), sceneFieldCustom(34));
+    CORRADE_COMPARE(cdata.size(), 3);
+    CORRADE_COMPARE(cdata.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(cdata.objectData().size(), 3);
+    CORRADE_COMPARE(cdata.objectData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(cdata.objectData().data() == ArrayOffsetObjectData);
+    CORRADE_COMPARE(cdata.fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(cdata.fieldArraySize(), 4);
+    CORRADE_COMPARE(cdata.fieldData().size(), 3);
+    CORRADE_COMPARE(cdata.fieldData().stride(), 4*sizeof(Int));
+    CORRADE_VERIFY(cdata.fieldData().data() == ArrayOffsetFieldData);
+}
+
+void SceneDataTest::constructFieldArray2D() {
+    char offsetObjectData[3*sizeof(UnsignedByte)];
+    char offsetFieldData[3*4*sizeof(Int)];
+    SceneFieldData data{sceneFieldCustom(34), Containers::StridedArrayView2D<char>{offsetObjectData, {3, sizeof(UnsignedByte)}}, SceneFieldType::Int, Containers::StridedArrayView2D<char>{offsetFieldData, {3, 4*sizeof(Int)}}, 4};
+    CORRADE_VERIFY(!data.isOffsetOnly());
+    CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
+    CORRADE_COMPARE(data.size(), 3);
+    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(data.objectData().size(), 3);
+    CORRADE_COMPARE(data.objectData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(data.objectData().data() == offsetObjectData);
+    CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(data.fieldArraySize(), 4);
+    CORRADE_COMPARE(data.fieldData().size(), 3);
+    CORRADE_COMPARE(data.fieldData().stride(), 4*sizeof(Int));
+    CORRADE_VERIFY(data.fieldData().data() == offsetFieldData);
+}
+
+void SceneDataTest::constructFieldArrayTypeErased() {
+    Int offsetData[3*4];
+    Containers::StridedArrayView1D<Int> offset{offsetData, 3, 4*sizeof(Int)};
+    UnsignedByte offsetObjectData[3];
+    SceneFieldData data{sceneFieldCustom(34), SceneObjectType::UnsignedByte, Containers::arrayCast<const char>(Containers::stridedArrayView(offsetObjectData)), SceneFieldType::Int, Containers::arrayCast<const char>(offset), 4};
+    CORRADE_VERIFY(!data.isOffsetOnly());
+    CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
+    CORRADE_COMPARE(data.size(), 3);
+    CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(data.objectData().size(), 3);
+    CORRADE_COMPARE(data.objectData().stride(), sizeof(UnsignedByte));
+    CORRADE_VERIFY(data.objectData().data() == offsetObjectData);
+    CORRADE_COMPARE(data.fieldArraySize(), 4);
+    CORRADE_COMPARE(data.fieldData().size(), 3);
+    CORRADE_COMPARE(data.fieldData().stride(), 4*sizeof(Int));
+    CORRADE_VERIFY(data.fieldData().data() == offsetData);
+}
+
+void SceneDataTest::constructFieldArrayOffsetOnly() {
+    struct Data {
+        Byte parent;
+        UnsignedByte object;
+        Int offset[4];
+    };
+
+    SceneFieldData data{sceneFieldCustom(34), 3, SceneObjectType::UnsignedByte, offsetof(Data, object), sizeof(Data), SceneFieldType::Int, offsetof(Data, offset), sizeof(Data), 4};
+    CORRADE_VERIFY(data.isOffsetOnly());
+    CORRADE_COMPARE(data.name(), sceneFieldCustom(34));
+    CORRADE_COMPARE(data.size(), 3);
+    CORRADE_COMPARE(data.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(data.fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(data.fieldArraySize(), 4);
+
+    Data actual[3];
+    CORRADE_COMPARE(data.fieldData(actual).size(), 3);
+    CORRADE_COMPARE(data.fieldData(actual).stride(), sizeof(Data));
+    CORRADE_VERIFY(data.fieldData(actual).data() == &actual[0].offset);
+    CORRADE_COMPARE(data.objectData(actual).size(), 3);
+    CORRADE_COMPARE(data.objectData(actual).stride(), sizeof(Data));
+    CORRADE_VERIFY(data.objectData(actual).data() == &actual[0].object);
+
+    constexpr SceneFieldData cdata{sceneFieldCustom(34), 3, SceneObjectType::UnsignedByte, offsetof(Data, object), sizeof(Data), SceneFieldType::Int, offsetof(Data, offset), sizeof(Data), 4};
+    CORRADE_VERIFY(cdata.isOffsetOnly());
+    CORRADE_COMPARE(cdata.name(), sceneFieldCustom(34));
+    CORRADE_COMPARE(cdata.size(), 3);
+    CORRADE_COMPARE(cdata.objectType(), SceneObjectType::UnsignedByte);
+    CORRADE_COMPARE(cdata.fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(cdata.fieldArraySize(), 4);
+}
+
+void SceneDataTest::constructFieldInconsistentViewSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    const UnsignedShort rotationObjectData[3]{};
+    const Complexd rotationFieldData[2];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Rotation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
+    CORRADE_COMPARE(out.str(), "Trade::SceneFieldData: expected object and field view to have the same size but got 3 and 2\n");
+}
+
+void SceneDataTest::constructFieldWrongType() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    const UnsignedShort rotationObjectData[3]{};
+    const Quaternion rotationFieldData[3];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Transformation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
+    SceneFieldData{SceneField::Transformation, 3, SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort), SceneFieldType::Quaternion, 0, sizeof(Quaternion)};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: Trade::SceneFieldType::Quaternion is not a valid type for Trade::SceneField::Transformation\n"
+        "Trade::SceneFieldData: Trade::SceneFieldType::Quaternion is not a valid type for Trade::SceneField::Transformation\n");
+}
+
+void SceneDataTest::constructFieldTooLargeObjectStride() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    UnsignedInt enough[2];
+    char toomuch[2*(32768 + sizeof(UnsignedInt))];
+
+    /* These should be fine */
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32767}, SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}.flipped<0>(), SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 32767, SceneFieldType::UnsignedInt, 0, 4};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 65536, -32768, SceneFieldType::UnsignedInt, 0, 4};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}, SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32769}.flipped<0>(), SceneFieldType::UnsignedInt, enough};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 32768, SceneFieldType::UnsignedInt, 0, 4};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 65538, -32769, SceneFieldType::UnsignedInt, 0, 4};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got 32768\n"
+        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got -32769\n"
+        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got 32768\n"
+        "Trade::SceneFieldData: expected object view stride to fit into 16 bits, but got -32769\n");
+}
+
+void SceneDataTest::constructFieldTooLargeFieldStride() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    UnsignedInt enough[2];
+    char toomuch[2*(32768 + sizeof(UnsignedInt))];
+
+    /* These should be fine */
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32767}};
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}.flipped<0>()};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 0, 32767};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 65536, -32768};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32768}};
+    SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, enough, SceneFieldType::UnsignedInt, Containers::StridedArrayView1D<UnsignedInt>{Containers::arrayCast<UnsignedInt>(toomuch), 2, 32769}.flipped<0>()};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 0, 32768};
+    SceneFieldData{SceneField::Mesh, 2, SceneObjectType::UnsignedInt, 0, 4, SceneFieldType::UnsignedInt, 65538, -32769};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got 32768\n"
+        "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got -32769\n"
+        "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got 32768\n"
+        "Trade::SceneFieldData: expected field view stride to fit into 16 bits, but got -32769\n");
+}
+
+void SceneDataTest::constructFieldWrongDataAccess() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    const UnsignedShort rotationObjectData[3]{};
+    const Quaternion rotationFieldData[3];
+    SceneFieldData a{SceneField::Rotation, Containers::arrayView(rotationObjectData), Containers::arrayView(rotationFieldData)};
+    SceneFieldData b{SceneField::Rotation, 3, SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort), SceneFieldType::Quaternion, 0, sizeof(Quaternion)};
+    CORRADE_VERIFY(!a.isOffsetOnly());
+    CORRADE_VERIFY(b.isOffsetOnly());
+
+    a.objectData(rotationObjectData); /* This is fine, no asserts */
+    a.fieldData(rotationFieldData);
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    b.objectData();
+    b.fieldData();
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData::objectData(): the field is offset-only, supply a data array\n"
+        "Trade::SceneFieldData::fieldData(): the field is offset-only, supply a data array\n");
+}
+
+void SceneDataTest::constructField2DWrongSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    char rotationFieldData[5*sizeof(Complex)];
+    char rotationObjectData[5*sizeof(UnsignedInt)];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Rotation,
+        Containers::StridedArrayView2D<char>{rotationObjectData, {4, 5}}.every(2),
+        SceneFieldType::Complex,
+        Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}.every(2)};
+    SceneFieldData{SceneField::Translation,
+        Containers::StridedArrayView2D<char>{rotationObjectData, {4, sizeof(UnsignedInt)}}.every(2),
+        SceneFieldType::Vector3,
+        Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}.every(2)};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: expected second object view dimension size 1, 2, 4 or 8 but got 5\n"
+        "Trade::SceneFieldData: second field view dimension size 8 doesn't match Trade::SceneFieldType::Vector3\n");
+}
+
+void SceneDataTest::constructField2DNonContiguous() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    char rotationObjectData[8*sizeof(UnsignedInt)];
+    char rotationFieldData[8*sizeof(Complex)];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Rotation,
+        Containers::StridedArrayView2D<char>{rotationObjectData, {4, 2*sizeof(UnsignedInt)}}.every({1, 2}),
+        SceneFieldType::Complex,
+        Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}};
+    SceneFieldData{SceneField::Rotation,
+        Containers::StridedArrayView2D<char>{rotationObjectData, {4, sizeof(UnsignedInt)}},
+        SceneFieldType::Complex,
+        Containers::StridedArrayView2D<char>{rotationFieldData, {4, 2*sizeof(Complex)}}.every({1, 2})};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: second object view dimension is not contiguous\n"
+        "Trade::SceneFieldData: second field view dimension is not contiguous\n");
+}
+
+void SceneDataTest::constructFieldArrayNonContiguous() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    UnsignedByte offsetObjectData[3];
+    Int offsetFieldData[3*4];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData data{sceneFieldCustom(34), Containers::arrayView(offsetObjectData), Containers::StridedArrayView2D<Int>{offsetFieldData, {3, 4}}.every({1, 2})};
+    CORRADE_COMPARE(out.str(), "Trade::SceneFieldData: second field view dimension is not contiguous\n");
+}
+
+void SceneDataTest::constructFieldArrayNotAllowed() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    UnsignedShort rotationObjectData[3]{};
+    Quaternion rotationFieldData[3];
+    Containers::ArrayView<UnsignedShort> rotationObjects = rotationObjectData;
+    Containers::ArrayView<Quaternion> rotationFields = rotationFieldData;
+    Containers::StridedArrayView2D<Quaternion> rotationFields2D{rotationFieldData, {3, 3}, {0, sizeof(Quaternion)}};
+    auto rotationFields2DChar = Containers::arrayCast<2, const char>(rotationFields2D);
+    auto rotationObjectsChar = Containers::arrayCast<2, const char>(rotationObjects);
+
+    /* This is all fine */
+    SceneFieldData{SceneField::Rotation,
+        SceneObjectType::UnsignedShort, rotationObjects,
+        SceneFieldType::Quaternion, rotationFields, 0};
+    SceneFieldData{SceneField::Rotation, 3,
+        SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort),
+        SceneFieldType::Quaternion, 0, sizeof(Quaternion), 0};
+    SceneFieldData{sceneFieldCustom(37),
+        rotationObjects,
+        rotationFields2D};
+    SceneFieldData{sceneFieldCustom(37),
+        rotationObjectsChar,
+        SceneFieldType::Quaternion, rotationFields2DChar, 3};
+    SceneFieldData{sceneFieldCustom(37), 3,
+        SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort),
+        SceneFieldType::Quaternion, 0, sizeof(Quaternion), 3};
+
+    /* This is not */
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{SceneField::Rotation,
+        SceneObjectType::UnsignedShort, rotationObjects,
+        SceneFieldType::Quaternion, rotationFields, 3};
+    SceneFieldData{SceneField::Rotation, 3,
+        SceneObjectType::UnsignedShort, 0, sizeof(UnsignedShort),
+        SceneFieldType::Quaternion, 0, sizeof(Quaternion), 3};
+    SceneFieldData{SceneField::Rotation,
+        rotationObjects,
+        rotationFields2D};
+    SceneFieldData{SceneField::Rotation,
+        rotationObjectsChar,
+        SceneFieldType::Quaternion, rotationFields2DChar, 3};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: Trade::SceneField::Rotation can't be an array field\n"
+        "Trade::SceneFieldData: Trade::SceneField::Rotation can't be an array field\n"
+        "Trade::SceneFieldData: Trade::SceneField::Rotation can't be an array field\n"
+        "Trade::SceneFieldData: Trade::SceneField::Rotation can't be an array field\n");
+}
+
+void SceneDataTest::constructFieldArray2DWrongSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    char rotationObjectData[4*sizeof(UnsignedInt)];
+    char rotationFieldData[4*sizeof(Complex)];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{sceneFieldCustom(37),
+        Containers::StridedArrayView2D<char>{rotationObjectData, {4, sizeof(UnsignedInt)}}.every(2),
+        SceneFieldType::Int,
+        Containers::StridedArrayView2D<char>{rotationFieldData, {4, sizeof(Complex)}}.every(2), 3};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: second field view dimension size 8 doesn't match Trade::SceneFieldType::Int and field array size 3\n");
+}
+
+void SceneDataTest::constructFieldArray2DNonContiguous() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    char offsetObjectData[18*sizeof(UnsignedInt)];
+    char offsetFieldData[18*sizeof(Int)];
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneFieldData{sceneFieldCustom(37),
+        Containers::StridedArrayView2D<char>{offsetObjectData, {3, 2*sizeof(UnsignedInt)}}.every({1, 2}),
+        SceneFieldType::Int,
+        Containers::StridedArrayView2D<char>{offsetFieldData, {3, 3*sizeof(Int)}}, 3};
+    SceneFieldData{sceneFieldCustom(37),
+        Containers::StridedArrayView2D<char>{offsetObjectData, {3, sizeof(UnsignedInt)}},
+        SceneFieldType::Int,
+        Containers::StridedArrayView2D<char>{offsetFieldData, {3, 6*sizeof(Int)}}.every({1, 2}), 3};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneFieldData: second object view dimension is not contiguous\n"
+        "Trade::SceneFieldData: second field view dimension is not contiguous\n");
 }
 
 void SceneDataTest::construct() {
-    const int a{};
-    const SceneData data{{0, 1, 4}, {2, 5}, &a};
+    struct TransformParent {
+        UnsignedShort object;
+        Matrix4 transformation;
+        Int parent;
+    };
 
-    CORRADE_COMPARE(data.children2D(), (std::vector<UnsignedInt>{0, 1, 4}));
-    CORRADE_COMPARE(data.children3D(), (std::vector<UnsignedInt>{2, 5}));
-    CORRADE_COMPARE(data.importerState(), &a);
+    Containers::StridedArrayView1D<TransformParent> transformsParentFieldObjectData;
+    Containers::StridedArrayView1D<UnsignedByte> meshFieldData;
+    Containers::StridedArrayView1D<Vector2> radiusFieldData;
+    Containers::StridedArrayView1D<UnsignedShort> materialMeshRadiusObjectData;
+    Containers::ArrayTuple data{
+        {NoInit, 5, transformsParentFieldObjectData},
+        {NoInit, 2, meshFieldData},
+        {NoInit, 2, radiusFieldData},
+        {NoInit, 2, materialMeshRadiusObjectData},
+    };
+    transformsParentFieldObjectData[0].object = 4;
+    transformsParentFieldObjectData[0].transformation = Matrix4::translation(Vector3::xAxis(5.0f));
+    transformsParentFieldObjectData[0].parent = -1;
+
+    transformsParentFieldObjectData[1].object = 2;
+    transformsParentFieldObjectData[1].transformation = Matrix4::translation(Vector3::yAxis(5.0f));
+    transformsParentFieldObjectData[1].parent = 0;
+
+    transformsParentFieldObjectData[2].object = 3;
+    transformsParentFieldObjectData[2].transformation = Matrix4::translation(Vector3::zAxis(5.0f));
+    transformsParentFieldObjectData[2].parent = 2;
+
+    transformsParentFieldObjectData[3].object = 0;
+    transformsParentFieldObjectData[3].transformation = Matrix4::translation(Vector3::yScale(5.0f));
+    transformsParentFieldObjectData[3].parent = 1;
+
+    transformsParentFieldObjectData[4].object = 1;
+    transformsParentFieldObjectData[4].transformation = Matrix4::translation(Vector3::zScale(5.0f));
+    transformsParentFieldObjectData[4].parent = -1;
+
+    meshFieldData[0] = 5;
+    radiusFieldData[0] = {37.5f, 1.5f};
+    materialMeshRadiusObjectData[0] = 2;
+
+    meshFieldData[1] = 7;
+    radiusFieldData[1] = {22.5f, 0.5f};
+    materialMeshRadiusObjectData[1] = 6;
+
+    int importerState;
+    SceneFieldData transformations{SceneField::Transformation,
+        transformsParentFieldObjectData.slice(&TransformParent::object),
+        transformsParentFieldObjectData.slice(&TransformParent::transformation)};
+    /* Offset-only */
+    SceneFieldData parents{SceneField::Parent, 5,
+        SceneObjectType::UnsignedShort, offsetof(TransformParent, object), sizeof(TransformParent),
+        SceneFieldType::Int, offsetof(TransformParent, parent), sizeof(TransformParent)};
+    SceneFieldData meshes{SceneField::Mesh,
+        materialMeshRadiusObjectData,
+        meshFieldData};
+    /* Custom & array */
+    SceneFieldData radiuses{sceneFieldCustom(37),
+        materialMeshRadiusObjectData,
+        Containers::arrayCast<2, Float>(radiusFieldData)};
+    SceneData scene{SceneObjectType::UnsignedShort, 8, std::move(data), {
+        transformations, parents, meshes, radiuses
+    }, &importerState};
+
+    /* Basics */
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_VERIFY(!scene.fieldData().empty());
+    CORRADE_COMPARE(static_cast<const void*>(scene.data()), transformsParentFieldObjectData.data());
+    CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), transformsParentFieldObjectData.data());
+    CORRADE_COMPARE(scene.objectCount(), 8);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldCount(), 4);
+    CORRADE_COMPARE(scene.importerState(), &importerState);
+
+    /* Field property access by ID */
+    CORRADE_COMPARE(scene.fieldName(0), SceneField::Transformation);
+    CORRADE_COMPARE(scene.fieldName(1), SceneField::Parent);
+    CORRADE_COMPARE(scene.fieldName(2), SceneField::Mesh);
+    CORRADE_COMPARE(scene.fieldName(3), sceneFieldCustom(37));
+    CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::Matrix4x4);
+    CORRADE_COMPARE(scene.fieldType(1), SceneFieldType::Int);
+    CORRADE_COMPARE(scene.fieldType(2), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldType(3), SceneFieldType::Float);
+    CORRADE_COMPARE(scene.fieldSize(0), 5);
+    CORRADE_COMPARE(scene.fieldSize(1), 5);
+    CORRADE_COMPARE(scene.fieldSize(2), 2);
+    CORRADE_COMPARE(scene.fieldSize(3), 2);
+    CORRADE_COMPARE(scene.fieldArraySize(0), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(1), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(2), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(3), 2);
+
+    /* Raw field data access by ID */
+    CORRADE_COMPARE(scene.fieldData(2).name(), SceneField::Mesh);
+    CORRADE_COMPARE(scene.fieldData(2).size(), 2);
+    CORRADE_COMPARE(scene.fieldData(2).objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(2).objectData())[1], 6);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedByte>(scene.fieldData(2).fieldData())[1], 7);
+    CORRADE_VERIFY(!scene.fieldData(2).isOffsetOnly());
+    CORRADE_COMPARE(scene.fieldData(2).fieldType(), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldData(2).fieldArraySize(), 0);
+    /* Offset-only */
+    CORRADE_COMPARE(scene.fieldData(1).name(), SceneField::Parent);
+    CORRADE_COMPARE(scene.fieldData(1).size(), 5);
+    CORRADE_COMPARE(scene.fieldData(1).objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_VERIFY(!scene.fieldData(1).isOffsetOnly());
+    CORRADE_COMPARE(scene.fieldData(1).fieldType(), SceneFieldType::Int);
+    CORRADE_COMPARE(scene.fieldData(1).fieldArraySize(), 0);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(1).objectData())[4], 1);
+    CORRADE_COMPARE(Containers::arrayCast<const Int>(scene.fieldData(1).fieldData())[4], -1);
+    /* Array */
+    CORRADE_COMPARE(scene.fieldData(3).name(), sceneFieldCustom(37));
+    CORRADE_COMPARE(scene.fieldData(3).size(), 2);
+    CORRADE_COMPARE(scene.fieldData(3).objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_VERIFY(!scene.fieldData(3).isOffsetOnly());
+    CORRADE_COMPARE(scene.fieldData(3).fieldType(), SceneFieldType::Float);
+    CORRADE_COMPARE(scene.fieldData(3).fieldArraySize(), 2);
+    CORRADE_COMPARE(Containers::arrayCast<const UnsignedShort>(scene.fieldData(3).objectData())[0], 2);
+    CORRADE_COMPARE(Containers::arrayCast<const Vector2>(scene.fieldData(3).fieldData())[0], (Vector2{37.5f, 1.5f}));
+
+    /* Typeless object access by ID with a cast later */
+    CORRADE_COMPARE(scene.objects(0).size()[0], 5);
+    CORRADE_COMPARE(scene.objects(1).size()[0], 5);
+    CORRADE_COMPARE(scene.objects(2).size()[0], 2);
+    CORRADE_COMPARE(scene.objects(3).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableObjects(0).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableObjects(1).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableObjects(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableObjects(3).size()[0], 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(0))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(1))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(3))[0]), 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(0))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(1))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(3))[0]), 2);
+
+    /* Typeless field access by ID with a cast later */
+    CORRADE_COMPARE(scene.field(0).size()[0], 5);
+    CORRADE_COMPARE(scene.field(1).size()[0], 5);
+    CORRADE_COMPARE(scene.field(2).size()[0], 2);
+    CORRADE_COMPARE(scene.field(3).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableField(0).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableField(1).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableField(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableField(3).size()[0], 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, const Matrix4>(scene.field(0))[2]), Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE((Containers::arrayCast<1, const Int>(scene.field(1))[4]), -1);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedByte>(scene.field(2))[1]), 7);
+    CORRADE_COMPARE((Containers::arrayCast<1, const Vector2>(scene.field(3))[0]), (Vector2{37.5f, 1.5f}));
+    CORRADE_COMPARE((Containers::arrayCast<1, Matrix4>(scene.mutableField(0))[2]), Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE((Containers::arrayCast<1, Int>(scene.mutableField(1))[4]), -1);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedByte>(scene.mutableField(2))[1]), 7);
+    CORRADE_COMPARE((Containers::arrayCast<1, Vector2>(scene.mutableField(3))[0]), (Vector2{37.5f, 1.5f}));
+
+    /* Typed object access by ID */
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(0).size(), 5);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(1).size(), 5);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(2).size(), 2);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(3).size(), 2);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(0).size(), 5);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(1).size(), 5);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(2).size(), 2);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(3).size(), 2);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(0)[2], 3);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(1)[4], 1);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(2)[1], 6);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(3)[0], 2);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(0)[2], 3);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(1)[4], 1);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(2)[1], 6);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(3)[0], 2);
+
+    /* Typed field access by ID */
+    CORRADE_COMPARE(scene.field<Matrix4>(0).size(), 5);
+    CORRADE_COMPARE(scene.field<Int>(1).size(), 5);
+    CORRADE_COMPARE(scene.field<UnsignedByte>(2).size(), 2);
+    CORRADE_COMPARE(scene.field<Float[]>(3).size()[0], 2);
+    CORRADE_COMPARE(scene.field<Float[]>(3).size()[1], 2);
+    CORRADE_COMPARE(scene.mutableField<Matrix4>(0).size(), 5);
+    CORRADE_COMPARE(scene.mutableField<Int>(1).size(), 5);
+    CORRADE_COMPARE(scene.mutableField<UnsignedByte>(2).size(), 2);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(3).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(3).size()[1], 2);
+    CORRADE_COMPARE(scene.field<Matrix4>(0)[2], Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE(scene.field<Int>(1)[4], -1);
+    CORRADE_COMPARE(scene.field<UnsignedByte>(2)[1], 7);
+    CORRADE_COMPARE(scene.field<Float[]>(3)[0][0], 37.5f);
+    CORRADE_COMPARE(scene.field<Float[]>(3)[0][1], 1.5f);
+    CORRADE_COMPARE(scene.mutableField<Matrix4>(0)[2], Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE(scene.mutableField<Int>(1)[4], -1);
+    CORRADE_COMPARE(scene.mutableField<UnsignedByte>(2)[1], 7);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(3)[0][0], 37.5f);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(3)[0][1], 1.5f);
+
+    /* Field property access by name */
+    CORRADE_COMPARE(scene.fieldId(SceneField::Transformation), 0);
+    CORRADE_COMPARE(scene.fieldId(SceneField::Parent), 1);
+    CORRADE_COMPARE(scene.fieldId(SceneField::Mesh), 2);
+    CORRADE_COMPARE(scene.fieldId(sceneFieldCustom(37)), 3);
+    CORRADE_VERIFY(scene.hasField(SceneField::Transformation));
+    CORRADE_VERIFY(scene.hasField(SceneField::Parent));
+    CORRADE_VERIFY(scene.hasField(SceneField::Mesh));
+    CORRADE_VERIFY(scene.hasField(sceneFieldCustom(37)));
+    CORRADE_VERIFY(!scene.hasField(SceneField::Skin));
+    CORRADE_COMPARE(scene.fieldType(SceneField::Transformation), SceneFieldType::Matrix4x4);
+    CORRADE_COMPARE(scene.fieldType(SceneField::Parent), SceneFieldType::Int);
+    CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldType(sceneFieldCustom(37)), SceneFieldType::Float);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Transformation), 5);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Parent), 5);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Mesh), 2);
+    CORRADE_COMPARE(scene.fieldSize(sceneFieldCustom(37)), 2);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Transformation), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Parent), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Mesh), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(sceneFieldCustom(37)), 2);
+
+    /* Typeless object access by name with a cast later */
+    CORRADE_COMPARE(scene.objects(SceneField::Transformation).size()[0], 5);
+    CORRADE_COMPARE(scene.objects(SceneField::Parent).size()[0], 5);
+    CORRADE_COMPARE(scene.objects(2).size()[0], 2);
+    CORRADE_COMPARE(scene.objects(3).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableObjects(SceneField::Transformation).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableObjects(SceneField::Parent).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableObjects(2).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableObjects(3).size()[0], 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(SceneField::Transformation))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(SceneField::Parent))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedShort>(scene.objects(3))[0]), 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(SceneField::Transformation))[2]), 3);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(SceneField::Parent))[4]), 1);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(2))[1]), 6);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedShort>(scene.mutableObjects(3))[0]), 2);
+
+    /* Typeless field access by name with a cast later */
+    CORRADE_COMPARE(scene.field(SceneField::Transformation).size()[0], 5);
+    CORRADE_COMPARE(scene.field(SceneField::Parent).size()[0], 5);
+    CORRADE_COMPARE(scene.field(SceneField::Mesh).size()[0], 2);
+    CORRADE_COMPARE(scene.field(sceneFieldCustom(37)).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableField(SceneField::Transformation).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableField(SceneField::Parent).size()[0], 5);
+    CORRADE_COMPARE(scene.mutableField(SceneField::Mesh).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableField(sceneFieldCustom(37)).size()[0], 2);
+    CORRADE_COMPARE((Containers::arrayCast<1, const Matrix4>(scene.field(SceneField::Transformation))[2]), Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE((Containers::arrayCast<1, const Int>(scene.field(SceneField::Parent))[4]), -1);
+    CORRADE_COMPARE((Containers::arrayCast<1, const UnsignedByte>(scene.field(SceneField::Mesh))[1]), 7);
+    CORRADE_COMPARE((Containers::arrayCast<1, const Vector2>(scene.field(sceneFieldCustom(37)))[0]), (Vector2{37.5f, 1.5f}));
+    CORRADE_COMPARE((Containers::arrayCast<1, Matrix4>(scene.mutableField(SceneField::Transformation))[2]), Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE((Containers::arrayCast<1, Int>(scene.mutableField(SceneField::Parent))[4]), -1);
+    CORRADE_COMPARE((Containers::arrayCast<1, UnsignedByte>(scene.mutableField(SceneField::Mesh))[1]), 7);
+    CORRADE_COMPARE((Containers::arrayCast<1, Vector2>(scene.mutableField(sceneFieldCustom(37)))[0]), (Vector2{37.5f, 1.5f}));
+
+    /* Typed object access by name */
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Transformation).size(), 5);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Parent).size(), 5);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Mesh).size(), 2);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(sceneFieldCustom(37)).size(), 2);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Transformation).size(), 5);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Parent).size(), 5);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Mesh).size(), 2);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(sceneFieldCustom(37)).size(), 2);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Transformation)[2], 3);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Parent)[4], 1);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(SceneField::Mesh)[1], 6);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(sceneFieldCustom(37))[0], 2);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Transformation)[2], 3);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Parent)[4], 1);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(SceneField::Mesh)[1], 6);
+    CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(sceneFieldCustom(37))[0], 2);
+
+    /* Typed field access by name */
+    CORRADE_COMPARE(scene.field<Matrix4>(SceneField::Transformation).size(), 5);
+    CORRADE_COMPARE(scene.field<Int>(SceneField::Parent).size(), 5);
+    CORRADE_COMPARE(scene.field<UnsignedByte>(SceneField::Mesh).size(), 2);
+    CORRADE_COMPARE(scene.field<Float[]>(sceneFieldCustom(37)).size()[0], 2);
+    CORRADE_COMPARE(scene.field<Float[]>(sceneFieldCustom(37)).size()[1], 2);
+    CORRADE_COMPARE(scene.mutableField<Matrix4>(SceneField::Transformation).size(), 5);
+    CORRADE_COMPARE(scene.mutableField<Int>(SceneField::Parent).size(), 5);
+    CORRADE_COMPARE(scene.mutableField<UnsignedByte>(SceneField::Mesh).size(), 2);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(sceneFieldCustom(37)).size()[0], 2);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(sceneFieldCustom(37)).size()[1], 2);
+    CORRADE_COMPARE(scene.field<Matrix4>(SceneField::Transformation)[2], Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE(scene.field<Int>(SceneField::Parent)[4], -1);
+    CORRADE_COMPARE(scene.field<UnsignedByte>(SceneField::Mesh)[1], 7);
+    CORRADE_COMPARE(scene.field<Float[]>(sceneFieldCustom(37))[0][0], 37.5f);
+    CORRADE_COMPARE(scene.field<Float[]>(sceneFieldCustom(37))[0][1], 1.5f);
+    CORRADE_COMPARE(scene.mutableField<Matrix4>(SceneField::Transformation)[2], Matrix4::translation(Vector3::zAxis(5.0f)));
+    CORRADE_COMPARE(scene.mutableField<Int>(SceneField::Parent)[4], -1);
+    CORRADE_COMPARE(scene.mutableField<UnsignedByte>(SceneField::Mesh)[1], 7);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(sceneFieldCustom(37))[0][0], 37.5f);
+    CORRADE_COMPARE(scene.mutableField<Float[]>(sceneFieldCustom(37))[0][1], 1.5f);
+}
+
+void SceneDataTest::constructZeroFields() {
+    int importerState;
+    SceneData scene{SceneObjectType::UnsignedShort, 37563, nullptr, {}, &importerState};
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_VERIFY(scene.fieldData().empty());
+    CORRADE_COMPARE(static_cast<const void*>(scene.data()), nullptr);
+    CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), nullptr);
+    CORRADE_COMPARE(scene.importerState(), &importerState);
+    CORRADE_COMPARE(scene.objectCount(), 37563);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldCount(), 0);
+}
+
+void SceneDataTest::constructZeroObjects() {
+    int importerState;
+    SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials}, &importerState};
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_VERIFY(!scene.fieldData().empty());
+    CORRADE_COMPARE(static_cast<const void*>(scene.data()), nullptr);
+    CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), nullptr);
+    CORRADE_COMPARE(scene.importerState(), &importerState);
+    CORRADE_COMPARE(scene.objectCount(), 0);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
+    CORRADE_COMPARE(scene.fieldCount(), 2);
+
+    /* Field property access by name */
+    CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldType(SceneField::MeshMaterial), SceneFieldType::UnsignedInt);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Mesh), 0);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 0);
+    CORRADE_COMPARE(scene.objects(SceneField::Mesh).data(), nullptr);
+    CORRADE_COMPARE(scene.objects(SceneField::MeshMaterial).data(), nullptr);
+}
+
+void SceneDataTest::constructNotOwned() {
+    auto&& instanceData = NotOwnedData[testCaseInstanceId()];
+    setTestCaseDescription(instanceData.name);
+
+    struct Data {
+        UnsignedShort object;
+        UnsignedByte mesh;
+    } data[]{
+        {0, 2},
+        {1, 1},
+        {2, 0}
+    };
+
+    int importerState;
+    SceneFieldData mesh{SceneField::Mesh,
+        Containers::stridedArrayView(data).slice(&Data::object),
+        Containers::stridedArrayView(data).slice(&Data::mesh)};
+    SceneData scene{SceneObjectType::UnsignedShort, 7, instanceData.dataFlags, Containers::arrayView(data), {mesh}, &importerState};
+
+    CORRADE_COMPARE(scene.dataFlags(), instanceData.dataFlags);
+    CORRADE_COMPARE(static_cast<const void*>(scene.data()), +data);
+    if(instanceData.dataFlags & DataFlag::Mutable)
+        CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), +data);
+    CORRADE_COMPARE(scene.objectCount(), 7);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldCount(), 1);
+    CORRADE_COMPARE(scene.importerState(), &importerState);
+
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(0).size(), 3);
+    CORRADE_COMPARE(scene.objects<UnsignedShort>(0)[2], 2);
+    if(instanceData.dataFlags & DataFlag::Mutable)
+        CORRADE_COMPARE(scene.mutableObjects<UnsignedShort>(0)[2], 2);
+
+    CORRADE_COMPARE(scene.field<UnsignedByte>(0).size(), 3);
+    CORRADE_COMPARE(scene.field<UnsignedByte>(0)[2], 0);
+    if(instanceData.dataFlags & DataFlag::Mutable)
+        CORRADE_COMPARE(scene.mutableField<UnsignedByte>(0)[2], 0);
+}
+
+void SceneDataTest::constructDuplicateField() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    /* Builtin fields are checked using a bitfield, as they have monotonic
+       numbering */
+    SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData meshesAgain{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials, meshesAgain}};
+    CORRADE_COMPARE(out.str(), "Trade::SceneData: duplicate field Trade::SceneField::Mesh\n");
+}
+
+void SceneDataTest::constructDuplicateCustomField() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    /* These are checked in an O(n^2) way, separately from builtin fields.
+       Can't use a bitfield since the field index can be anything. */
+    SceneFieldData customA{sceneFieldCustom(37), SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData customB{sceneFieldCustom(1038576154), SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData customAAgain{sceneFieldCustom(37), SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {customA, customB, customAAgain}};
+    CORRADE_COMPARE(out.str(), "Trade::SceneData: duplicate field Trade::SceneField::Custom(37)\n");
+}
+
+void SceneDataTest::constructInconsistentObjectType() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedShort, nullptr, SceneFieldType::UnsignedInt, nullptr};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials}};
+    CORRADE_COMPARE(out.str(), "Trade::SceneData: inconsistent object type, got Trade::SceneObjectType::UnsignedShort for field 1 but expected Trade::SceneObjectType::UnsignedInt\n");
+}
+
+void SceneDataTest::constructObjectDataNotContained() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    Containers::Array<char> data{reinterpret_cast<char*>(0xbadda9), 10, [](char*, std::size_t){}};
+    Containers::ArrayView<UnsignedShort> dataIn{reinterpret_cast<UnsignedShort*>(0xbadda9), 5};
+    Containers::ArrayView<UnsignedShort> dataSlightlyOut{reinterpret_cast<UnsignedShort*>(0xbaddaa), 5};
+    Containers::ArrayView<UnsignedShort> dataOut{reinterpret_cast<UnsignedShort*>(0xdead), 5};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    /* First a "slightly off" view that exceeds the original by one byte */
+    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+        SceneFieldData{SceneField::Mesh, dataSlightlyOut, dataIn}
+    }};
+    /* Second a view that's in a completely different location */
+    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Mesh, dataOut, dataIn}
+    }};
+    /* Verify the owning constructor does the checks as well */
+    SceneData{SceneObjectType::UnsignedShort, 5, std::move(data), {
+        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Mesh, dataOut, dataIn}
+    }};
+    /* And if we have no data at all, it doesn't try to dereference them but
+       still checks properly */
+    SceneData{SceneObjectType::UnsignedShort, 5, nullptr, {
+        SceneFieldData{SceneField::Mesh, dataOut, dataIn}
+    }};
+    /* Finally, offset-only fields with a different message */
+    SceneData{SceneObjectType::UnsignedByte, 6, Containers::Array<char>{24}, {
+        SceneFieldData{SceneField::Mesh, 6, SceneObjectType::UnsignedByte, 4, 4, SceneFieldType::UnsignedByte, 0, 4}
+    }};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData: object data [0xbaddaa:0xbaddb4] of field 0 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: object data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: object data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: object data [0xdead:0xdeb7] of field 0 are not contained in passed data array [0x0:0x0]\n"
+
+        "Trade::SceneData: offset-only object data of field 0 span 25 bytes but passed data array has only 24\n");
+}
+
+void SceneDataTest::constructFieldDataNotContained() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    /* Mostly the same as constructObjectDataNotContained() with object and
+       field views swapped, and added checks for array fields */
+
+    Containers::Array<char> data{reinterpret_cast<char*>(0xbadda9), 10, [](char*, std::size_t){}};
+    Containers::ArrayView<UnsignedShort> dataIn{reinterpret_cast<UnsignedShort*>(0xbadda9), 5};
+    Containers::ArrayView<UnsignedShort> dataSlightlyOut{reinterpret_cast<UnsignedShort*>(0xbaddaa), 5};
+    Containers::ArrayView<UnsignedShort> dataOut{reinterpret_cast<UnsignedShort*>(0xdead), 5};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    /* First a "slightly off" view that exceeds the original by one byte */
+    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+        SceneFieldData{SceneField::Mesh, dataIn, dataSlightlyOut}
+    }};
+    /* Second a view that's in a completely different location */
+    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Mesh, dataIn, dataOut}
+    }};
+    /* Verify array size is taken into account as well. If not, the data would
+       span only 7 bytes out of 10 (instead of 12), which is fine. */
+    SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
+        SceneFieldData{sceneFieldCustom(37), dataIn.prefix(2), Containers::StridedArrayView2D<UnsignedByte>{Containers::ArrayView<UnsignedByte>{reinterpret_cast<UnsignedByte*>(0xbadda9), 12}, {2, 6}}}
+    }};
+    /* Verify the owning constructor does the checks as well */
+    SceneData{SceneObjectType::UnsignedShort, 5, std::move(data), {
+        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Mesh, dataIn, dataOut}
+    }};
+    /* Not checking for nullptr data, since that got checked for object view
+       already and there's no way to trigger it for fields */
+    /* Finally, offset-only fields with a different message */
+    SceneData{SceneObjectType::UnsignedShort, 6, Containers::Array<char>{24}, {
+        SceneFieldData{SceneField::Mesh, 6, SceneObjectType::UnsignedShort, 0, 4, SceneFieldType::UnsignedByte, 4, 4}
+    }};
+    /* This again spans 21 bytes if array size isn't taken into account, and 25
+       if it is */
+    SceneData{SceneObjectType::UnsignedShort, 5, Containers::Array<char>{24}, {
+        SceneFieldData{sceneFieldCustom(37), 5, SceneObjectType::UnsignedShort, 0, 5, SceneFieldType::UnsignedByte, 0, 5, 5}
+    }};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData: field data [0xbaddaa:0xbaddb4] of field 0 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: field data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: field data [0xbadda9:0xbaddb5] of field 0 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+        "Trade::SceneData: field data [0xdead:0xdeb7] of field 1 are not contained in passed data array [0xbadda9:0xbaddb3]\n"
+
+        "Trade::SceneData: offset-only field data of field 0 span 25 bytes but passed data array has only 24\n"
+        "Trade::SceneData: offset-only field data of field 0 span 25 bytes but passed data array has only 24\n");
+}
+
+void SceneDataTest::constructObjectTypeTooSmall() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    /* This is fine */
+    SceneData{SceneObjectType::UnsignedByte, 0xff, nullptr, {}};
+    SceneData{SceneObjectType::UnsignedShort, 0xffff, nullptr, {}};
+    SceneData{SceneObjectType::UnsignedInt, 0xffffffffu, nullptr, {}};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData{SceneObjectType::UnsignedByte, 0x100, nullptr, {}};
+    SceneData{SceneObjectType::UnsignedShort, 0x10000, nullptr, {}};
+    SceneData{SceneObjectType::UnsignedInt, 0x100000000ull, nullptr, {}};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData: Trade::SceneObjectType::UnsignedByte is too small for 256 objects\n"
+        "Trade::SceneData: Trade::SceneObjectType::UnsignedShort is too small for 65536 objects\n"
+        "Trade::SceneData: Trade::SceneObjectType::UnsignedInt is too small for 4294967296 objects\n");
+}
+
+void SceneDataTest::constructNotOwnedFlagOwned() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    const char data[32]{};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData{SceneObjectType::UnsignedByte, 5, DataFlag::Owned, Containers::arrayView(data), {}};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData: can't construct with non-owned data but Trade::DataFlag::Owned\n");
+}
+
+void SceneDataTest::constructMismatchedTRSViews() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    Containers::ArrayView<const char> data{reinterpret_cast<char*>(0xcafe0000),
+        /* Three entries, each having a 2D TRS and 3 object IDs */
+        3*(24 + 12)};
+    Containers::ArrayView<const UnsignedInt> translationObjectData{
+        reinterpret_cast<const UnsignedInt*>(data.data()), 3};
+    Containers::ArrayView<const Vector2> translationFieldData{
+        reinterpret_cast<const Vector2*>(data.data() + 0x0c), 3};
+    Containers::ArrayView<const UnsignedInt> rotationObjectData{
+        reinterpret_cast<const UnsignedInt*>(data.data() + 0x24), 3};
+    Containers::ArrayView<const Complex> rotationFieldData{
+        reinterpret_cast<const Complex*>(data.data() + 0x30), 3};
+    Containers::ArrayView<const UnsignedInt> scalingObjectData{
+        reinterpret_cast<const UnsignedInt*>(data.data() + 0x48), 3};
+    Containers::ArrayView<const Vector2> scalingFieldData{
+        reinterpret_cast<const Vector2*>(data.data() + 0x54), 3};
+
+    SceneFieldData translations{SceneField::Translation, translationObjectData, translationFieldData};
+    SceneFieldData rotationsDifferent{SceneField::Rotation, rotationObjectData, rotationFieldData};
+    SceneFieldData scalingsDifferent{SceneField::Scaling, scalingObjectData, scalingFieldData};
+    SceneFieldData rotationsSameButLess{SceneField::Rotation, translationObjectData.except(1), rotationFieldData.except(1)};
+    SceneFieldData scalingsSameButLess{SceneField::Scaling, translationObjectData.except(2), scalingFieldData.except(2)};
+
+    /* Test that all pairs get checked */
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, rotationsDifferent}};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, scalingsDifferent}};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {rotationsDifferent, scalingsDifferent}};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, rotationsSameButLess}};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {translations, scalingsSameButLess}};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {rotationsSameButLess, scalingsSameButLess}};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData: Trade::SceneField::Rotation object data [0xcafe0024:0xcafe0030] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0048:0xcafe0054] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0048:0xcafe0054] is different from Trade::SceneField::Rotation object data [0xcafe0024:0xcafe0030]\n"
+        "Trade::SceneData: Trade::SceneField::Rotation object data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Translation object data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::Scaling object data [0xcafe0000:0xcafe0004] is different from Trade::SceneField::Rotation object data [0xcafe0000:0xcafe0008]\n");
+}
+
+void SceneDataTest::constructMismatchedMeshMaterialView() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    Containers::ArrayView<const char> data{reinterpret_cast<char*>(0xcafe0000),
+        /* Three entries, each having mesh/material ID and 2 object IDs */
+        3*(8 + 8)};
+    Containers::ArrayView<const UnsignedInt> meshObjectData{
+        reinterpret_cast<const UnsignedInt*>(data.data()), 3};
+    Containers::ArrayView<const UnsignedInt> meshFieldData{
+        reinterpret_cast<const UnsignedInt*>(data.data() + 0x0c), 3};
+    Containers::ArrayView<const UnsignedInt> meshMaterialObjectData{
+        reinterpret_cast<const UnsignedInt*>(data.data() + 0x18), 3};
+    Containers::ArrayView<const UnsignedInt> meshMaterialFieldData{
+        reinterpret_cast<const UnsignedInt*>(data.data() + 0x24), 3};
+
+    SceneFieldData meshes{SceneField::Mesh, meshObjectData, meshFieldData};
+    SceneFieldData meshMaterialsDifferent{SceneField::MeshMaterial, meshMaterialObjectData, meshMaterialFieldData};
+    SceneFieldData meshMaterialsSameButLess{SceneField::MeshMaterial, meshObjectData.except(1), meshMaterialFieldData.except(1)};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {meshes, meshMaterialsDifferent}};
+    SceneData{SceneObjectType::UnsignedInt, 3, {}, data, {meshes, meshMaterialsSameButLess}};
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData: Trade::SceneField::MeshMaterial object data [0xcafe0018:0xcafe0024] is different from Trade::SceneField::Mesh object data [0xcafe0000:0xcafe000c]\n"
+        "Trade::SceneData: Trade::SceneField::MeshMaterial object data [0xcafe0000:0xcafe0008] is different from Trade::SceneField::Mesh object data [0xcafe0000:0xcafe000c]\n");
 }
 
 void SceneDataTest::constructCopy() {
@@ -59,25 +1570,1475 @@ void SceneDataTest::constructCopy() {
 }
 
 void SceneDataTest::constructMove() {
-    const int a{};
-    SceneData data{{0, 1, 4}, {2, 5}, &a};
+    struct Mesh {
+        UnsignedShort object;
+        UnsignedInt mesh;
+    };
 
-    SceneData b{std::move(data)};
+    Containers::Array<char> data{NoInit, 3*sizeof(Mesh)};
+    auto meshData = Containers::arrayCast<Mesh>(data);
+    meshData[0] = {0, 2};
+    meshData[1] = {73, 1};
+    meshData[2] = {122, 2};
 
-    CORRADE_COMPARE(b.children2D(), (std::vector<UnsignedInt>{0, 1, 4}));
-    CORRADE_COMPARE(b.children3D(), (std::vector<UnsignedInt>{2, 5}));
-    CORRADE_COMPARE(b.importerState(), &a);
+    int importerState;
+    SceneFieldData meshes{SceneField::Mesh, stridedArrayView(meshData).slice(&Mesh::object), stridedArrayView(meshData).slice(&Mesh::mesh)};
+    SceneData a{SceneObjectType::UnsignedShort, 15, std::move(data), {meshes}, &importerState};
 
-    const int c{};
-    SceneData d{{1, 3}, {1, 4, 5}, &c};
-    d = std::move(b);
+    SceneData b{std::move(a)};
+    CORRADE_COMPARE(b.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(b.objectCount(), 15);
+    CORRADE_COMPARE(b.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(b.fieldCount(), 1);
+    CORRADE_COMPARE(b.importerState(), &importerState);
+    CORRADE_COMPARE(static_cast<const void*>(b.data()), meshData.data());
+    CORRADE_COMPARE(b.fieldName(0), SceneField::Mesh);
+    CORRADE_COMPARE(b.fieldType(0), SceneFieldType::UnsignedInt);
+    CORRADE_COMPARE(b.fieldSize(0), 3);
+    CORRADE_COMPARE(b.fieldArraySize(0), 0);
+    CORRADE_COMPARE(b.objects<UnsignedShort>(0)[2], 122);
+    CORRADE_COMPARE(b.field<UnsignedInt>(0)[2], 2);
 
-    CORRADE_COMPARE(d.children2D(), (std::vector<UnsignedInt>{0, 1, 4}));
-    CORRADE_COMPARE(d.children3D(), (std::vector<UnsignedInt>{2, 5}));
-    CORRADE_COMPARE(d.importerState(), &a);
+    SceneData c{SceneObjectType::UnsignedByte, 76, nullptr, {}};
+    c = std::move(b);
+    CORRADE_COMPARE(c.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(c.objectCount(), 15);
+    CORRADE_COMPARE(c.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(c.fieldCount(), 1);
+    CORRADE_COMPARE(c.importerState(), &importerState);
+    CORRADE_COMPARE(static_cast<const void*>(c.data()), meshData.data());
+    CORRADE_COMPARE(c.fieldName(0), SceneField::Mesh);
+    CORRADE_COMPARE(c.fieldType(0), SceneFieldType::UnsignedInt);
+    CORRADE_COMPARE(c.fieldSize(0), 3);
+    CORRADE_COMPARE(c.fieldArraySize(0), 0);
+    CORRADE_COMPARE(c.objects<UnsignedShort>(0)[2], 122);
+    CORRADE_COMPARE(c.field<UnsignedInt>(0)[2], 2);
 
     CORRADE_VERIFY(std::is_nothrow_move_constructible<SceneData>::value);
     CORRADE_VERIFY(std::is_nothrow_move_assignable<SceneData>::value);
+}
+
+template<class> struct NameTraits;
+#define _c(format) template<> struct NameTraits<format> {                   \
+        static const char* name() { return #format; }                       \
+    };
+_c(UnsignedByte)
+_c(Byte)
+_c(UnsignedShort)
+_c(Short)
+_c(UnsignedInt)
+_c(Int)
+_c(UnsignedLong)
+_c(Long)
+_c(Float)
+_c(Double)
+_c(Vector2)
+_c(Vector2d)
+_c(Vector3)
+_c(Vector3d)
+_c(Matrix3)
+_c(Matrix3x3)
+_c(Matrix3d)
+_c(Matrix3x3d)
+_c(Matrix4)
+_c(Matrix4x4)
+_c(Matrix4d)
+_c(Matrix4x4d)
+_c(Complex)
+_c(Complexd)
+_c(Quaternion)
+_c(Quaterniond)
+_c(DualComplex)
+_c(DualComplexd)
+_c(DualQuaternion)
+_c(DualQuaterniond)
+#undef _c
+
+template<class T> void SceneDataTest::objectsAsArrayByIndex() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        T object;
+        UnsignedByte mesh;
+    } fields[]{
+        {T(15), 0},
+        {T(37), 1},
+        {T(44), 15}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{Implementation::sceneObjectTypeFor<T>(), 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, Implementation::sceneObjectTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+    CORRADE_COMPARE_AS(scene.objectsAsArray(1),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
+        TestSuite::Compare::Container);
+}
+
+template<class T> void SceneDataTest::objectsAsArrayByName() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        T object;
+        UnsignedByte mesh;
+    } fields[]{
+        {T(15), 0},
+        {T(37), 1},
+        {T(44), 15}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{Implementation::sceneObjectTypeFor<T>(), 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, Implementation::sceneObjectTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+
+    UnsignedInt expected[]{15, 37, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.objectsAsArray(SceneField::Mesh)),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    UnsignedInt out[3];
+    scene.objectsInto(SceneField::Mesh, out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+void SceneDataTest::objectsAsArrayLongType() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedLong object;
+        UnsignedByte mesh;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedLong, 0x100000000ull, {}, fields, {
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+
+    /* AsArray calls into IntoArray, which then has the assert, so this tests
+       both */
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.objectsAsArray(0);
+    scene.objectsAsArray(SceneField::Mesh);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::objectsInto(): indices for up to 4294967296 objects can't fit into a 32-bit type, access them directly via objects() instead\n"
+        "Trade::SceneData::objectsInto(): indices for up to 4294967296 objects can't fit into a 32-bit type, access them directly via objects() instead\n");
+}
+
+void SceneDataTest::objectsIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedByte mesh;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    UnsignedInt destination[2];
+    scene.objectsInto(0, destination);
+    scene.objectsInto(SceneField::Mesh, destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::parentsAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedByte object;
+        T parent;
+    } fields[]{
+        {0, T(15)},
+        {1, T(-1)},
+        {15, T(44)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::UnsignedInt, nullptr},
+        SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
+    }};
+    CORRADE_COMPARE_AS(scene.parentsAsArray(),
+        Containers::arrayView<Int>({15, -1, 44}),
+        TestSuite::Compare::Container);
+}
+
+#ifndef CORRADE_TARGET_32BIT
+void SceneDataTest::parentsAsArrayLongType() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedLong object;
+        Long parent;
+    };
+
+    Containers::Array<char> data{nullptr, 0x100000000ull*sizeof(Field), [](char*, std::size_t) {}};
+    Containers::StridedArrayView1D<Field> view = Containers::arrayCast<Field>(data);
+
+    SceneData scene{SceneObjectType::UnsignedLong, 0x100000000ull, std::move(data), {
+        SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
+    }};
+
+    /* AsArray calls into IntoArray, which then has the assert, so this tests
+       both */
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.parentsAsArray();
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::parentsInto(): parent indices for up to 4294967296 objects can't fit into a 32-bit type, access them directly via field() instead\n");
+}
+#endif
+
+void SceneDataTest::parentsIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        Int parent;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    Int destination[2];
+    scene.parentsInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::parentsInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::transformations2DAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    typedef typename T::Type U;
+
+    struct Transformation {
+        UnsignedInt object;
+        T transformation;
+    };
+
+    struct Component {
+        UnsignedInt object;
+        Vector2 translation;
+        Vector2 scaling;
+    };
+
+    Containers::StridedArrayView1D<Transformation> transformations;
+    Containers::StridedArrayView1D<Component> components;
+    Containers::Array<char> data = Containers::ArrayTuple{
+        {NoInit, 4, transformations},
+        {NoInit, 2, components}
+    };
+    transformations[0] = {1, T::translation({U(3.0), U(2.0)})};
+    transformations[1] = {0, T::rotation(Math::Deg<U>(35.0))};
+    transformations[2] = {4, T::translation({U(1.5), U(2.5)})*
+                             T::rotation(Math::Deg<U>(-15.0))};
+    transformations[3] = {5, T::rotation(Math::Deg<U>(-15.0))*
+                             T::translation({U(1.5), U(2.5)})};
+    /* Object number 4 additionally has a scaling component (which isn't
+       representable with dual complex numbers). It currently doesn't get added
+       to the transformations returned from transformations2DInto() but that
+       may change in the future for dual complex numbers). The translation
+       component is then *assumed* to be equivalent to what's stored in the
+       Transformation field and so applied neither. Here it's different, and
+       that shouldn't affect anything. */
+    components[0] = {4, {-1.5f, -2.5f}, {2.0f, 5.0f}};
+    /* This is deliberately an error -- specifying a TRS for an object that
+       doesn't have a Transformation field. Since there's no fast way to check
+       for those and error/warn on those, they get just ignored. */
+    components[1] = {2, {3.5f, -1.0f}, {1.0f, 1.5f}};
+
+    SceneData scene{SceneObjectType::UnsignedInt, 6, std::move(data), {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Transformation,
+            transformations.slice(&Transformation::object),
+            transformations.slice(&Transformation::transformation)},
+        SceneFieldData{SceneField::Translation,
+            components.slice(&Component::object),
+            components.slice(&Component::translation)},
+        SceneFieldData{SceneField::Scaling,
+            components.slice(&Component::object),
+            components.slice(&Component::scaling)},
+    }};
+
+    Matrix3 expected[]{
+        Matrix3::translation({3.0f, 2.0f}),
+        Matrix3::rotation(35.0_degf),
+        Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation(-15.0_degf),
+        Matrix3::rotation(-15.0_degf)*Matrix3::translation({1.5f, 2.5f})
+    };
+    CORRADE_COMPARE_AS(arrayView(scene.transformations2DAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    Matrix3 out[4];
+    scene.transformations2DInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+template<class T> void SceneDataTest::transformations2DAsArrayTRS() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedInt object;
+        Math::Vector2<T> translation;
+        Math::Complex<T> rotation;
+        Math::Vector2<T> scaling;
+    } fields[]{
+        {1, {T(3.0), T(2.0)},
+            {},
+            {T(1.0), T(1.0)}},
+        {0, {},
+            Math::Complex<T>::rotation(Math::Deg<T>{T(35.0)}),
+            {T(1.0), T(1.0)}},
+        {2, {}, /* Identity transformation here */
+            {},
+            {T(1.0), T(1.0)}},
+        {4, {},
+            {},
+            {T(2.0), T(1.0)}},
+        {7, {T(1.5), T(2.5)},
+            Math::Complex<T>::rotation(Math::Deg<T>{T(-15.0)}),
+            {T(-0.5), T(4.0)}},
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneFieldData translation{SceneField::Translation,
+        view.slice(&Field::object),
+        view.slice(&Field::translation)};
+    SceneFieldData rotation{SceneField::Rotation,
+        view.slice(&Field::object),
+        view.slice(&Field::rotation)};
+    SceneFieldData scaling{SceneField::Scaling,
+        view.slice(&Field::object),
+        view.slice(&Field::scaling)};
+
+    /* Just one of translation / rotation / scaling */
+    {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3::translation({3.0f, 2.0f}),
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3::translation({1.5f, 2.5f})
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            rotation
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3{Math::IdentityInit},
+            Matrix3::rotation(35.0_degf),
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3::rotation(-15.0_degf)
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3::scaling({2.0f, 1.0f}),
+            Matrix3::scaling({-0.5f, 4.0f})
+        }), TestSuite::Compare::Container);
+    }
+
+    /* Pairs */
+    {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation,
+            rotation
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3::translation({3.0f, 2.0f}),
+            Matrix3::rotation(35.0_degf),
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation,
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3::translation({3.0f, 2.0f}),
+            Matrix3{Math::IdentityInit},
+            Matrix3{Math::IdentityInit},
+            Matrix3::scaling({2.0f, 1.0f}),
+            Matrix3::translation({1.5f, 2.5f})*Matrix3::scaling({-0.5f, 4.0f})
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            rotation,
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3{Math::IdentityInit},
+            Matrix3::rotation(35.0_degf),
+            Matrix3{Math::IdentityInit},
+            Matrix3::scaling({2.0f, 1.0f}),
+            Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})
+        }), TestSuite::Compare::Container);
+    }
+
+    /* All */
+    {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation,
+            rotation,
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView<Matrix3>({
+            Matrix3::translation({3.0f, 2.0f}),
+            Matrix3::rotation(35.0_degf),
+            Matrix3{Math::IdentityInit},
+            Matrix3::scaling({2.0f, 1.0f}),
+            Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})
+        }), TestSuite::Compare::Container);
+    }
+}
+
+template<class T> void SceneDataTest::transformations2DAsArrayBut3DType() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<T>::type(), nullptr}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.transformations2DAsArray();
+    CORRADE_COMPARE(out.str(), Utility::formatString(
+        "Trade::SceneData::transformations2DInto(): field has a 3D transformation type Trade::SceneFieldType::{}\n", NameTraits<T>::name()));
+}
+
+template<class T> void SceneDataTest::transformations2DAsArrayBut3DTypeTRS() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    SceneData translation{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr}
+    }};
+    SceneData rotation{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Quaternion<T>>::type(), nullptr}
+    }};
+    SceneData scaling{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    translation.transformations2DAsArray();
+    rotation.transformations2DAsArray();
+    scaling.transformations2DAsArray();
+    CORRADE_COMPARE(out.str(), Utility::formatString(
+        "Trade::SceneData::transformations2DInto(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData::transformations2DInto(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData::transformations2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector3<T>>::name(), NameTraits<Math::Quaternion<T>>::name()));
+}
+
+void SceneDataTest::transformations2DIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        Matrix3 transformation;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Transformation, view.slice(&Field::object), view.slice(&Field::transformation)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    Matrix3 destination[2];
+    scene.transformations2DInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::transformations2DInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::transformations3DAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    typedef typename T::Type U;
+
+    struct Transformation {
+        UnsignedInt object;
+        T transformation;
+    };
+
+    struct Component {
+        UnsignedInt object;
+        Vector3 translation;
+        Vector3 scaling;
+    };
+
+    Containers::StridedArrayView1D<Transformation> transformations;
+    Containers::StridedArrayView1D<Component> components;
+    Containers::Array<char> data = Containers::ArrayTuple{
+        {NoInit, 4, transformations},
+        {NoInit, 2, components}
+    };
+    transformations[0] = {1, T::translation({U(3.0), U(2.0), U(-0.5)})};
+    transformations[1] = {0, T::rotation(Math::Deg<U>(35.0),
+                                         Math::Vector3<U>::yAxis())};
+    transformations[2] = {4, T::translation({U(1.5), U(2.5), U(0.75)})*
+                             T::rotation(Math::Deg<U>(-15.0),
+                                         Math::Vector3<U>::xAxis())};
+    transformations[3] = {5, T::rotation(Math::Deg<U>(-15.0),
+                                         Math::Vector3<U>::xAxis())*
+                             T::translation({U(1.5), U(2.5), U(0.75)})};
+    /* Object number 4 additionally has a scaling component (which isn't
+       representable with dual quaternions). It currently doesn't get added
+       to the transformations returned from transformations2DInto() but that
+       may change in the future for dual quaternions). The translation
+       component is then *assumed* to be equivalent to what's stored in the
+       Transformation field and so applied neither. Here it's different, and
+       that shouldn't affect anything. */
+    components[0] = {4, {-1.5f, -2.5f, 5.5f}, {2.0f, 5.0f, 3.0f}};
+    /* This is deliberately an error -- specifying a TRS for an object that
+       doesn't have a Transformation field. Since there's no fast way to check
+       for those and error/warn on those, they get just ignored. */
+    components[1] = {2, {3.5f, -1.0f, 2.2f}, {1.0f, 1.5f, 1.0f}};
+
+    SceneData scene{SceneObjectType::UnsignedInt, 6, std::move(data), {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Transformation,
+            transformations.slice(&Transformation::object),
+            transformations.slice(&Transformation::transformation)},
+        SceneFieldData{SceneField::Translation,
+            components.slice(&Component::object),
+            components.slice(&Component::translation)},
+        SceneFieldData{SceneField::Scaling,
+            components.slice(&Component::object),
+            components.slice(&Component::scaling)},
+    }};
+
+    Matrix4 expected[]{
+        Matrix4::translation({3.0f, 2.0f, -0.5f}),
+        Matrix4::rotationY(35.0_degf),
+        Matrix4::translation({1.5f, 2.5f, 0.75f})*Matrix4::rotationX(-15.0_degf),
+        Matrix4::rotationX(-15.0_degf)*Matrix4::translation({1.5f, 2.5f, 0.75f})
+    };
+    CORRADE_COMPARE_AS(arrayView(scene.transformations3DAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    Matrix4 out[4];
+    scene.transformations3DInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+template<class T> void SceneDataTest::transformations3DAsArrayTRS() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedInt object;
+        Math::Vector3<T> translation;
+        Math::Quaternion<T> rotation;
+        Math::Vector3<T> scaling;
+    } fields[]{
+        {1, {T(3.0), T(2.0), T(1.0)},
+            {},
+            {T(1.0), T(1.0), T(1.0)}},
+        {0, {},
+            Math::Quaternion<T>::rotation(Math::Deg<T>{T(35.0)}, Math::Vector3<T>::yAxis()),
+            {T(1.0), T(1.0), T(1.0)}},
+        {2, {}, /* Identity transformation here */
+            {},
+            {T(1.0), T(1.0), T(1.0)}},
+        {4, {},
+            {},
+            {T(2.0), T(1.0), T(0.0)}},
+        {7, {T(1.5), T(2.5), T(3.5)},
+            Math::Quaternion<T>::rotation(Math::Deg<T>{T(-15.0)}, Math::Vector3<T>::xAxis()),
+            {T(-0.5), T(4.0), T(-16.0)}},
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneFieldData translation{SceneField::Translation,
+        view.slice(&Field::object),
+        view.slice(&Field::translation)};
+    SceneFieldData rotation{SceneField::Rotation,
+        view.slice(&Field::object),
+        view.slice(&Field::rotation)};
+    SceneFieldData scaling{SceneField::Scaling,
+        view.slice(&Field::object),
+        view.slice(&Field::scaling)};
+
+    /* Just one of translation / rotation / scaling */
+    {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4::translation({3.0f, 2.0, 1.0f}),
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4::translation({1.5f, 2.5f, 3.5f})
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            rotation
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4{Math::IdentityInit},
+            Matrix4::rotationY(35.0_degf),
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4::rotationX(-15.0_degf)
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
+            Matrix4::scaling({-0.5f, 4.0f, -16.0f})
+        }), TestSuite::Compare::Container);
+    }
+
+    /* Pairs */
+    {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation,
+            rotation
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4::translation({3.0f, 2.0, 1.0f}),
+            Matrix4::rotationY(35.0_degf),
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX(-15.0_degf)
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation,
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4::translation({3.0f, 2.0, 1.0f}),
+            Matrix4{Math::IdentityInit},
+            Matrix4{Math::IdentityInit},
+            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
+            Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
+        }), TestSuite::Compare::Container);
+    } {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            rotation,
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4{Math::IdentityInit},
+            Matrix4::rotationY(35.0_degf),
+            Matrix4{Math::IdentityInit},
+            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
+            Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
+        }), TestSuite::Compare::Container);
+    }
+
+    /* All */
+    {
+        SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
+            translation,
+            rotation,
+            scaling
+        }};
+        CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView<Matrix4>({
+            Matrix4::translation({3.0f, 2.0, 1.0f}),
+            Matrix4::rotationY(35.0_degf),
+            Matrix4{Math::IdentityInit},
+            Matrix4::scaling({2.0f, 1.0f, 0.0f}),
+            Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
+        }), TestSuite::Compare::Container);
+    }
+}
+
+template<class T> void SceneDataTest::transformations3DAsArrayBut2DType() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<T>::type(), nullptr}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.transformations3DAsArray();
+    CORRADE_COMPARE(out.str(), Utility::formatString(
+        "Trade::SceneData::transformations3DInto(): field has a 2D transformation type Trade::SceneFieldType::{}\n", NameTraits<T>::name()));
+}
+
+template<class T> void SceneDataTest::transformations3DAsArrayBut2DTypeTRS() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    SceneData translation{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr}
+    }};
+    SceneData rotation{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Complex<T>>::type(), nullptr}
+    }};
+    SceneData scaling{SceneObjectType::UnsignedInt, 0, nullptr, {
+        SceneFieldData{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    translation.transformations3DAsArray();
+    rotation.transformations3DAsArray();
+    scaling.transformations3DAsArray();
+    CORRADE_COMPARE(out.str(), Utility::formatString(
+        "Trade::SceneData::transformations3DInto(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData::transformations3DInto(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData::transformations3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector2<T>>::name(), NameTraits<Math::Complex<T>>::name()));
+}
+
+void SceneDataTest::transformations3DIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        Matrix4 transformation;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Transformation, view.slice(&Field::object), view.slice(&Field::transformation)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    Matrix4 destination[2];
+    scene.transformations3DInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::transformations3DInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::meshesAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedByte object;
+        T mesh;
+    } fields[3]{
+        {0, T(15)},
+        {1, T(37)},
+        {15, T(44)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+
+    UnsignedInt expected[]{15, 37, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.meshesAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    UnsignedInt out[3];
+    scene.meshesInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+void SceneDataTest::meshesIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt mesh;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    UnsignedInt destination[2];
+    scene.meshesInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::meshesInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::meshMaterialsAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedByte object;
+        T meshMaterial;
+    } fields[]{
+        {0, T(15)},
+        {1, T(37)},
+        {15, T(44)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::MeshMaterial, view.slice(&Field::object), view.slice(&Field::meshMaterial)}
+    }};
+
+    UnsignedInt expected[]{15, 37, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.meshMaterialsAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    UnsignedInt out[3];
+    scene.meshMaterialsInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+void SceneDataTest::meshMaterialsIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt meshMaterial;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::MeshMaterial, view.slice(&Field::object), view.slice(&Field::meshMaterial)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    UnsignedInt destination[2];
+    scene.meshMaterialsInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::meshMaterialsInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::lightsAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedByte object;
+        T light;
+    } fields[]{
+        {0, T(15)},
+        {1, T(37)},
+        {15, T(44)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
+    }};
+
+    UnsignedInt expected[]{15, 37, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.lightsAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    UnsignedInt out[3];
+    scene.lightsInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+void SceneDataTest::lightsIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt light;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    UnsignedInt destination[2];
+    scene.lightsInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::lightsInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::camerasAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedByte object;
+        T camera;
+    } fields[]{
+        {0, T(15)},
+        {1, T(37)},
+        {15, T(44)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
+    }};
+
+    UnsignedInt expected[]{15, 37, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.camerasAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    UnsignedInt out[3];
+    scene.camerasInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+void SceneDataTest::camerasIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt camera;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    UnsignedInt destination[2];
+    scene.camerasInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::camerasInto(): expected a view with 3 elements but got 2\n");
+}
+
+template<class T> void SceneDataTest::skinsAsArray() {
+    setTestCaseTemplateName(NameTraits<T>::name());
+
+    struct Field {
+        UnsignedByte object;
+        T skin;
+    } fields[]{
+        {0, T(15)},
+        {1, T(37)},
+        {15, T(44)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
+    }};
+
+    UnsignedInt expected[]{15, 37, 44};
+    CORRADE_COMPARE_AS(arrayView(scene.skinsAsArray()),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+
+    /* Test Into() as well as it only shares a common helper with AsArray() but
+       has different top-level code paths */
+    UnsignedInt out[3];
+    scene.skinsInto(out);
+    CORRADE_COMPARE_AS(Containers::arrayView(out),
+        Containers::arrayView(expected),
+        TestSuite::Compare::Container);
+}
+
+void SceneDataTest::skinsIntoArrayInvalidSize() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt skin;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    UnsignedInt destination[2];
+    scene.skinsInto(destination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::skinsInto(): expected a view with 3 elements but got 2\n");
+}
+
+void SceneDataTest::mutableAccessNotAllowed() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    const struct Field {
+        UnsignedInt object;
+        UnsignedShort foobar;
+        UnsignedShort mesh;
+    } fields[2]{};
+
+    Containers::StridedArrayView1D<const Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{sceneFieldCustom(35),
+            view.slice(&Field::object),
+            view.slice(&Field::foobar)},
+        SceneFieldData{SceneField::Mesh,
+            view.slice(&Field::object),
+            view.slice(&Field::mesh)},
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.mutableData();
+    scene.mutableObjects(0);
+    scene.mutableObjects<UnsignedInt>(0);
+    scene.mutableObjects(SceneField::Mesh);
+    scene.mutableObjects<UnsignedInt>(SceneField::Mesh);
+    scene.mutableField(0);
+    scene.mutableField<UnsignedInt>(0);
+    scene.mutableField<UnsignedInt[]>(1);
+    scene.mutableField(SceneField::Mesh);
+    scene.mutableField<UnsignedInt>(SceneField::Mesh);
+    scene.mutableField<UnsignedInt[]>(sceneFieldCustom(35));
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::mutableData(): data not mutable\n"
+        "Trade::SceneData::mutableObjects(): data not mutable\n"
+        "Trade::SceneData::mutableObjects(): data not mutable\n"
+        "Trade::SceneData::mutableObjects(): data not mutable\n"
+        "Trade::SceneData::mutableObjects(): data not mutable\n"
+        "Trade::SceneData::mutableField(): data not mutable\n"
+        "Trade::SceneData::mutableField(): data not mutable\n"
+        "Trade::SceneData::mutableField(): data not mutable\n"
+        "Trade::SceneData::mutableField(): data not mutable\n"
+        "Trade::SceneData::mutableField(): data not mutable\n"
+        "Trade::SceneData::mutableField(): data not mutable\n");
+}
+
+void SceneDataTest::objectsNotFound() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedShort foobar;
+        UnsignedShort mesh;
+    } fields[2]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+        SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::foobar)},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.objects(2);
+    scene.objects<UnsignedInt>(2);
+    scene.mutableObjects(2);
+    scene.mutableObjects<UnsignedInt>(2);
+    scene.objects(sceneFieldCustom(666));
+    scene.objects<UnsignedInt>(sceneFieldCustom(666));
+    scene.mutableObjects(sceneFieldCustom(666));
+    scene.mutableObjects<UnsignedInt>(sceneFieldCustom(666));
+
+    scene.objectsAsArray(2);
+    scene.objectsAsArray(sceneFieldCustom(666));
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::objects(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::objects(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableObjects(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableObjects(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::objects(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::objects(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableObjects(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableObjects(): field Trade::SceneField::Custom(666) not found\n"
+
+        "Trade::SceneData::objectsInto(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::objectsInto(): field Trade::SceneField::Custom(666) not found\n");
+}
+
+void SceneDataTest::objectsWrongType() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedShort object;
+        UnsignedShort foobar;
+        UnsignedInt mesh;
+    } fields[2]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedShort, 5, DataFlag::Mutable, fields, {
+        SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::foobar)},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.objects<UnsignedByte>(1);
+    scene.mutableObjects<UnsignedByte>(1);
+    scene.objects<UnsignedByte>(SceneField::Mesh);
+    scene.mutableObjects<UnsignedByte>(SceneField::Mesh);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::objects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n"
+        "Trade::SceneData::mutableObjects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n"
+        "Trade::SceneData::objects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n"
+        "Trade::SceneData::mutableObjects(): objects are Trade::SceneObjectType::UnsignedShort but requested Trade::SceneObjectType::UnsignedByte\n");
+}
+
+void SceneDataTest::fieldNotFound() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt foo, bar;
+    } fields[2]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+        SceneFieldData{sceneFieldCustom(34), view.slice(&Field::object), view.slice(&Field::foo)},
+        SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::bar)},
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.fieldData(2);
+    scene.fieldName(2);
+    scene.fieldType(2);
+    scene.fieldSize(2);
+    scene.fieldArraySize(2);
+    scene.field(2);
+    scene.field<UnsignedInt>(2);
+    scene.field<UnsignedInt[]>(2);
+    scene.mutableField(2);
+    scene.mutableField<UnsignedInt>(2);
+    scene.mutableField<UnsignedInt[]>(2);
+
+    scene.fieldId(sceneFieldCustom(666));
+    scene.fieldType(sceneFieldCustom(666));
+    scene.fieldSize(sceneFieldCustom(666));
+    scene.fieldArraySize(sceneFieldCustom(666));
+    scene.field(sceneFieldCustom(666));
+    scene.field<UnsignedInt>(sceneFieldCustom(666));
+    scene.field<UnsignedInt[]>(sceneFieldCustom(666));
+    scene.mutableField(sceneFieldCustom(666));
+    scene.mutableField<UnsignedInt>(sceneFieldCustom(666));
+    scene.mutableField<UnsignedInt[]>(sceneFieldCustom(666));
+
+    scene.parentsAsArray();
+    scene.transformations2DAsArray();
+    scene.transformations3DAsArray();
+    /* Test both AsArray() and Into() for transformations as they only share a
+       common helper but have different top-level code paths. They however have
+       the same assertion messages to save binary size a bit. */
+    scene.transformations2DInto(nullptr);
+    scene.transformations3DInto(nullptr);
+    scene.meshesAsArray();
+    scene.meshMaterialsAsArray();
+    scene.lightsAsArray();
+    scene.camerasAsArray();
+    scene.skinsAsArray();
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::fieldData(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::fieldName(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::fieldType(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::fieldSize(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::fieldArraySize(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::field(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::field(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::field(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableField(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableField(): index 2 out of range for 2 fields\n"
+        "Trade::SceneData::mutableField(): index 2 out of range for 2 fields\n"
+
+        "Trade::SceneData::fieldId(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::fieldType(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::fieldSize(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::fieldArraySize(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::field(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::field(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::field(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableField(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableField(): field Trade::SceneField::Custom(666) not found\n"
+        "Trade::SceneData::mutableField(): field Trade::SceneField::Custom(666) not found\n"
+
+        "Trade::SceneData::parentsInto(): field not found\n"
+        /* Test both AsArray() and Into() for transformations as they only
+           share a common helper but have different top-level code paths. They
+           however have the same assertion messages to save binary size a
+           bit. */
+        "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
+        "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
+        "Trade::SceneData::meshesInto(): field not found\n"
+        "Trade::SceneData::meshMaterialsInto(): field not found\n"
+        "Trade::SceneData::lightsInto(): field not found\n"
+        "Trade::SceneData::camerasInto(): field not found\n"
+        "Trade::SceneData::skinsInto(): field not found\n");
+}
+
+void SceneDataTest::fieldWrongType() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedShort foobar;
+        UnsignedShort mesh;
+    } fields[2]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+        SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), view.slice(&Field::foobar)},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.field<UnsignedByte>(1);
+    scene.field<UnsignedByte[]>(1);
+    scene.mutableField<UnsignedByte>(1);
+    scene.mutableField<UnsignedByte[]>(1);
+    scene.field<UnsignedByte>(SceneField::Mesh);
+    scene.field<UnsignedByte[]>(SceneField::Mesh);
+    scene.mutableField<UnsignedByte>(SceneField::Mesh);
+    scene.mutableField<UnsignedByte[]>(SceneField::Mesh);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::field(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::field(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::field(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::field(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Mesh is Trade::SceneFieldType::UnsignedShort but requested a type equivalent to Trade::SceneFieldType::UnsignedByte\n");
+}
+
+void SceneDataTest::fieldWrongArrayAccess() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt mesh;
+        UnsignedInt foobar;
+    } fields[2]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, DataFlag::Mutable, fields, {
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)},
+        SceneFieldData{sceneFieldCustom(35), view.slice(&Field::object), Containers::arrayCast<2, UnsignedInt>(view.slice(&Field::foobar))},
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    scene.field<UnsignedInt[]>(0);
+    scene.field<UnsignedInt>(1);
+    scene.mutableField<UnsignedInt[]>(0);
+    scene.mutableField<UnsignedInt>(1);
+    scene.field<UnsignedInt[]>(SceneField::Mesh);
+    scene.field<UnsignedInt>(sceneFieldCustom(35));
+    scene.mutableField<UnsignedInt[]>(SceneField::Mesh);
+    scene.mutableField<UnsignedInt>(sceneFieldCustom(35));
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::field(): Trade::SceneField::Mesh is not an array field, can't use T[] to access it\n"
+        "Trade::SceneData::field(): Trade::SceneField::Custom(35) is an array field, use T[] to access it\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Mesh is not an array field, can't use T[] to access it\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Custom(35) is an array field, use T[] to access it\n"
+        "Trade::SceneData::field(): Trade::SceneField::Mesh is not an array field, can't use T[] to access it\n"
+        "Trade::SceneData::field(): Trade::SceneField::Custom(35) is an array field, use T[] to access it\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Mesh is not an array field, can't use T[] to access it\n"
+        "Trade::SceneData::mutableField(): Trade::SceneField::Custom(35) is an array field, use T[] to access it\n");
+}
+
+void SceneDataTest::releaseFieldData() {
+    struct Field {
+        UnsignedByte object;
+        UnsignedInt mesh;
+    };
+
+    Containers::Array<char> data{NoInit, 3*sizeof(Field)};
+    Containers::StridedArrayView1D<Field> view = Containers::arrayCast<Field>(data);
+
+    auto fields = Containers::array({
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    });
+    SceneFieldData* originalFields = fields;
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, std::move(data), std::move(fields)};
+
+    Containers::Array<SceneFieldData> released = scene.releaseFieldData();
+    CORRADE_COMPARE(released.data(), originalFields);
+    CORRADE_COMPARE(released.size(), 2);
+
+    /* Fields are all gone */
+    CORRADE_COMPARE(static_cast<const void*>(scene.fieldData()), nullptr);
+    CORRADE_COMPARE(scene.fieldCount(), 0);
+
+    /* Data stays untouched, object count and type as well, as it con't result
+       in any dangling data access */
+    CORRADE_COMPARE(scene.data(), view.data());
+    CORRADE_COMPARE(scene.objectCount(), 50);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedByte);
+}
+
+void SceneDataTest::releaseData() {
+    struct Field {
+        UnsignedByte object;
+        UnsignedByte mesh;
+    };
+
+    Containers::Array<char> data{NoInit, 3*sizeof(Field)};
+    Containers::StridedArrayView1D<Field> view = Containers::arrayCast<Field>(data);
+
+    SceneData scene{SceneObjectType::UnsignedByte, 50, std::move(data), {
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedByte, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
+    }};
+
+    Containers::Array<char> released = scene.releaseData();
+    CORRADE_COMPARE(released.data(), view.data());
+    CORRADE_COMPARE(released.size(), 3*sizeof(Field));
+
+    /* Both fields and data are all gone */
+    CORRADE_COMPARE(static_cast<const void*>(scene.fieldData()), nullptr);
+    CORRADE_COMPARE(scene.fieldCount(), 0);
+    CORRADE_COMPARE(static_cast<const void*>(scene.data()), nullptr);
+
+    /* Object count and type stays untouched, as it con't result in any
+       dangling data access */
+    CORRADE_COMPARE(scene.objectCount(), 50);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedByte);
 }
 
 }}}}

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -50,8 +50,8 @@ namespace Magnum { namespace Trade { namespace Test { namespace {
 struct SceneDataTest: TestSuite::Tester {
     explicit SceneDataTest();
 
-    void objectTypeSize();
-    void objectTypeSizeInvalid();
+    void objectTypeSizeAlignment();
+    void objectTypeSizeAlignmentInvalid();
     void debugObjectType();
 
     void customFieldName();
@@ -59,8 +59,8 @@ struct SceneDataTest: TestSuite::Tester {
     void customFieldNameNotCustom();
     void debugFieldName();
 
-    void fieldTypeSize();
-    void fieldTypeSizeInvalid();
+    void fieldTypeSizeAlignment();
+    void fieldTypeSizeAlignmentInvalid();
     void debugFieldType();
 
     void constructField();
@@ -223,8 +223,8 @@ const struct {
 #endif
 
 SceneDataTest::SceneDataTest() {
-    addTests({&SceneDataTest::objectTypeSize,
-              &SceneDataTest::objectTypeSizeInvalid,
+    addTests({&SceneDataTest::objectTypeSizeAlignment,
+              &SceneDataTest::objectTypeSizeAlignmentInvalid,
               &SceneDataTest::debugObjectType,
 
               &SceneDataTest::customFieldName,
@@ -232,8 +232,8 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::customFieldNameNotCustom,
               &SceneDataTest::debugFieldName,
 
-              &SceneDataTest::fieldTypeSize,
-              &SceneDataTest::fieldTypeSizeInvalid,
+              &SceneDataTest::fieldTypeSizeAlignment,
+              &SceneDataTest::fieldTypeSizeAlignmentInvalid,
               &SceneDataTest::debugFieldType,
 
               &SceneDataTest::constructField,
@@ -427,14 +427,18 @@ SceneDataTest::SceneDataTest() {
 
 using namespace Math::Literals;
 
-void SceneDataTest::objectTypeSize() {
+void SceneDataTest::objectTypeSizeAlignment() {
     CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedByte), 1);
+    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedByte), 1);
     CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedShort), 2);
+    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedShort), 2);
     CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedInt), 4);
+    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedInt), 4);
     CORRADE_COMPARE(sceneObjectTypeSize(SceneObjectType::UnsignedLong), 8);
+    CORRADE_COMPARE(sceneObjectTypeAlignment(SceneObjectType::UnsignedLong), 8);
 }
 
-void SceneDataTest::objectTypeSizeInvalid() {
+void SceneDataTest::objectTypeSizeAlignmentInvalid() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -443,11 +447,15 @@ void SceneDataTest::objectTypeSizeInvalid() {
     Error redirectError{&out};
 
     sceneObjectTypeSize(SceneObjectType{});
+    sceneObjectTypeAlignment(SceneObjectType{});
     sceneObjectTypeSize(SceneObjectType(0x73));
+    sceneObjectTypeAlignment(SceneObjectType(0x73));
 
     CORRADE_COMPARE(out.str(),
         "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x0)\n"
-        "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x73)\n");
+        "Trade::sceneObjectTypeAlignment(): invalid type Trade::SceneObjectType(0x0)\n"
+        "Trade::sceneObjectTypeSize(): invalid type Trade::SceneObjectType(0x73)\n"
+        "Trade::sceneObjectTypeAlignment(): invalid type Trade::SceneObjectType(0x73)\n");
 }
 
 void SceneDataTest::debugObjectType() {
@@ -506,7 +514,7 @@ void SceneDataTest::debugFieldName() {
     CORRADE_COMPARE(out.str(), "Trade::SceneField::Transformation Trade::SceneField::Custom(73) Trade::SceneField(0xdeadda7)\n");
 }
 
-void SceneDataTest::fieldTypeSize() {
+void SceneDataTest::fieldTypeSizeAlignment() {
     /* Test at least one of every size */
     CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Byte), sizeof(Byte));
     CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Degh), sizeof(Degh));
@@ -526,9 +534,16 @@ void SceneDataTest::fieldTypeSize() {
     CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix3x4d), sizeof(Matrix3x4d));
     CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Matrix4x4d), sizeof(Matrix4x4d));
     CORRADE_COMPARE(sceneFieldTypeSize(SceneFieldType::Pointer), sizeof(const void*));
+
+    /* Test at least one of every alignment */
+    CORRADE_COMPARE(sceneFieldTypeAlignment(SceneFieldType::Vector3ub), alignof(UnsignedByte));
+    CORRADE_COMPARE(sceneFieldTypeAlignment(SceneFieldType::Matrix3x3h), alignof(Half));
+    CORRADE_COMPARE(sceneFieldTypeAlignment(SceneFieldType::Range3Di), alignof(UnsignedInt));
+    CORRADE_COMPARE(sceneFieldTypeAlignment(SceneFieldType::DualComplexd), alignof(Double));
+    CORRADE_COMPARE(sceneFieldTypeAlignment(SceneFieldType::Pointer), alignof(const void*));
 }
 
-void SceneDataTest::fieldTypeSizeInvalid() {
+void SceneDataTest::fieldTypeSizeAlignmentInvalid() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -537,11 +552,15 @@ void SceneDataTest::fieldTypeSizeInvalid() {
     Error redirectError{&out};
 
     sceneFieldTypeSize(SceneFieldType{});
+    sceneFieldTypeAlignment(SceneFieldType{});
     sceneFieldTypeSize(SceneFieldType(0xdead));
+    sceneFieldTypeAlignment(SceneFieldType(0xdead));
 
     CORRADE_COMPARE(out.str(),
         "Trade::sceneFieldTypeSize(): invalid type Trade::SceneFieldType(0x0)\n"
-        "Trade::sceneFieldTypeSize(): invalid type Trade::SceneFieldType(0xdead)\n");
+        "Trade::sceneFieldTypeAlignment(): invalid type Trade::SceneFieldType(0x0)\n"
+        "Trade::sceneFieldTypeSize(): invalid type Trade::SceneFieldType(0xdead)\n"
+        "Trade::sceneFieldTypeAlignment(): invalid type Trade::SceneFieldType(0xdead)\n");
 }
 
 void SceneDataTest::debugFieldType() {

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -335,6 +335,8 @@ SceneDataTest::SceneDataTest() {
     addTests({&SceneDataTest::parentsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::transformations2DAsArray<Matrix3>,
               &SceneDataTest::transformations2DAsArray<Matrix3d>,
+              &SceneDataTest::transformations2DAsArray<Matrix3x2>,
+              &SceneDataTest::transformations2DAsArray<Matrix3x2d>,
               &SceneDataTest::transformations2DAsArray<DualComplex>,
               &SceneDataTest::transformations2DAsArray<DualComplexd>,
               &SceneDataTest::transformations2DAsArrayTRS<Float, Float, Double>,
@@ -349,6 +351,8 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS,
               &SceneDataTest::transformations3DAsArray<Matrix4>,
               &SceneDataTest::transformations3DAsArray<Matrix4d>,
+              &SceneDataTest::transformations3DAsArray<Matrix4x3>,
+              &SceneDataTest::transformations3DAsArray<Matrix4x3d>,
               &SceneDataTest::transformations3DAsArray<DualQuaternion>,
               &SceneDataTest::transformations3DAsArray<DualQuaterniond>,
               &SceneDataTest::transformations3DAsArrayTRS<Float, Double, Double>,
@@ -1779,8 +1783,12 @@ _c(Vector3)
 _c(Vector3d)
 _c(Matrix3)
 _c(Matrix3d)
+_c(Matrix3x2)
+_c(Matrix3x2d)
 _c(Matrix4)
 _c(Matrix4d)
+_c(Matrix4x3)
+_c(Matrix4x3d)
 _c(Complex)
 _c(Complexd)
 _c(Quaternion)
@@ -1805,8 +1813,10 @@ template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
     #endif
 
     SceneFieldData transformationMatrices2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3<T>>::type(), nullptr};
+    SceneFieldData transformationRectangularMatrices2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix3x2<T>>::type(), nullptr};
     SceneFieldData transformations2D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualComplex<T>>::type(), nullptr};
     SceneFieldData transformationMatrices3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4<T>>::type(), nullptr};
+    SceneFieldData transformationRectangularMatrices3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Matrix4x3<T>>::type(), nullptr};
     SceneFieldData transformations3D{SceneField::Transformation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::DualQuaternion<T>>::type(), nullptr};
     SceneFieldData translations2D{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr};
     SceneFieldData translations3D{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr};
@@ -1821,6 +1831,10 @@ template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, translations3D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, rotations3D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices2D, scalings3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, translations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, rotations3D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices2D, scalings3D}};
+
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, translations3D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, rotations3D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations2D, scalings3D}};
@@ -1831,6 +1845,10 @@ template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, translations2D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, rotations2D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationMatrices3D, scalings2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, translations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, rotations2D}};
+    SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformationRectangularMatrices3D, scalings2D}};
+
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, translations2D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, rotations2D}};
     SceneData{SceneObjectType::UnsignedInt, 0, nullptr, {transformations3D, scalings2D}};
@@ -1844,6 +1862,10 @@ template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
         "Trade::SceneData: expected a 2D translation field but got Trade::SceneFieldType::{0}\n"
         "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
         "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
+
+        "Trade::SceneData: expected a 2D translation field but got Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
         "Trade::SceneData: expected a 2D rotation field but got Trade::SceneFieldType::{1}\n"
         "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
         "Trade::SceneData: expected a 2D scaling field but got Trade::SceneFieldType::{0}\n"
@@ -1851,6 +1873,10 @@ template<class T> void SceneDataTest::constructMismatchedTRSDimensionality() {
         "Trade::SceneData: expected a 3D translation field but got Trade::SceneFieldType::{2}\n"
         "Trade::SceneData: expected a 3D rotation field but got Trade::SceneFieldType::{3}\n"
         "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D translation field but got Trade::SceneFieldType::{2}\n"
+        "Trade::SceneData: expected a 3D rotation field but got Trade::SceneFieldType::{3}\n"
+        "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n"
+
         "Trade::SceneData: expected a 3D translation field but got Trade::SceneFieldType::{2}\n"
         "Trade::SceneData: expected a 3D rotation field but got Trade::SceneFieldType::{3}\n"
         "Trade::SceneData: expected a 3D scaling field but got Trade::SceneFieldType::{2}\n"
@@ -2429,10 +2455,21 @@ void SceneDataTest::parentsIntoArrayInvalidSizeOrOffset() {
         "Trade::SceneData::parentsInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
+template<class T> struct TransformationTypeFor {
+    typedef T Type;
+};
+template<class T> struct TransformationTypeFor<Math::Matrix3x2<T>> {
+    typedef Math::Matrix3<T> Type;
+};
+template<class T> struct TransformationTypeFor<Math::Matrix4x3<T>> {
+    typedef Math::Matrix4<T> Type;
+};
+
 template<class T> void SceneDataTest::transformations2DAsArray() {
     setTestCaseTemplateName(NameTraits<T>::name());
 
     typedef typename T::Type U;
+    typedef typename TransformationTypeFor<T>::Type TT;
 
     struct Transformation {
         UnsignedInt object;
@@ -2451,12 +2488,12 @@ template<class T> void SceneDataTest::transformations2DAsArray() {
         {NoInit, 4, transformations},
         {NoInit, 2, components}
     };
-    transformations[0] = {1, T::translation({U(3.0), U(2.0)})};
-    transformations[1] = {0, T::rotation(Math::Deg<U>(35.0))};
-    transformations[2] = {4, T::translation({U(1.5), U(2.5)})*
-                             T::rotation(Math::Deg<U>(-15.0))};
-    transformations[3] = {5, T::rotation(Math::Deg<U>(-15.0))*
-                             T::translation({U(1.5), U(2.5)})};
+    transformations[0] = {1, T{TT::translation({U(3.0), U(2.0)})}};
+    transformations[1] = {0, T{TT::rotation(Math::Deg<U>(35.0))}};
+    transformations[2] = {4, T{TT::translation({U(1.5), U(2.5)})*
+                               TT::rotation(Math::Deg<U>(-15.0))}};
+    transformations[3] = {5, T{TT::rotation(Math::Deg<U>(-15.0))*
+                               TT::translation({U(1.5), U(2.5)})}};
     /* Object number 4 additionally has a scaling component (which isn't
        representable with dual complex numbers). It currently doesn't get added
        to the transformations returned from transformations2DInto() but that
@@ -2980,6 +3017,7 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
     setTestCaseTemplateName(NameTraits<T>::name());
 
     typedef typename T::Type U;
+    typedef typename TransformationTypeFor<T>::Type TT;
 
     struct Transformation {
         UnsignedInt object;
@@ -2998,15 +3036,15 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
         {NoInit, 4, transformations},
         {NoInit, 2, components}
     };
-    transformations[0] = {1, T::translation({U(3.0), U(2.0), U(-0.5)})};
-    transformations[1] = {0, T::rotation(Math::Deg<U>(35.0),
-                                         Math::Vector3<U>::yAxis())};
-    transformations[2] = {4, T::translation({U(1.5), U(2.5), U(0.75)})*
-                             T::rotation(Math::Deg<U>(-15.0),
-                                         Math::Vector3<U>::xAxis())};
-    transformations[3] = {5, T::rotation(Math::Deg<U>(-15.0),
-                                         Math::Vector3<U>::xAxis())*
-                             T::translation({U(1.5), U(2.5), U(0.75)})};
+    transformations[0] = {1, T{TT::translation({U(3.0), U(2.0), U(-0.5)})}};
+    transformations[1] = {0, T{TT::rotation(Math::Deg<U>(35.0),
+                                            Math::Vector3<U>::yAxis())}};
+    transformations[2] = {4, T{TT::translation({U(1.5), U(2.5), U(0.75)})*
+                               TT::rotation(Math::Deg<U>(-15.0),
+                                            Math::Vector3<U>::xAxis())}};
+    transformations[3] = {5, T{TT::rotation(Math::Deg<U>(-15.0),
+                                            Math::Vector3<U>::xAxis())*
+                               TT::translation({U(1.5), U(2.5), U(0.75)})}};
     /* Object number 4 additionally has a scaling component (which isn't
        representable with dual quaternions). It currently doesn't get added
        to the transformations returned from transformations2DInto() but that

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -1290,7 +1290,7 @@ void SceneDataTest::constructNotOwned() {
     CORRADE_COMPARE(scene.dataFlags(), instanceData.dataFlags);
     CORRADE_COMPARE(static_cast<const void*>(scene.data()), +data);
     if(instanceData.dataFlags & DataFlag::Mutable)
-        CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), +data);
+        CORRADE_COMPARE(static_cast<void*>(scene.mutableData()), static_cast<void*>(data));
     CORRADE_COMPARE(scene.objectCount(), 7);
     CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldCount(), 1);

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -112,14 +112,14 @@ struct SceneDataTest: TestSuite::Tester {
     void parentsIntoArray();
     void parentsIntoArrayInvalidSizeOrOffset();
     template<class T> void transformations2DAsArray();
-    template<class T> void transformations2DAsArrayTRS();
+    template<class T, class U, class V> void transformations2DAsArrayTRS();
     template<class T> void transformations2DAsArrayBut3DType();
     template<class T> void transformations2DAsArrayBut3DTypeTRS();
     void transformations2DIntoArray();
     void transformations2DIntoArrayTRS();
     void transformations2DIntoArrayInvalidSizeOrOffset();
     template<class T> void transformations3DAsArray();
-    template<class T> void transformations3DAsArrayTRS();
+    template<class T, class U, class V> void transformations3DAsArrayTRS();
     template<class T> void transformations3DAsArrayBut2DType();
     template<class T> void transformations3DAsArrayBut2DTypeTRS();
     void transformations3DIntoArray();
@@ -261,8 +261,8 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations2DAsArray<Matrix3d>,
               &SceneDataTest::transformations2DAsArray<DualComplex>,
               &SceneDataTest::transformations2DAsArray<DualComplexd>,
-              &SceneDataTest::transformations2DAsArrayTRS<Float>,
-              &SceneDataTest::transformations2DAsArrayTRS<Double>,
+              &SceneDataTest::transformations2DAsArrayTRS<Float, Float, Double>,
+              &SceneDataTest::transformations2DAsArrayTRS<Double, Double, Float>,
               &SceneDataTest::transformations2DAsArrayBut3DType<Matrix4x4>,
               &SceneDataTest::transformations2DAsArrayBut3DType<Matrix4x4d>,
               &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaternion>,
@@ -279,8 +279,8 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations3DAsArray<Matrix4d>,
               &SceneDataTest::transformations3DAsArray<DualQuaternion>,
               &SceneDataTest::transformations3DAsArray<DualQuaterniond>,
-              &SceneDataTest::transformations3DAsArrayTRS<Float>,
-              &SceneDataTest::transformations3DAsArrayTRS<Double>,
+              &SceneDataTest::transformations3DAsArrayTRS<Float, Double, Double>,
+              &SceneDataTest::transformations3DAsArrayTRS<Double, Float, Float>,
               &SceneDataTest::transformations3DAsArrayBut2DType<Matrix3x3>,
               &SceneDataTest::transformations3DAsArrayBut2DType<Matrix3x3d>,
               &SceneDataTest::transformations3DAsArrayBut2DType<DualComplex>,
@@ -2097,30 +2097,30 @@ template<class T> void SceneDataTest::transformations2DAsArray() {
     }), TestSuite::Compare::Container);
 }
 
-template<class T> void SceneDataTest::transformations2DAsArrayTRS() {
-    setTestCaseTemplateName(NameTraits<T>::name());
+template<class T, class U, class V> void SceneDataTest::transformations2DAsArrayTRS() {
+    setTestCaseTemplateName({NameTraits<T>::name(), NameTraits<U>::name(), NameTraits<V>::name()});
 
     struct Field {
         UnsignedInt object;
         Math::Vector2<T> translation;
-        Math::Complex<T> rotation;
-        Math::Vector2<T> scaling;
+        Math::Complex<U> rotation;
+        Math::Vector2<V> scaling;
     } fields[]{
         {1, {T(3.0), T(2.0)},
             {},
-            {T(1.0), T(1.0)}},
+            {V(1.0), V(1.0)}},
         {0, {},
-            Math::Complex<T>::rotation(Math::Deg<T>{T(35.0)}),
-            {T(1.0), T(1.0)}},
+            Math::Complex<U>::rotation(Math::Deg<U>{U(35.0)}),
+            {V(1.0), V(1.0)}},
         {2, {}, /* Identity transformation here */
             {},
-            {T(1.0), T(1.0)}},
+            {V(1.0), V(1.0)}},
         {4, {},
             {},
-            {T(2.0), T(1.0)}},
+            {V(2.0), V(1.0)}},
         {7, {T(1.5), T(2.5)},
-            Math::Complex<T>::rotation(Math::Deg<T>{T(-15.0)}),
-            {T(-0.5), T(4.0)}},
+            Math::Complex<U>::rotation(Math::Deg<U>{U(-15.0)}),
+            {V(-0.5), V(4.0)}},
     };
 
     Containers::StridedArrayView1D<Field> view = fields;
@@ -2470,30 +2470,30 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
     }), TestSuite::Compare::Container);
 }
 
-template<class T> void SceneDataTest::transformations3DAsArrayTRS() {
-    setTestCaseTemplateName(NameTraits<T>::name());
+template<class T, class U, class V> void SceneDataTest::transformations3DAsArrayTRS() {
+    setTestCaseTemplateName({NameTraits<T>::name(), NameTraits<U>::name(), NameTraits<V>::name()});
 
     struct Field {
         UnsignedInt object;
         Math::Vector3<T> translation;
-        Math::Quaternion<T> rotation;
-        Math::Vector3<T> scaling;
+        Math::Quaternion<U> rotation;
+        Math::Vector3<V> scaling;
     } fields[]{
         {1, {T(3.0), T(2.0), T(1.0)},
             {},
-            {T(1.0), T(1.0), T(1.0)}},
+            {V(1.0), V(1.0), V(1.0)}},
         {0, {},
-            Math::Quaternion<T>::rotation(Math::Deg<T>{T(35.0)}, Math::Vector3<T>::yAxis()),
-            {T(1.0), T(1.0), T(1.0)}},
+            Math::Quaternion<U>::rotation(Math::Deg<U>{U(35.0)}, Math::Vector3<U>::yAxis()),
+            {V(1.0), V(1.0), V(1.0)}},
         {2, {}, /* Identity transformation here */
             {},
-            {T(1.0), T(1.0), T(1.0)}},
+            {V(1.0), V(1.0), V(1.0)}},
         {4, {},
             {},
-            {T(2.0), T(1.0), T(0.0)}},
+            {V(2.0), V(1.0), V(0.0)}},
         {7, {T(1.5), T(2.5), T(3.5)},
-            Math::Quaternion<T>::rotation(Math::Deg<T>{T(-15.0)}, Math::Vector3<T>::xAxis()),
-            {T(-0.5), T(4.0), T(-16.0)}},
+            Math::Quaternion<U>::rotation(Math::Deg<U>{U(-15.0)}, Math::Vector3<U>::xAxis()),
+            {V(-0.5), V(4.0), V(-16.0)}},
     };
 
     Containers::StridedArrayView1D<Field> view = fields;

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -3006,7 +3006,7 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset() {
     struct Field {
         UnsignedInt object;
         Matrix3 transformation;
-    } fields[3]{};
+    } fields[3]; /* GCC 4.8 ICEs if I do a {} here */
 
     Containers::StridedArrayView1D<Field> view = fields;
 
@@ -3032,7 +3032,7 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS() {
     struct Field {
         UnsignedInt object;
         Vector2 translation;
-    } fields[3]{};
+    } fields[3]; /* GCC 4.8 ICEs if I do a {} here */
 
     Containers::StridedArrayView1D<Field> view = fields;
 
@@ -3557,7 +3557,7 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset() {
     struct Field {
         UnsignedInt object;
         Matrix4 transformation;
-    } fields[3]{};
+    } fields[3]; /* GCC 4.8 ICEs if I do a {} here */
 
     Containers::StridedArrayView1D<Field> view = fields;
 
@@ -3583,7 +3583,7 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS() {
     struct Field {
         UnsignedInt object;
         Vector2 translation;
-    } fields[3]{};
+    } fields[3]; /* GCC 4.8 ICEs if I do a {} here */
 
     Containers::StridedArrayView1D<Field> view = fields;
 

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -303,9 +303,9 @@ SceneDataTest::SceneDataTest() {
         Containers::arraySize(IntoArrayOffsetData));
 
     addTests({&SceneDataTest::meshesIntoArrayInvalidSizeOrOffset,
-              &SceneDataTest::meshMaterialsAsArray<UnsignedByte>,
-              &SceneDataTest::meshMaterialsAsArray<UnsignedShort>,
-              &SceneDataTest::meshMaterialsAsArray<UnsignedInt>});
+              &SceneDataTest::meshMaterialsAsArray<Byte>,
+              &SceneDataTest::meshMaterialsAsArray<Short>,
+              &SceneDataTest::meshMaterialsAsArray<Int>});
 
     addInstancedTests({&SceneDataTest::meshMaterialsIntoArray},
         Containers::arraySize(IntoArrayOffsetData));
@@ -1314,7 +1314,7 @@ void SceneDataTest::constructZeroFields() {
 void SceneDataTest::constructZeroObjects() {
     int importerState;
     SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
     SceneData scene{SceneObjectType::UnsignedInt, 0, nullptr, {meshes, materials}, &importerState};
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
     CORRADE_VERIFY(!scene.fieldData().empty());
@@ -1327,7 +1327,7 @@ void SceneDataTest::constructZeroObjects() {
 
     /* Field property access by name */
     CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedShort);
-    CORRADE_COMPARE(scene.fieldType(SceneField::MeshMaterial), SceneFieldType::UnsignedInt);
+    CORRADE_COMPARE(scene.fieldType(SceneField::MeshMaterial), SceneFieldType::Int);
     CORRADE_COMPARE(scene.fieldSize(SceneField::Mesh), 0);
     CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 0);
     CORRADE_COMPARE(scene.objects(SceneField::Mesh).data(), nullptr);
@@ -1381,7 +1381,7 @@ void SceneDataTest::constructDuplicateField() {
     /* Builtin fields are checked using a bitfield, as they have monotonic
        numbering */
     SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr};
     SceneFieldData meshesAgain{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr};
 
     std::ostringstream out;
@@ -1413,7 +1413,7 @@ void SceneDataTest::constructInconsistentObjectType() {
     #endif
 
     SceneFieldData meshes{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedShort, nullptr};
-    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedShort, nullptr, SceneFieldType::UnsignedInt, nullptr};
+    SceneFieldData materials{SceneField::MeshMaterial, SceneObjectType::UnsignedShort, nullptr, SceneFieldType::Int, nullptr};
 
     std::ostringstream out;
     Error redirectError{&out};
@@ -1439,12 +1439,12 @@ void SceneDataTest::constructObjectDataNotContained() {
     }};
     /* Second a view that's in a completely different location */
     SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
-        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataOut, dataIn}
     }};
     /* Verify the owning constructor does the checks as well */
     SceneData{SceneObjectType::UnsignedShort, 5, std::move(data), {
-        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataOut, dataIn}
     }};
     /* And if we have no data at all, it doesn't try to dereference them but
@@ -1486,7 +1486,7 @@ void SceneDataTest::constructFieldDataNotContained() {
     }};
     /* Second a view that's in a completely different location */
     SceneData{SceneObjectType::UnsignedShort, 5, {}, data, {
-        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataIn, dataOut}
     }};
     /* Verify array size is taken into account as well. If not, the data would
@@ -1496,7 +1496,7 @@ void SceneDataTest::constructFieldDataNotContained() {
     }};
     /* Verify the owning constructor does the checks as well */
     SceneData{SceneObjectType::UnsignedShort, 5, std::move(data), {
-        SceneFieldData{SceneField::MeshMaterial, dataIn, dataIn},
+        SceneFieldData{SceneField::Light, dataIn, dataIn},
         SceneFieldData{SceneField::Mesh, dataIn, dataOut}
     }};
     /* Not checking for nullptr data, since that got checked for object view
@@ -1614,8 +1614,8 @@ void SceneDataTest::constructMismatchedMeshMaterialView() {
         reinterpret_cast<const UnsignedInt*>(data.data() + 0x0c), 3};
     Containers::ArrayView<const UnsignedInt> meshMaterialObjectData{
         reinterpret_cast<const UnsignedInt*>(data.data() + 0x18), 3};
-    Containers::ArrayView<const UnsignedInt> meshMaterialFieldData{
-        reinterpret_cast<const UnsignedInt*>(data.data() + 0x24), 3};
+    Containers::ArrayView<const Int> meshMaterialFieldData{
+        reinterpret_cast<const Int*>(data.data() + 0x24), 3};
 
     SceneFieldData meshes{SceneField::Mesh, meshObjectData, meshFieldData};
     SceneFieldData meshMaterialsDifferent{SceneField::MeshMaterial, meshMaterialObjectData, meshMaterialFieldData};
@@ -2892,7 +2892,7 @@ template<class T> void SceneDataTest::meshMaterialsAsArray() {
         T meshMaterial;
     } fields[]{
         {0, T(15)},
-        {1, T(37)},
+        {1, T(-1)},
         {15, T(44)}
     };
 
@@ -2905,7 +2905,7 @@ template<class T> void SceneDataTest::meshMaterialsAsArray() {
     }};
 
     CORRADE_COMPARE_AS(scene.meshMaterialsAsArray(),
-        Containers::arrayView<UnsignedInt>({15, 37, 44}),
+        Containers::arrayView<Int>({15, -1, 44}),
         TestSuite::Compare::Container);
 }
 
@@ -2919,10 +2919,10 @@ void SceneDataTest::meshMaterialsIntoArray() {
 
     struct Field {
         UnsignedInt object;
-        UnsignedInt meshMaterial;
+        Int meshMaterial;
     } fields[]{
         {1, 15},
-        {0, 37},
+        {0, -1},
         {4, 44}
     };
 
@@ -2938,7 +2938,7 @@ void SceneDataTest::meshMaterialsIntoArray() {
 
     /* The offset-less overload should give back all data */
     {
-        UnsignedInt out[3];
+        Int out[3];
         scene.meshMaterialsInto(out);
         CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
             view.slice(&Field::meshMaterial),
@@ -2946,7 +2946,7 @@ void SceneDataTest::meshMaterialsIntoArray() {
 
     /* The offset variant only a subset */
     } {
-        Containers::Array<UnsignedInt> out{data.size};
+        Containers::Array<Int> out{data.size};
         CORRADE_COMPARE(scene.meshMaterialsInto(data.offset, out), data.expectedSize);
         CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
             view.slice(&Field::meshMaterial)
@@ -2962,7 +2962,7 @@ void SceneDataTest::meshMaterialsIntoArrayInvalidSizeOrOffset() {
 
     struct Field {
         UnsignedInt object;
-        UnsignedInt meshMaterial;
+        Int meshMaterial;
     } fields[3]{};
 
     Containers::StridedArrayView1D<Field> view = fields;
@@ -2973,7 +2973,7 @@ void SceneDataTest::meshMaterialsIntoArrayInvalidSizeOrOffset() {
 
     std::ostringstream out;
     Error redirectError{&out};
-    UnsignedInt destination[2];
+    Int destination[2];
     scene.meshMaterialsInto(destination);
     scene.meshMaterialsInto(4, destination);
     CORRADE_COMPARE(out.str(),

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -4985,25 +4985,25 @@ void SceneDataTest::childrenFor() {
 
     /* Just one child */
     CORRADE_COMPARE_AS(scene.childrenFor(3),
-        Containers::arrayView<UnsignedInt>({2}),
+        Containers::arrayView<UnsignedLong>({2}),
         TestSuite::Compare::Container);
 
     /* More */
     CORRADE_COMPARE_AS(scene.childrenFor(-1),
-        Containers::arrayView<UnsignedInt>({4, 0}),
+        Containers::arrayView<UnsignedLong>({4, 0}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.childrenFor(4),
-        Containers::arrayView<UnsignedInt>({3, 1, 5}),
+        Containers::arrayView<UnsignedLong>({3, 1, 5}),
         TestSuite::Compare::Container);
 
     /* Object that is present in the parent array but has no children */
     CORRADE_COMPARE_AS(scene.childrenFor(5),
-        Containers::arrayView<UnsignedInt>({}),
+        Containers::arrayView<UnsignedLong>({}),
         TestSuite::Compare::Container);
 
     /* Object that is not in the parent array at all */
     CORRADE_COMPARE_AS(scene.childrenFor(6),
-        Containers::arrayView<UnsignedInt>({}),
+        Containers::arrayView<UnsignedLong>({}),
         TestSuite::Compare::Container);
 }
 
@@ -5024,17 +5024,17 @@ void SceneDataTest::childrenForTrivialParent() {
 
     /* Trivial children */
     CORRADE_COMPARE_AS(scene.childrenFor(-1),
-        Containers::arrayView<UnsignedInt>({3, 4, 2, 4}),
+        Containers::arrayView<UnsignedLong>({3, 4, 2, 4}),
         TestSuite::Compare::Container);
 
     /* Object that is present in the parent array but has no children */
     CORRADE_COMPARE_AS(scene.childrenFor(4),
-        Containers::arrayView<UnsignedInt>({}),
+        Containers::arrayView<UnsignedLong>({}),
         TestSuite::Compare::Container);
 
     /* Object that is not in the parent array */
     CORRADE_COMPARE_AS(scene.childrenFor(5),
-        Containers::arrayView<UnsignedInt>({}),
+        Containers::arrayView<UnsignedLong>({}),
         TestSuite::Compare::Container);
 }
 
@@ -5461,7 +5461,7 @@ void SceneDataTest::fieldForFieldMissing() {
 
     CORRADE_COMPARE(scene.parentFor(6), Containers::NullOpt);
     CORRADE_COMPARE_AS(scene.childrenFor(6),
-        Containers::arrayView<UnsignedInt>({}),
+        Containers::arrayView<UnsignedLong>({}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE(scene.transformation2DFor(6), Containers::NullOpt);
     CORRADE_COMPARE(scene.translationRotationScaling2DFor(6), Containers::NullOpt);

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -101,32 +101,44 @@ struct SceneDataTest: TestSuite::Tester {
     template<class T> void objectsAsArrayByIndex();
     template<class T> void objectsAsArrayByName();
     void objectsAsArrayLongType();
-    void objectsIntoArrayInvalidSize();
+    void objectsIntoArrayByIndex();
+    void objectsIntoArrayByName();
+    void objectsIntoArrayInvalidSizeOrOffset();
     template<class T> void parentsAsArray();
     #ifndef CORRADE_TARGET_32BIT
     void parentsAsArrayLongType();
     #endif
-    void parentsIntoArrayInvalidSize();
+    void parentsIntoArray();
+    void parentsIntoArrayInvalidSizeOrOffset();
     template<class T> void transformations2DAsArray();
     template<class T> void transformations2DAsArrayTRS();
     template<class T> void transformations2DAsArrayBut3DType();
     template<class T> void transformations2DAsArrayBut3DTypeTRS();
-    void transformations2DIntoArrayInvalidSize();
+    void transformations2DIntoArray();
+    void transformations2DIntoArrayTRS();
+    void transformations2DIntoArrayInvalidSizeOrOffset();
     template<class T> void transformations3DAsArray();
     template<class T> void transformations3DAsArrayTRS();
     template<class T> void transformations3DAsArrayBut2DType();
     template<class T> void transformations3DAsArrayBut2DTypeTRS();
-    void transformations3DIntoArrayInvalidSize();
+    void transformations3DIntoArray();
+    void transformations3DIntoArrayTRS();
+    void transformations3DIntoArrayInvalidSizeOrOffset();
     template<class T> void meshesAsArray();
-    void meshesIntoArrayInvalidSize();
+    void meshesIntoArray();
+    void meshesIntoArrayInvalidSizeOrOffset();
     template<class T> void meshMaterialsAsArray();
-    void meshMaterialsIntoArrayInvalidSize();
+    void meshMaterialsIntoArray();
+    void meshMaterialsIntoArrayInvalidSizeOrOffset();
     template<class T> void lightsAsArray();
-    void lightsIntoArrayInvalidSize();
+    void lightsIntoArray();
+    void lightsIntoArrayInvalidSizeOrOffset();
     template<class T> void camerasAsArray();
-    void camerasIntoArrayInvalidSize();
+    void camerasIntoArray();
+    void camerasIntoArrayInvalidSizeOrOffset();
     template<class T> void skinsAsArray();
-    void skinsIntoArrayInvalidSize();
+    void skinsIntoArray();
+    void skinsIntoArrayInvalidSizeOrOffset();
 
     void mutableAccessNotAllowed();
 
@@ -147,6 +159,18 @@ const struct {
 } NotOwnedData[]{
     {"", {}},
     {"mutable", DataFlag::Mutable}
+};
+
+const struct {
+    const char* name;
+    std::size_t offset;
+    std::size_t size;
+    std::size_t expectedSize;
+} IntoArrayOffsetData[]{
+    {"whole", 0, 3, 3},
+    {"one element in the middle", 1, 1, 1},
+    {"suffix to a larger array", 2, 10, 1},
+    {"offset at the end", 3, 10, 0}
 };
 
 SceneDataTest::SceneDataTest() {
@@ -215,8 +239,13 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::objectsAsArrayByName<UnsignedShort>,
               &SceneDataTest::objectsAsArrayByName<UnsignedInt>,
               &SceneDataTest::objectsAsArrayByName<UnsignedLong>,
-              &SceneDataTest::objectsAsArrayLongType,
-              &SceneDataTest::objectsIntoArrayInvalidSize,
+              &SceneDataTest::objectsAsArrayLongType});
+
+    addInstancedTests({&SceneDataTest::objectsIntoArrayByIndex,
+                       &SceneDataTest::objectsIntoArrayByName},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::objectsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::parentsAsArray<Byte>,
               &SceneDataTest::parentsAsArray<Short>,
               &SceneDataTest::parentsAsArray<Int>,
@@ -224,7 +253,12 @@ SceneDataTest::SceneDataTest() {
               #ifndef CORRADE_TARGET_32BIT
               &SceneDataTest::parentsAsArrayLongType,
               #endif
-              &SceneDataTest::parentsIntoArrayInvalidSize,
+              });
+
+    addInstancedTests({&SceneDataTest::parentsIntoArray},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::parentsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::transformations2DAsArray<Matrix3>,
               &SceneDataTest::transformations2DAsArray<Matrix3d>,
               &SceneDataTest::transformations2DAsArray<DualComplex>,
@@ -236,8 +270,13 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaternion>,
               &SceneDataTest::transformations2DAsArrayBut3DType<DualQuaterniond>,
               &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Float>,
-              &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Double>,
-              &SceneDataTest::transformations2DIntoArrayInvalidSize,
+              &SceneDataTest::transformations2DAsArrayBut3DTypeTRS<Double>});
+
+    addInstancedTests({&SceneDataTest::transformations2DIntoArray,
+                       &SceneDataTest::transformations2DIntoArrayTRS},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::transformations3DAsArray<Matrix4>,
               &SceneDataTest::transformations3DAsArray<Matrix4d>,
               &SceneDataTest::transformations3DAsArray<DualQuaternion>,
@@ -249,28 +288,53 @@ SceneDataTest::SceneDataTest() {
               &SceneDataTest::transformations3DAsArrayBut2DType<DualComplex>,
               &SceneDataTest::transformations3DAsArrayBut2DType<DualComplexd>,
               &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Float>,
-              &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Double>,
-              &SceneDataTest::transformations3DIntoArrayInvalidSize,
+              &SceneDataTest::transformations3DAsArrayBut2DTypeTRS<Double>});
+
+    addInstancedTests({&SceneDataTest::transformations3DIntoArray,
+                       &SceneDataTest::transformations3DIntoArrayTRS},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::meshesAsArray<UnsignedByte>,
               &SceneDataTest::meshesAsArray<UnsignedShort>,
-              &SceneDataTest::meshesAsArray<UnsignedInt>,
-              &SceneDataTest::meshesIntoArrayInvalidSize,
+              &SceneDataTest::meshesAsArray<UnsignedInt>});
+
+    addInstancedTests({&SceneDataTest::meshesIntoArray},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::meshesIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::meshMaterialsAsArray<UnsignedByte>,
               &SceneDataTest::meshMaterialsAsArray<UnsignedShort>,
-              &SceneDataTest::meshMaterialsAsArray<UnsignedInt>,
-              &SceneDataTest::meshMaterialsIntoArrayInvalidSize,
+              &SceneDataTest::meshMaterialsAsArray<UnsignedInt>});
+
+    addInstancedTests({&SceneDataTest::meshMaterialsIntoArray},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::meshMaterialsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::lightsAsArray<UnsignedByte>,
               &SceneDataTest::lightsAsArray<UnsignedShort>,
-              &SceneDataTest::lightsAsArray<UnsignedInt>,
-              &SceneDataTest::lightsIntoArrayInvalidSize,
+              &SceneDataTest::lightsAsArray<UnsignedInt>});
+
+    addInstancedTests({&SceneDataTest::lightsIntoArray},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::lightsIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::camerasAsArray<UnsignedByte>,
               &SceneDataTest::camerasAsArray<UnsignedShort>,
-              &SceneDataTest::camerasAsArray<UnsignedInt>,
-              &SceneDataTest::camerasIntoArrayInvalidSize,
+              &SceneDataTest::camerasAsArray<UnsignedInt>});
+
+    addInstancedTests({&SceneDataTest::camerasIntoArray},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::camerasIntoArrayInvalidSizeOrOffset,
               &SceneDataTest::skinsAsArray<UnsignedByte>,
               &SceneDataTest::skinsAsArray<UnsignedShort>,
-              &SceneDataTest::skinsAsArray<UnsignedInt>,
-              &SceneDataTest::skinsIntoArrayInvalidSize,
+              &SceneDataTest::skinsAsArray<UnsignedInt>});
+
+    addInstancedTests({&SceneDataTest::skinsIntoArray},
+        Containers::arraySize(IntoArrayOffsetData));
+
+    addTests({&SceneDataTest::skinsIntoArrayInvalidSizeOrOffset,
 
               &SceneDataTest::mutableAccessNotAllowed,
 
@@ -1675,6 +1739,7 @@ template<class T> void SceneDataTest::objectsAsArrayByIndex() {
         SceneFieldData{SceneField::Parent, Implementation::sceneObjectTypeFor<T>(), nullptr, SceneFieldType::Int, nullptr},
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
+
     CORRADE_COMPARE_AS(scene.objectsAsArray(1),
         Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
@@ -1700,17 +1765,8 @@ template<class T> void SceneDataTest::objectsAsArrayByName() {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
-    UnsignedInt expected[]{15, 37, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.objectsAsArray(SceneField::Mesh)),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    UnsignedInt out[3];
-    scene.objectsInto(SceneField::Mesh, out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.objectsAsArray(SceneField::Mesh),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
@@ -1741,7 +1797,99 @@ void SceneDataTest::objectsAsArrayLongType() {
         "Trade::SceneData::objectsInto(): indices for up to 4294967296 objects can't fit into a 32-bit type, access them directly via objects() instead\n");
 }
 
-void SceneDataTest::objectsIntoArrayInvalidSize() {
+void SceneDataTest::objectsIntoArrayByIndex() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt mesh;
+    } fields[] {
+        {15, 0},
+        {37, 1},
+        {44, 15}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh,
+            view.slice(&Field::object),
+            view.slice(&Field::mesh)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.objectsInto(1, out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.objectsInto(1, data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::objectsIntoArrayByName() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt mesh;
+    } fields[] {
+        {15, 0},
+        {37, 1},
+        {44, 15}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 50, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh,
+            view.slice(&Field::object),
+            view.slice(&Field::mesh)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.objectsInto(SceneField::Mesh, out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::object),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.objectsInto(SceneField::Mesh, data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::object)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::objectsIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -1762,9 +1910,13 @@ void SceneDataTest::objectsIntoArrayInvalidSize() {
     UnsignedInt destination[2];
     scene.objectsInto(0, destination);
     scene.objectsInto(SceneField::Mesh, destination);
+    scene.objectsInto(0, 4, destination);
+    scene.objectsInto(SceneField::Mesh, 4, destination);
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n"
-        "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::objectsInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::objectsInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::objectsInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::parentsAsArray() {
@@ -1787,17 +1939,8 @@ template<class T> void SceneDataTest::parentsAsArray() {
         SceneFieldData{SceneField::Parent, view.slice(&Field::object), view.slice(&Field::parent)}
     }};
 
-    Int expected[]{15, -1, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.parentsAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    Int out[3];
-    scene.parentsInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.parentsAsArray(),
+        Containers::arrayView({15, -1, 44}),
         TestSuite::Compare::Container);
 }
 
@@ -1829,7 +1972,53 @@ void SceneDataTest::parentsAsArrayLongType() {
 }
 #endif
 
-void SceneDataTest::parentsIntoArrayInvalidSize() {
+void SceneDataTest::parentsIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Int parent;
+    } fields[] {
+        {1, 15},
+        {0, -1},
+        {4, 44}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Mesh, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::UnsignedInt, nullptr},
+        SceneFieldData{SceneField::Parent,
+            view.slice(&Field::object),
+            view.slice(&Field::parent)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        Int out[3];
+        scene.parentsInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::parent),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<Int> out{data.size};
+        CORRADE_COMPARE(scene.parentsInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::parent)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::parentsIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -1849,8 +2038,10 @@ void SceneDataTest::parentsIntoArrayInvalidSize() {
     Error redirectError{&out};
     Int destination[2];
     scene.parentsInto(destination);
+    scene.parentsInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::parentsInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::parentsInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::parentsInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::transformations2DAsArray() {
@@ -1908,23 +2099,12 @@ template<class T> void SceneDataTest::transformations2DAsArray() {
             components.slice(&Component::scaling)},
     }};
 
-    Matrix3 expected[]{
+    CORRADE_COMPARE_AS(scene.transformations2DAsArray(), Containers::arrayView({
         Matrix3::translation({3.0f, 2.0f}),
         Matrix3::rotation(35.0_degf),
         Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation(-15.0_degf),
         Matrix3::rotation(-15.0_degf)*Matrix3::translation({1.5f, 2.5f})
-    };
-    CORRADE_COMPARE_AS(arrayView(scene.transformations2DAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    Matrix3 out[4];
-    scene.transformations2DInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
+    }), TestSuite::Compare::Container);
 }
 
 template<class T> void SceneDataTest::transformations2DAsArrayTRS() {
@@ -2103,7 +2283,112 @@ template<class T> void SceneDataTest::transformations2DAsArrayBut3DTypeTRS() {
         "Trade::SceneData::transformations2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector3<T>>::name(), NameTraits<Math::Quaternion<T>>::name()));
 }
 
-void SceneDataTest::transformations2DIntoArrayInvalidSize() {
+void SceneDataTest::transformations2DIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Matrix3 transformation;
+    } fields[] {
+        {1, Matrix3::translation({3.0f, 2.0f})*Matrix3::scaling({1.5f, 2.0f})},
+        {0, Matrix3::rotation(35.0_degf)},
+        {4, Matrix3::translation({3.0f, 2.0f})*Matrix3::rotation(35.0_degf)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Transformation,
+            view.slice(&Field::object),
+            view.slice(&Field::transformation)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        Matrix3 out[3];
+        scene.transformations2DInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::transformation),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<Matrix3> out{data.size};
+        CORRADE_COMPARE(scene.transformations2DInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::transformation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::transformations2DIntoArrayTRS() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Vector2 translation;
+        Complex rotation;
+        Vector2 scaling;
+    } fields[] {
+        {1, {3.0f, 2.0f}, {}, {1.5f, 2.0f}},
+        {0, {}, Complex::rotation(35.0_degf), {1.0f, 1.0f}},
+        {4, {3.0f, 2.0f}, Complex::rotation(35.0_degf), {1.0f, 1.0f}}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Translation,
+            view.slice(&Field::object),
+            view.slice(&Field::translation)},
+        SceneFieldData{SceneField::Rotation,
+            view.slice(&Field::object),
+            view.slice(&Field::rotation)},
+        SceneFieldData{SceneField::Scaling,
+            view.slice(&Field::object),
+            view.slice(&Field::scaling)},
+    }};
+
+    Matrix3 expected[]{
+        Matrix3::translation({3.0f, 2.0f})*Matrix3::scaling({1.5f, 2.0f}),
+        Matrix3::rotation(35.0_degf),
+        Matrix3::translation({3.0f, 2.0f})*Matrix3::rotation(35.0_degf)
+    };
+
+    /* The offset-less overload should give back all data */
+    {
+        Matrix3 out[3];
+        scene.transformations2DInto(out);
+        CORRADE_COMPARE_AS(Containers::arrayView(out),
+            Containers::arrayView(expected),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<Matrix3> out{data.size};
+        CORRADE_COMPARE(scene.transformations2DInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2123,8 +2408,10 @@ void SceneDataTest::transformations2DIntoArrayInvalidSize() {
     Error redirectError{&out};
     Matrix3 destination[2];
     scene.transformations2DInto(destination);
+    scene.transformations2DInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::transformations2DInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::transformations2DInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::transformations2DInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::transformations3DAsArray() {
@@ -2185,23 +2472,12 @@ template<class T> void SceneDataTest::transformations3DAsArray() {
             components.slice(&Component::scaling)},
     }};
 
-    Matrix4 expected[]{
+    CORRADE_COMPARE_AS(scene.transformations3DAsArray(), Containers::arrayView({
         Matrix4::translation({3.0f, 2.0f, -0.5f}),
         Matrix4::rotationY(35.0_degf),
         Matrix4::translation({1.5f, 2.5f, 0.75f})*Matrix4::rotationX(-15.0_degf),
         Matrix4::rotationX(-15.0_degf)*Matrix4::translation({1.5f, 2.5f, 0.75f})
-    };
-    CORRADE_COMPARE_AS(arrayView(scene.transformations3DAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    Matrix4 out[4];
-    scene.transformations3DInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
+    }), TestSuite::Compare::Container);
 }
 
 template<class T> void SceneDataTest::transformations3DAsArrayTRS() {
@@ -2380,7 +2656,112 @@ template<class T> void SceneDataTest::transformations3DAsArrayBut2DTypeTRS() {
         "Trade::SceneData::transformations3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector2<T>>::name(), NameTraits<Math::Complex<T>>::name()));
 }
 
-void SceneDataTest::transformations3DIntoArrayInvalidSize() {
+void SceneDataTest::transformations3DIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Matrix4 transformation;
+    } fields[] {
+        {1, Matrix4::translation({3.0f, 2.0f, 1.0f})*Matrix4::scaling({1.5f, 2.0f, 4.5f})},
+        {0, Matrix4::rotationX(35.0_degf)},
+        {4, Matrix4::translation({3.0f, 2.0f, 1.0f})*Matrix4::rotationX(35.0_degf)}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Transformation,
+            view.slice(&Field::object),
+            view.slice(&Field::transformation)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        Matrix4 out[3];
+        scene.transformations3DInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::transformation),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<Matrix4> out{data.size};
+        CORRADE_COMPARE(scene.transformations3DInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::transformation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::transformations3DIntoArrayTRS() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        Vector3 translation;
+        Quaternion rotation;
+        Vector3 scaling;
+    } fields[] {
+        {1, {3.0f, 2.0f, 1.0f}, {}, {1.5f, 2.0f, 4.5f}},
+        {0, {}, Quaternion::rotation(35.0_degf, Vector3::xAxis()), {1.0f, 1.0f, 1.0f}},
+        {4, {3.0f, 2.0f, 1.0f}, Quaternion::rotation(35.0_degf, Vector3::xAxis()), {1.0f, 1.0f, 1.0f}}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Translation,
+            view.slice(&Field::object),
+            view.slice(&Field::translation)},
+        SceneFieldData{SceneField::Rotation,
+            view.slice(&Field::object),
+            view.slice(&Field::rotation)},
+        SceneFieldData{SceneField::Scaling,
+            view.slice(&Field::object),
+            view.slice(&Field::scaling)},
+    }};
+
+    Matrix4 expected[]{
+        Matrix4::translation({3.0f, 2.0f, 1.0f})*Matrix4::scaling({1.5f, 2.0f, 4.5f}),
+        Matrix4::rotationX(35.0_degf),
+        Matrix4::translation({3.0f, 2.0f, 1.0f})*Matrix4::rotationX(35.0_degf)
+    };
+
+    /* The offset-less overload should give back all data */
+    {
+        Matrix4 out[3];
+        scene.transformations3DInto(out);
+        CORRADE_COMPARE_AS(Containers::arrayView(out),
+            Containers::arrayView(expected),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<Matrix4> out{data.size};
+        CORRADE_COMPARE(scene.transformations3DInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2400,8 +2781,10 @@ void SceneDataTest::transformations3DIntoArrayInvalidSize() {
     Error redirectError{&out};
     Matrix4 destination[2];
     scene.transformations3DInto(destination);
+    scene.transformations3DInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::transformations3DInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::transformations3DInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::transformations3DInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::meshesAsArray() {
@@ -2424,21 +2807,58 @@ template<class T> void SceneDataTest::meshesAsArray() {
         SceneFieldData{SceneField::Mesh, view.slice(&Field::object), view.slice(&Field::mesh)}
     }};
 
-    UnsignedInt expected[]{15, 37, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.meshesAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    UnsignedInt out[3];
-    scene.meshesInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.meshesAsArray(),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-void SceneDataTest::meshesIntoArrayInvalidSize() {
+void SceneDataTest::meshesIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt mesh;
+    } fields[]{
+        {1, 15},
+        {0, 37},
+        {4, 44}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Mesh,
+            view.slice(&Field::object),
+            view.slice(&Field::mesh)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.meshesInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::mesh),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.meshesInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::mesh)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::meshesIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2458,8 +2878,10 @@ void SceneDataTest::meshesIntoArrayInvalidSize() {
     Error redirectError{&out};
     UnsignedInt destination[2];
     scene.meshesInto(destination);
+    scene.meshesInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::meshesInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::meshesInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::meshesInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::meshMaterialsAsArray() {
@@ -2482,21 +2904,58 @@ template<class T> void SceneDataTest::meshMaterialsAsArray() {
         SceneFieldData{SceneField::MeshMaterial, view.slice(&Field::object), view.slice(&Field::meshMaterial)}
     }};
 
-    UnsignedInt expected[]{15, 37, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.meshMaterialsAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    UnsignedInt out[3];
-    scene.meshMaterialsInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.meshMaterialsAsArray(),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-void SceneDataTest::meshMaterialsIntoArrayInvalidSize() {
+void SceneDataTest::meshMaterialsIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt meshMaterial;
+    } fields[]{
+        {1, 15},
+        {0, 37},
+        {4, 44}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::MeshMaterial,
+            view.slice(&Field::object),
+            view.slice(&Field::meshMaterial)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.meshMaterialsInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::meshMaterial),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.meshMaterialsInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::meshMaterial)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::meshMaterialsIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2516,8 +2975,10 @@ void SceneDataTest::meshMaterialsIntoArrayInvalidSize() {
     Error redirectError{&out};
     UnsignedInt destination[2];
     scene.meshMaterialsInto(destination);
+    scene.meshMaterialsInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::meshMaterialsInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::meshMaterialsInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::meshMaterialsInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::lightsAsArray() {
@@ -2540,21 +3001,58 @@ template<class T> void SceneDataTest::lightsAsArray() {
         SceneFieldData{SceneField::Light, view.slice(&Field::object), view.slice(&Field::light)}
     }};
 
-    UnsignedInt expected[]{15, 37, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.lightsAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    UnsignedInt out[3];
-    scene.lightsInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.lightsAsArray(),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-void SceneDataTest::lightsIntoArrayInvalidSize() {
+void SceneDataTest::lightsIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt light;
+    } fields[] {
+        {1, 15},
+        {0, 37},
+        {4, 44}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Light,
+            view.slice(&Field::object),
+            view.slice(&Field::light)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.lightsInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::light),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.lightsInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::light)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::lightsIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2574,8 +3072,10 @@ void SceneDataTest::lightsIntoArrayInvalidSize() {
     Error redirectError{&out};
     UnsignedInt destination[2];
     scene.lightsInto(destination);
+    scene.lightsInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::lightsInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::lightsInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::lightsInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::camerasAsArray() {
@@ -2598,21 +3098,58 @@ template<class T> void SceneDataTest::camerasAsArray() {
         SceneFieldData{SceneField::Camera, view.slice(&Field::object), view.slice(&Field::camera)}
     }};
 
-    UnsignedInt expected[]{15, 37, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.camerasAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    UnsignedInt out[3];
-    scene.camerasInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.camerasAsArray(),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-void SceneDataTest::camerasIntoArrayInvalidSize() {
+void SceneDataTest::camerasIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt camera;
+    } fields[]{
+        {1, 15},
+        {0, 37},
+        {4, 44}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Camera,
+            view.slice(&Field::object),
+            view.slice(&Field::camera)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.camerasInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::camera),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.camerasInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::camera)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::camerasIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2632,8 +3169,10 @@ void SceneDataTest::camerasIntoArrayInvalidSize() {
     Error redirectError{&out};
     UnsignedInt destination[2];
     scene.camerasInto(destination);
+    scene.camerasInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::camerasInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::camerasInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::camerasInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 template<class T> void SceneDataTest::skinsAsArray() {
@@ -2656,21 +3195,58 @@ template<class T> void SceneDataTest::skinsAsArray() {
         SceneFieldData{SceneField::Skin, view.slice(&Field::object), view.slice(&Field::skin)}
     }};
 
-    UnsignedInt expected[]{15, 37, 44};
-    CORRADE_COMPARE_AS(arrayView(scene.skinsAsArray()),
-        Containers::arrayView(expected),
-        TestSuite::Compare::Container);
-
-    /* Test Into() as well as it only shares a common helper with AsArray() but
-       has different top-level code paths */
-    UnsignedInt out[3];
-    scene.skinsInto(out);
-    CORRADE_COMPARE_AS(Containers::arrayView(out),
-        Containers::arrayView(expected),
+    CORRADE_COMPARE_AS(scene.skinsAsArray(),
+        Containers::arrayView<UnsignedInt>({15, 37, 44}),
         TestSuite::Compare::Container);
 }
 
-void SceneDataTest::skinsIntoArrayInvalidSize() {
+void SceneDataTest::skinsIntoArray() {
+    auto&& data = IntoArrayOffsetData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Both AsArray() and Into() share a common helper. The AsArray() test
+       above verified handling of various data types and this checks the
+       offset/size parameters of the Into() variant. */
+
+    struct Field {
+        UnsignedInt object;
+        UnsignedInt skin;
+    } fields[] {
+        {1, 15},
+        {0, 37},
+        {4, 44}
+    };
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        /* To verify it isn't just picking the first ever field */
+        SceneFieldData{SceneField::Parent, SceneObjectType::UnsignedInt, nullptr, SceneFieldType::Int, nullptr},
+        SceneFieldData{SceneField::Skin,
+            view.slice(&Field::object),
+            view.slice(&Field::skin)},
+    }};
+
+    /* The offset-less overload should give back all data */
+    {
+        UnsignedInt out[3];
+        scene.skinsInto(out);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(out),
+            view.slice(&Field::skin),
+            TestSuite::Compare::Container);
+
+    /* The offset variant only a subset */
+    } {
+        Containers::Array<UnsignedInt> out{data.size};
+        CORRADE_COMPARE(scene.skinsInto(data.offset, out), data.expectedSize);
+        CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
+            view.slice(&Field::skin)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+    }
+}
+
+void SceneDataTest::skinsIntoArrayInvalidSizeOrOffset() {
     #ifdef CORRADE_NO_ASSERT
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
@@ -2690,8 +3266,10 @@ void SceneDataTest::skinsIntoArrayInvalidSize() {
     Error redirectError{&out};
     UnsignedInt destination[2];
     scene.skinsInto(destination);
+    scene.skinsInto(4, destination);
     CORRADE_COMPARE(out.str(),
-        "Trade::SceneData::skinsInto(): expected a view with 3 elements but got 2\n");
+        "Trade::SceneData::skinsInto(): expected a view with 3 elements but got 2\n"
+        "Trade::SceneData::skinsInto(): offset 4 out of bounds for a field of size 3\n");
 }
 
 void SceneDataTest::mutableAccessNotAllowed() {
@@ -2862,18 +3440,29 @@ void SceneDataTest::fieldNotFound() {
     scene.mutableField<UnsignedInt[]>(sceneFieldCustom(666));
 
     scene.parentsAsArray();
+    scene.parentsInto(nullptr);
+    scene.parentsInto(0, nullptr);
     scene.transformations2DAsArray();
-    scene.transformations3DAsArray();
-    /* Test both AsArray() and Into() for transformations as they only share a
-       common helper but have different top-level code paths. They however have
-       the same assertion messages to save binary size a bit. */
     scene.transformations2DInto(nullptr);
+    scene.transformations2DInto(0, nullptr);
+    scene.transformations3DAsArray();
     scene.transformations3DInto(nullptr);
+    scene.transformations3DInto(0, nullptr);
     scene.meshesAsArray();
+    scene.meshesInto(nullptr);
+    scene.meshesInto(0, nullptr);
     scene.meshMaterialsAsArray();
+    scene.meshMaterialsInto(nullptr);
+    scene.meshMaterialsInto(0, nullptr);
     scene.lightsAsArray();
+    scene.lightsInto(nullptr);
+    scene.lightsInto(0, nullptr);
     scene.camerasAsArray();
+    scene.camerasInto(nullptr);
+    scene.camerasInto(0, nullptr);
     scene.skinsAsArray();
+    scene.skinsInto(nullptr);
+    scene.skinsInto(0, nullptr);
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData::fieldData(): index 2 out of range for 2 fields\n"
         "Trade::SceneData::fieldName(): index 2 out of range for 2 fields\n"
@@ -2898,19 +3487,32 @@ void SceneDataTest::fieldNotFound() {
         "Trade::SceneData::mutableField(): field Trade::SceneField::Custom(666) not found\n"
         "Trade::SceneData::mutableField(): field Trade::SceneField::Custom(666) not found\n"
 
+        /* AsArray() and Into() each share a common helper but have different
+           top-level code paths. They however have the same assertion messages
+           to save binary size a bit. */
         "Trade::SceneData::parentsInto(): field not found\n"
-        /* Test both AsArray() and Into() for transformations as they only
-           share a common helper but have different top-level code paths. They
-           however have the same assertion messages to save binary size a
-           bit. */
+        "Trade::SceneData::parentsInto(): field not found\n"
+        "Trade::SceneData::parentsInto(): field not found\n"
+        "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
-        "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
         "Trade::SceneData::meshesInto(): field not found\n"
+        "Trade::SceneData::meshesInto(): field not found\n"
+        "Trade::SceneData::meshesInto(): field not found\n"
+        "Trade::SceneData::meshMaterialsInto(): field not found\n"
+        "Trade::SceneData::meshMaterialsInto(): field not found\n"
         "Trade::SceneData::meshMaterialsInto(): field not found\n"
         "Trade::SceneData::lightsInto(): field not found\n"
+        "Trade::SceneData::lightsInto(): field not found\n"
+        "Trade::SceneData::lightsInto(): field not found\n"
         "Trade::SceneData::camerasInto(): field not found\n"
+        "Trade::SceneData::camerasInto(): field not found\n"
+        "Trade::SceneData::camerasInto(): field not found\n"
+        "Trade::SceneData::skinsInto(): field not found\n"
+        "Trade::SceneData::skinsInto(): field not found\n"
         "Trade::SceneData::skinsInto(): field not found\n");
 }
 

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -1508,6 +1508,11 @@ void SceneDataTest::constructDeprecated() {
        is set directly */
     CORRADE_COMPARE(scene.is2D(), data.is2D);
     CORRADE_COMPARE(scene.is3D(), data.is3D);
+
+    /* The deleters have to be trivial, otherwise this instance wouldn't be
+       usable from an AbstractImporter */
+    CORRADE_VERIFY(!scene.releaseFieldData().deleter());
+    CORRADE_VERIFY(!scene.releaseData().deleter());
 }
 
 void SceneDataTest::constructDeprecatedBoth2DAnd3D() {

--- a/src/Magnum/Trade/Test/SceneDataTest.cpp
+++ b/src/Magnum/Trade/Test/SceneDataTest.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <Corrade/Containers/ArrayTuple.h>
 #include <Corrade/Containers/Pair.h>
+#include <Corrade/Containers/Triple.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/TestSuite/Compare/Container.h>
 #include <Corrade/Utility/DebugStl.h>
@@ -118,6 +119,7 @@ struct SceneDataTest: TestSuite::Tester {
     void transformations2DIntoArray();
     void transformations2DIntoArrayTRS();
     void transformations2DIntoArrayInvalidSizeOrOffset();
+    void transformations2DIntoArrayInvalidSizeOrOffsetTRS();
     template<class T> void transformations3DAsArray();
     template<class T, class U, class V> void transformations3DAsArrayTRS();
     template<class T> void transformations3DAsArrayBut2DType();
@@ -125,6 +127,7 @@ struct SceneDataTest: TestSuite::Tester {
     void transformations3DIntoArray();
     void transformations3DIntoArrayTRS();
     void transformations3DIntoArrayInvalidSizeOrOffset();
+    void transformations3DIntoArrayInvalidSizeOrOffsetTRS();
     template<class T, class U> void meshesMaterialsAsArray();
     void meshesMaterialsIntoArray();
     void meshesMaterialsIntoArrayInvalidSizeOrOffset();
@@ -275,6 +278,7 @@ SceneDataTest::SceneDataTest() {
         Containers::arraySize(IntoArrayOffsetData));
 
     addTests({&SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset,
+              &SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS,
               &SceneDataTest::transformations3DAsArray<Matrix4>,
               &SceneDataTest::transformations3DAsArray<Matrix4d>,
               &SceneDataTest::transformations3DAsArray<DualQuaternion>,
@@ -293,6 +297,7 @@ SceneDataTest::SceneDataTest() {
         Containers::arraySize(IntoArrayOffsetData));
 
     addTests({&SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset,
+              &SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS,
               &SceneDataTest::meshesMaterialsAsArray<UnsignedByte, Int>,
               &SceneDataTest::meshesMaterialsAsArray<UnsignedShort, Byte>,
               &SceneDataTest::meshesMaterialsAsArray<UnsignedInt, Short>});
@@ -2147,6 +2152,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3{Math::IdentityInit},
             Matrix3::translation({1.5f, 2.5f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{1.5f, 2.5f}, {}, Vector2{1.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             rotation
@@ -2158,6 +2170,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3{Math::IdentityInit},
             Matrix3::rotation(-15.0_degf)
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{}, {}, Vector2{1.0f}},
+            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, Complex::rotation(-15.0_degf), Vector2{1.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             scaling
@@ -2169,6 +2188,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3::scaling({2.0f, 1.0f}),
             Matrix3::scaling({-0.5f, 4.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, {2.0f, 1.0f}},
+            {{}, {}, {-0.5f, 4.0f}},
+        })), TestSuite::Compare::Container);
     }
 
     /* Pairs */
@@ -2184,6 +2210,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3{Math::IdentityInit},
             Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
+            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), Vector2{1.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             translation,
@@ -2196,6 +2229,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3::scaling({2.0f, 1.0f}),
             Matrix3::translation({1.5f, 2.5f})*Matrix3::scaling({-0.5f, 4.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, {2.0f, 1.0f}},
+            {{1.5f, 2.5f}, {}, {-0.5f, 4.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             rotation,
@@ -2208,6 +2248,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3::scaling({2.0f, 1.0f}),
             Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{}, {}, Vector2{1.0f}},
+            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, {2.0f, 1.0f}},
+            {{}, Complex::rotation(-15.0_degf), {-0.5f, 4.0f}},
+        })), TestSuite::Compare::Container);
     }
 
     /* All */
@@ -2224,6 +2271,13 @@ template<class T, class U, class V> void SceneDataTest::transformations2DAsArray
             Matrix3::scaling({2.0f, 1.0f}),
             Matrix3::translation({1.5f, 2.5f})*Matrix3::rotation({-15.0_degf})*Matrix3::scaling({-0.5f, 4.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings2DAsArray(), (Containers::arrayView<Containers::Triple<Vector2, Complex, Vector2>>({
+            {{3.0f, 2.0f}, {}, Vector2{1.0f}},
+            {{}, Complex::rotation(35.0_degf), Vector2{1.0f}},
+            {{}, {}, Vector2{1.0f}},
+            {{}, {}, {2.0f, 1.0f}},
+            {{1.5f, 2.5f}, Complex::rotation(-15.0_degf), {-0.5f, 4.0f}},
+        })), TestSuite::Compare::Container);
     }
 }
 
@@ -2252,25 +2306,43 @@ template<class T> void SceneDataTest::transformations2DAsArrayBut3DTypeTRS() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneData translation{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr}
+    /* Because TRSAsArray() allocates an Array<Triple> and then calls
+       TRSInto(), which skips views that are nullptr, we wouldn't get the
+       assertion for translations, as those are at offset 0, which would be
+       interpreted as an empty view if there were no elements. So we have to
+       supply at least one element to make all assertions trigger. */
+    struct Field {
+        UnsignedInt object;
+        Math::Vector3<T> translation;
+        Math::Quaternion<T> rotation;
+        Math::Vector3<T> scaling;
+    } data[1];
+    Containers::StridedArrayView1D<Field> view = data;
+    SceneData translation{SceneObjectType::UnsignedInt, 1, {}, data, {
+        SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
     }};
-    SceneData rotation{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Quaternion<T>>::type(), nullptr}
+    SceneData rotation{SceneObjectType::UnsignedInt, 1, {}, data, {
+        SceneFieldData{SceneField::Rotation, view.slice(&Field::object), view.slice(&Field::rotation)}
     }};
-    SceneData scaling{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector3<T>>::type(), nullptr}
+    SceneData scaling{SceneObjectType::UnsignedInt, 1, {}, data, {
+        SceneFieldData{SceneField::Scaling, view.slice(&Field::object), view.slice(&Field::scaling)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
     translation.transformations2DAsArray();
+    translation.translationsRotationsScalings2DAsArray();
     rotation.transformations2DAsArray();
+    rotation.translationsRotationsScalings2DAsArray();
     scaling.transformations2DAsArray();
+    scaling.translationsRotationsScalings2DAsArray();
     CORRADE_COMPARE(out.str(), Utility::formatString(
         "Trade::SceneData::transformations2DInto(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): field has a 3D translation type Trade::SceneFieldType::{0}\n"
         "Trade::SceneData::transformations2DInto(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::transformations2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector3<T>>::name(), NameTraits<Math::Quaternion<T>>::name()));
+        "Trade::SceneData::translationsRotationsScalings2DInto(): field has a 3D rotation type Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData::transformations2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): field has a 3D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector3<T>>::name(), NameTraits<Math::Quaternion<T>>::name()));
 }
 
 void SceneDataTest::transformations2DIntoArray() {
@@ -2368,6 +2440,50 @@ void SceneDataTest::transformations2DIntoArrayTRS() {
             Containers::arrayView(expected),
             TestSuite::Compare::Container);
 
+    /* Variant with TRS components */
+    } {
+        Vector2 translationsOut[3];
+        Complex rotationsOut[3];
+        Vector2 scalingsOut[3];
+        scene.translationsRotationsScalings2DInto(translationsOut, rotationsOut, scalingsOut);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
+            view.slice(&Field::translation),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
+            view.slice(&Field::rotation),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
+            view.slice(&Field::scaling),
+            TestSuite::Compare::Container);
+
+    /* Variant with just translations */
+    } {
+        Vector2 translationsOut[3];
+        scene.translationsRotationsScalings2DInto(translationsOut, nullptr, nullptr);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
+            view.slice(&Field::translation),
+            TestSuite::Compare::Container);
+
+    /* Variant with just rotations */
+    } {
+        Complex rotationsOut[3];
+        scene.translationsRotationsScalings2DInto(nullptr, rotationsOut, nullptr);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
+            view.slice(&Field::rotation),
+            TestSuite::Compare::Container);
+
+    /* Variant with just scalings */
+    } {
+        Vector2 scalingsOut[3];
+        scene.translationsRotationsScalings2DInto(nullptr, nullptr, scalingsOut);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
+            view.slice(&Field::scaling),
+            TestSuite::Compare::Container);
+
+    /* Variant with neither is stupid, but should work too */
+    } {
+        scene.translationsRotationsScalings2DInto(nullptr, nullptr, nullptr);
+
     /* The offset variant only a subset */
     } {
         Containers::Array<Matrix3> out{data.size};
@@ -2375,6 +2491,56 @@ void SceneDataTest::transformations2DIntoArrayTRS() {
         CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
             Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
+
+    /* Variant with TRS components */
+    } {
+        Containers::Array<Vector2> translationsOut{data.size};
+        Containers::Array<Complex> rotationsOut{data.size};
+        Containers::Array<Vector2> scalingsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, translationsOut, rotationsOut, scalingsOut), data.expectedSize);
+        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
+            view.slice(&Field::translation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
+            view.slice(&Field::rotation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
+            view.slice(&Field::scaling)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with just translations */
+    } {
+        Containers::Array<Vector2> translationsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, translationsOut, nullptr, nullptr), data.expectedSize);
+        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
+            view.slice(&Field::translation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with just rotations */
+    } {
+        Containers::Array<Complex> rotationsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, nullptr, rotationsOut, nullptr), data.expectedSize);
+        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
+            view.slice(&Field::rotation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with just scalings */
+    } {
+        Containers::Array<Vector2> scalingsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, nullptr, nullptr, scalingsOut), data.expectedSize);
+        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
+            view.slice(&Field::scaling)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with neither is stupid, but should work too */
+    } {
+        CORRADE_COMPARE(scene.translationsRotationsScalings2DInto(data.offset, nullptr, nullptr, nullptr), 0);
     }
 }
 
@@ -2402,6 +2568,47 @@ void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffset() {
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData::transformations2DInto(): expected a view with 3 elements but got 2\n"
         "Trade::SceneData::transformations2DInto(): offset 4 out of bounds for a field of size 3\n");
+}
+
+void SceneDataTest::transformations2DIntoArrayInvalidSizeOrOffsetTRS() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        Vector2 translation;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    Vector2 translationDestinationCorrect[3];
+    Vector2 translationDestination[2];
+    Complex rotationDestinationCorrect[3];
+    Complex rotationDestination[2];
+    Vector2 scalingDestinationCorrect[3];
+    Vector2 scalingDestination[2];
+    scene.translationsRotationsScalings2DInto(translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
+    scene.translationsRotationsScalings2DInto(translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings2DInto(4, translationDestination, rotationDestination, scalingDestination);
+    scene.translationsRotationsScalings2DInto(0, translationDestinationCorrect, rotationDestination, nullptr);
+    scene.translationsRotationsScalings2DInto(0, translationDestinationCorrect, nullptr, scalingDestination);
+    scene.translationsRotationsScalings2DInto(0, nullptr, rotationDestinationCorrect, scalingDestination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::translationsRotationsScalings2DInto(): expected translation destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): expected rotation destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): expected scaling destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): translation and rotation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): translation and scaling destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): rotation and scaling destination views have different size, 3 vs 2\n");
 }
 
 template<class T> void SceneDataTest::transformations3DAsArray() {
@@ -2520,6 +2727,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4{Math::IdentityInit},
             Matrix4::translation({1.5f, 2.5f, 3.5f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{1.5f, 2.5f, 3.5f}, {}, Vector3{1.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             rotation
@@ -2531,6 +2745,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4{Math::IdentityInit},
             Matrix4::rotationX(-15.0_degf)
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{}, {}, Vector3{1.0f}},
+            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             scaling
@@ -2542,6 +2763,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4::scaling({2.0f, 1.0f, 0.0f}),
             Matrix4::scaling({-0.5f, 4.0f, -16.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, {2.0f, 1.0f, 0.0f}},
+            {{}, {}, {-0.5f, 4.0f, -16.0f}},
+        })), TestSuite::Compare::Container);
     }
 
     /* Pairs */
@@ -2557,6 +2785,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4{Math::IdentityInit},
             Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX(-15.0_degf)
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
+            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), Vector3{1.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             translation,
@@ -2569,6 +2804,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4::scaling({2.0f, 1.0f, 0.0f}),
             Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, {2.0f, 1.0f, 0.0f}},
+            {{1.5f, 2.5f, 3.5f}, {}, {-0.5f, 4.0f, -16.0f}},
+        })), TestSuite::Compare::Container);
     } {
         SceneData scene{SceneObjectType::UnsignedInt, 8, {}, fields, {
             rotation,
@@ -2581,6 +2823,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4::scaling({2.0f, 1.0f, 0.0f}),
             Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{}, {}, Vector3{1.0f}},
+            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, {2.0f, 1.0f, 0.0f}},
+            {{}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), {-0.5f, 4.0f, -16.0f}},
+        })), TestSuite::Compare::Container);
     }
 
     /* All */
@@ -2597,6 +2846,13 @@ template<class T, class U, class V> void SceneDataTest::transformations3DAsArray
             Matrix4::scaling({2.0f, 1.0f, 0.0f}),
             Matrix4::translation({1.5f, 2.5f, 3.5f})*Matrix4::rotationX({-15.0_degf})*Matrix4::scaling({-0.5f, 4.0f, -16.0f})
         }), TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scene.translationsRotationsScalings3DAsArray(), (Containers::arrayView<Containers::Triple<Vector3, Quaternion, Vector3>>({
+            {{3.0f, 2.0, 1.0f}, {}, Vector3{1.0f}},
+            {{}, Quaternion::rotation(35.0_degf, Vector3::yAxis()), Vector3{1.0f}},
+            {{}, {}, Vector3{1.0f}},
+            {{}, {}, {2.0f, 1.0f, 0.0f}},
+            {{1.5f, 2.5f, 3.5f}, Quaternion::rotation(-15.0_degf, Vector3::xAxis()), {-0.5f, 4.0f, -16.0f}},
+        })), TestSuite::Compare::Container);
     }
 }
 
@@ -2625,25 +2881,43 @@ template<class T> void SceneDataTest::transformations3DAsArrayBut2DTypeTRS() {
     CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
     #endif
 
-    SceneData translation{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Translation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr}
+    /* Because TRSAsArray() allocates an Array<Triple> and then calls
+       TRSInto(), which skips views that are nullptr, we wouldn't get the
+       assertion for translations, as those are at offset 0, which would be
+       interpreted as an empty view if there were no elements. So we have to
+       supply at least one element to make all assertions trigger. */
+    struct Field {
+        UnsignedInt object;
+        Math::Vector2<T> translation;
+        Math::Complex<T> rotation;
+        Math::Vector2<T> scaling;
+    } data[1];
+    Containers::StridedArrayView1D<Field> view = data;
+    SceneData translation{SceneObjectType::UnsignedInt, 1, {}, data, {
+        SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
     }};
-    SceneData rotation{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Rotation, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Complex<T>>::type(), nullptr}
+    SceneData rotation{SceneObjectType::UnsignedInt, 1, {}, data, {
+        SceneFieldData{SceneField::Rotation, view.slice(&Field::object), view.slice(&Field::rotation)}
     }};
-    SceneData scaling{SceneObjectType::UnsignedInt, 0, nullptr, {
-        SceneFieldData{SceneField::Scaling, SceneObjectType::UnsignedInt, nullptr, Implementation::SceneFieldTypeFor<Math::Vector2<T>>::type(), nullptr}
+    SceneData scaling{SceneObjectType::UnsignedInt, 1, {}, data, {
+        SceneFieldData{SceneField::Scaling, view.slice(&Field::object), view.slice(&Field::scaling)}
     }};
 
     std::ostringstream out;
     Error redirectError{&out};
     translation.transformations3DAsArray();
+    translation.translationsRotationsScalings3DAsArray();
     rotation.transformations3DAsArray();
+    rotation.translationsRotationsScalings3DAsArray();
     scaling.transformations3DAsArray();
+    scaling.translationsRotationsScalings3DAsArray();
     CORRADE_COMPARE(out.str(), Utility::formatString(
         "Trade::SceneData::transformations3DInto(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): field has a 2D translation type Trade::SceneFieldType::{0}\n"
         "Trade::SceneData::transformations3DInto(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
-        "Trade::SceneData::transformations3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector2<T>>::name(), NameTraits<Math::Complex<T>>::name()));
+        "Trade::SceneData::translationsRotationsScalings3DInto(): field has a 2D rotation type Trade::SceneFieldType::{1}\n"
+        "Trade::SceneData::transformations3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): field has a 2D scaling type Trade::SceneFieldType::{0}\n", NameTraits<Math::Vector2<T>>::name(), NameTraits<Math::Complex<T>>::name()));
 }
 
 void SceneDataTest::transformations3DIntoArray() {
@@ -2741,6 +3015,50 @@ void SceneDataTest::transformations3DIntoArrayTRS() {
             Containers::arrayView(expected),
             TestSuite::Compare::Container);
 
+    /* Variant with TRS components */
+    } {
+        Vector3 translationsOut[3];
+        Quaternion rotationsOut[3];
+        Vector3 scalingsOut[3];
+        scene.translationsRotationsScalings3DInto(translationsOut, rotationsOut, scalingsOut);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
+            view.slice(&Field::translation),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
+            view.slice(&Field::rotation),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
+            view.slice(&Field::scaling),
+            TestSuite::Compare::Container);
+
+    /* Variant with just translations */
+    } {
+        Vector3 translationsOut[3];
+        scene.translationsRotationsScalings3DInto(translationsOut, nullptr, nullptr);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(translationsOut),
+            view.slice(&Field::translation),
+            TestSuite::Compare::Container);
+
+    /* Variant with just rotations */
+    } {
+        Quaternion rotationsOut[3];
+        scene.translationsRotationsScalings3DInto(nullptr, rotationsOut, nullptr);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(rotationsOut),
+            view.slice(&Field::rotation),
+            TestSuite::Compare::Container);
+
+    /* Variant with just scalings */
+    } {
+        Vector3 scalingsOut[3];
+        scene.translationsRotationsScalings3DInto(nullptr, nullptr, scalingsOut);
+        CORRADE_COMPARE_AS(Containers::stridedArrayView(scalingsOut),
+            view.slice(&Field::scaling),
+            TestSuite::Compare::Container);
+
+    /* Variant with neither is stupid, but should work too */
+    } {
+        scene.translationsRotationsScalings3DInto(nullptr, nullptr, nullptr);
+
     /* The offset variant only a subset */
     } {
         Containers::Array<Matrix4> out{data.size};
@@ -2748,6 +3066,56 @@ void SceneDataTest::transformations3DIntoArrayTRS() {
         CORRADE_COMPARE_AS(out.prefix(data.expectedSize),
             Containers::arrayView(expected).slice(data.offset, data.offset + data.expectedSize),
             TestSuite::Compare::Container);
+
+    /* Variant with TRS components */
+    } {
+        Containers::Array<Vector3> translationsOut{data.size};
+        Containers::Array<Quaternion> rotationsOut{data.size};
+        Containers::Array<Vector3> scalingsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, translationsOut, rotationsOut, scalingsOut), data.expectedSize);
+        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
+            view.slice(&Field::translation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
+            view.slice(&Field::rotation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
+            view.slice(&Field::scaling)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with just translations */
+    } {
+        Containers::Array<Vector3> translationsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, translationsOut, nullptr, nullptr), data.expectedSize);
+        CORRADE_COMPARE_AS(translationsOut.prefix(data.expectedSize),
+            view.slice(&Field::translation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with just rotations */
+    } {
+        Containers::Array<Quaternion> rotationsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, nullptr, rotationsOut, nullptr), data.expectedSize);
+        CORRADE_COMPARE_AS(rotationsOut.prefix(data.expectedSize),
+            view.slice(&Field::rotation)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with just scalings */
+    } {
+        Containers::Array<Vector3> scalingsOut{data.size};
+        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, nullptr, nullptr, scalingsOut), data.expectedSize);
+        CORRADE_COMPARE_AS(scalingsOut.prefix(data.expectedSize),
+            view.slice(&Field::scaling)
+                .slice(data.offset, data.offset + data.expectedSize),
+            TestSuite::Compare::Container);
+
+    /* Variant with neither is stupid, but should work too */
+    } {
+        CORRADE_COMPARE(scene.translationsRotationsScalings3DInto(data.offset, nullptr, nullptr, nullptr), 0);
     }
 }
 
@@ -2775,6 +3143,47 @@ void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffset() {
     CORRADE_COMPARE(out.str(),
         "Trade::SceneData::transformations3DInto(): expected a view with 3 elements but got 2\n"
         "Trade::SceneData::transformations3DInto(): offset 4 out of bounds for a field of size 3\n");
+}
+
+void SceneDataTest::transformations3DIntoArrayInvalidSizeOrOffsetTRS() {
+    #ifdef CORRADE_NO_ASSERT
+    CORRADE_SKIP("CORRADE_NO_ASSERT defined, can't test assertions");
+    #endif
+
+    struct Field {
+        UnsignedInt object;
+        Vector2 translation;
+    } fields[3]{};
+
+    Containers::StridedArrayView1D<Field> view = fields;
+
+    SceneData scene{SceneObjectType::UnsignedInt, 5, {}, fields, {
+        SceneFieldData{SceneField::Translation, view.slice(&Field::object), view.slice(&Field::translation)}
+    }};
+
+    std::ostringstream out;
+    Error redirectError{&out};
+    Vector3 translationDestinationCorrect[3];
+    Vector3 translationDestination[2];
+    Quaternion rotationDestinationCorrect[3];
+    Quaternion rotationDestination[2];
+    Vector3 scalingDestinationCorrect[3];
+    Vector3 scalingDestination[2];
+    scene.translationsRotationsScalings3DInto(translationDestination, rotationDestinationCorrect, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(translationDestinationCorrect, rotationDestination, scalingDestinationCorrect);
+    scene.translationsRotationsScalings3DInto(translationDestinationCorrect, rotationDestinationCorrect, scalingDestination);
+    scene.translationsRotationsScalings3DInto(4, translationDestination, rotationDestination, scalingDestination);
+    scene.translationsRotationsScalings3DInto(0, translationDestinationCorrect, rotationDestination, nullptr);
+    scene.translationsRotationsScalings3DInto(0, translationDestinationCorrect, nullptr, scalingDestination);
+    scene.translationsRotationsScalings3DInto(0, nullptr, rotationDestinationCorrect, scalingDestination);
+    CORRADE_COMPARE(out.str(),
+        "Trade::SceneData::translationsRotationsScalings3DInto(): expected translation destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): expected rotation destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): expected scaling destination view either empty or with 3 elements but got 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): offset 4 out of bounds for a field of size 3\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): translation and rotation destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): translation and scaling destination views have different size, 3 vs 2\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): rotation and scaling destination views have different size, 3 vs 2\n");
 }
 
 template<class T, class U> void SceneDataTest::meshesMaterialsAsArray() {
@@ -3428,9 +3837,15 @@ void SceneDataTest::fieldNotFound() {
     scene.transformations2DAsArray();
     scene.transformations2DInto(nullptr);
     scene.transformations2DInto(0, nullptr);
+    scene.translationsRotationsScalings2DAsArray();
+    scene.translationsRotationsScalings2DInto(nullptr, nullptr, nullptr);
+    scene.translationsRotationsScalings2DInto(0, nullptr, nullptr, nullptr);
     scene.transformations3DAsArray();
     scene.transformations3DInto(nullptr);
     scene.transformations3DInto(0, nullptr);
+    scene.translationsRotationsScalings3DAsArray();
+    scene.translationsRotationsScalings3DInto(nullptr, nullptr, nullptr);
+    scene.translationsRotationsScalings3DInto(0, nullptr, nullptr, nullptr);
     scene.meshesMaterialsAsArray();
     scene.meshesMaterialsInto(nullptr, nullptr);
     scene.meshesMaterialsInto(0, nullptr, nullptr);
@@ -3476,9 +3891,15 @@ void SceneDataTest::fieldNotFound() {
         "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): no transformation-related field found\n"
+        "Trade::SceneData::translationsRotationsScalings2DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
         "Trade::SceneData::transformations3DInto(): no transformation-related field found\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): no transformation-related field found\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): no transformation-related field found\n"
+        "Trade::SceneData::translationsRotationsScalings3DInto(): no transformation-related field found\n"
         "Trade::SceneData::meshesMaterialsInto(): field Trade::SceneField::Mesh not found\n"
         "Trade::SceneData::meshesMaterialsInto(): field Trade::SceneField::Mesh not found\n"
         "Trade::SceneData::meshesMaterialsInto(): field Trade::SceneField::Mesh not found\n"

--- a/src/Magnum/Trade/Test/SceneToolsTest.cpp
+++ b/src/Magnum/Trade/Test/SceneToolsTest.cpp
@@ -423,32 +423,35 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
 
     /* To be extra sure, verify the actual data. Parents have a few objects
        added, the rest is the same */
-    CORRADE_COMPARE_AS(scene.objectsAsArray(SceneField::Parent), Containers::arrayView<UnsignedInt>({
-        15, 21, 22, 23, 1, 63, 64, 65, 66
-    }), TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(scene.parentsAsArray(), Containers::arrayView<Int>({
-        -1, -1, 1, 2, -1, 3, 3, 0, 4
-    }), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.parentsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({
+        {15, -1},
+        {21, -1},
+        {22, 1},
+        {23, 2},
+        {1, -1},
+        {63, 3},
+        {64, 3},
+        {65, 0},
+        {66, 4}
+    })), TestSuite::Compare::Container);
 
-    /* Meshes have certain objects reassigned (and materials as well, as they
-       share the same object mapping view), field data stay the same */
-    CORRADE_COMPARE_AS(scene.objectsAsArray(SceneField::Mesh), Containers::arrayView<UnsignedInt>({
-        15, 23, 63, 64, 1, 65, 21
-    }), TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(scene.objectsAsArray(SceneField::MeshMaterial), Containers::arrayView<UnsignedInt>({
-        15, 23, 63, 64, 1, 65, 21
-    }), TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(),
-        Containers::arrayView(meshesMaterials),
-        TestSuite::Compare::Container);
+    /* Meshes / materials have certain objects reassigned, field data stay the
+       same */
+    CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>>({
+        {15, {6, 4}},
+        {23, {1, 0}},
+        {63, {2, 3}},
+        {64, {4, 2}},
+        {1, {7, 2}},
+        {65, {3, 1}},
+        {21, {5, -1}}
+    })), TestSuite::Compare::Container);
 
     /* Cameras have certain objects reassigned, field data stay the same */
-    CORRADE_COMPARE_AS(scene.objectsAsArray(SceneField::Camera), Containers::arrayView<UnsignedInt>({
-        22, 66
-    }), TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(scene.camerasAsArray(),
-        Containers::arrayView(cameras),
-        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.camerasAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, UnsignedInt>>({
+        {22, 1},
+        {66, 5}
+    })), TestSuite::Compare::Container);
 }
 
 }}}}

--- a/src/Magnum/Trade/Test/SceneToolsTest.cpp
+++ b/src/Magnum/Trade/Test/SceneToolsTest.cpp
@@ -1,0 +1,324 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <Corrade/TestSuite/Tester.h>
+#include <Corrade/TestSuite/Compare/Container.h>
+#include <Corrade/TestSuite/Compare/Numeric.h>
+
+#include "Magnum/Math/Complex.h"
+#include "Magnum/Math/Vector2.h"
+#include "Magnum/Trade/Implementation/sceneTools.h"
+
+namespace Magnum { namespace Trade { namespace Test { namespace {
+
+struct SceneToolsTest: TestSuite::Tester {
+    explicit SceneToolsTest();
+
+    void combine();
+    void combineAlignment();
+    void combineObjectsShared();
+    void combineObjectsPlaceholderFieldPlaceholder();
+    void combineObjectSharedFieldPlaceholder();
+};
+
+struct {
+    const char* name;
+    SceneObjectType objectType;
+} CombineData[]{
+    {"UnsignedByte output", SceneObjectType::UnsignedByte},
+    {"UnsignedShort output", SceneObjectType::UnsignedShort},
+    {"UnsignedInt output", SceneObjectType::UnsignedInt},
+    {"UnsignedLong output", SceneObjectType::UnsignedLong},
+};
+
+SceneToolsTest::SceneToolsTest() {
+    addInstancedTests({&SceneToolsTest::combine},
+        Containers::arraySize(CombineData));
+
+    addTests({&SceneToolsTest::combineAlignment,
+              &SceneToolsTest::combineObjectsShared,
+              &SceneToolsTest::combineObjectsPlaceholderFieldPlaceholder,
+              &SceneToolsTest::combineObjectSharedFieldPlaceholder});
+}
+
+using namespace Math::Literals;
+
+void SceneToolsTest::combine() {
+    auto&& data = CombineData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    /* Testing the four possible object types, it should be possible to combine
+       them */
+
+    const UnsignedInt meshObjects[]{45, 78, 23};
+    const UnsignedByte meshes[]{3, 5, 17};
+
+    const UnsignedShort parentObjects[]{33, 25};
+    const Short parents[]{-1, 0};
+
+    const UnsignedByte translationObjects[]{16};
+    const Vector2d translations[]{{1.5, -0.5}};
+
+    const UnsignedLong fooObjects[]{15, 23};
+    const Int foos[]{0, 1, 2, 3};
+
+    SceneData scene = Implementation::sceneCombine(data.objectType, 167, Containers::arrayView({
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
+        SceneFieldData{SceneField::Parent, Containers::arrayView(parentObjects), Containers::arrayView(parents)},
+        SceneFieldData{SceneField::Translation, Containers::arrayView(translationObjects), Containers::arrayView(translations)},
+        /* Array field */
+        SceneFieldData{sceneFieldCustom(15), Containers::arrayView(fooObjects), Containers::StridedArrayView2D<const Int>{foos, {2, 2}}},
+        /* Empty field */
+        SceneFieldData{SceneField::Camera, Containers::ArrayView<const UnsignedByte>{}, Containers::ArrayView<const UnsignedShort>{}}
+    }));
+
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(scene.objectType(), data.objectType);
+    CORRADE_COMPARE(scene.objectCount(), 167);
+    CORRADE_COMPARE(scene.fieldCount(), 5);
+
+    CORRADE_COMPARE(scene.fieldName(0), SceneField::Mesh);
+    CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldArraySize(0), 0);
+    CORRADE_COMPARE_AS(scene.objectsAsArray(0), Containers::arrayView<UnsignedInt>({
+        45, 78, 23
+    }), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<UnsignedByte>(0),
+        Containers::arrayView(meshes),
+        TestSuite::Compare::Container);
+
+    CORRADE_COMPARE(scene.fieldName(1), SceneField::Parent);
+    CORRADE_COMPARE(scene.fieldType(1), SceneFieldType::Short);
+    CORRADE_COMPARE(scene.fieldArraySize(1), 0);
+    CORRADE_COMPARE_AS(scene.objectsAsArray(1), Containers::arrayView<UnsignedInt>({
+        33, 25
+    }), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Short>(1),
+        Containers::arrayView(parents),
+        TestSuite::Compare::Container);
+
+    CORRADE_COMPARE(scene.fieldName(2), SceneField::Translation);
+    CORRADE_COMPARE(scene.fieldType(2), SceneFieldType::Vector2d);
+    CORRADE_COMPARE(scene.fieldArraySize(2), 0);
+    CORRADE_COMPARE_AS(scene.objectsAsArray(2),
+        Containers::arrayView<UnsignedInt>({16}),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Vector2d>(2),
+        Containers::arrayView(translations),
+        TestSuite::Compare::Container);
+
+    CORRADE_COMPARE(scene.fieldName(3), sceneFieldCustom(15));
+    CORRADE_COMPARE(scene.fieldType(3), SceneFieldType::Int);
+    CORRADE_COMPARE(scene.fieldArraySize(3), 2);
+    CORRADE_COMPARE_AS(scene.objectsAsArray(3),
+        Containers::arrayView<UnsignedInt>({15, 23}),
+        TestSuite::Compare::Container);
+    /** @todo clean up once it's possible to compare multidimensional
+        containers */
+    CORRADE_COMPARE_AS(scene.field<Int[]>(3)[0],
+        (Containers::StridedArrayView2D<const Int>{foos, {2, 2}})[0],
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Int[]>(3)[1],
+        (Containers::StridedArrayView2D<const Int>{foos, {2, 2}})[1],
+        TestSuite::Compare::Container);
+
+    CORRADE_COMPARE(scene.fieldName(4), SceneField::Camera);
+    CORRADE_COMPARE(scene.fieldType(4), SceneFieldType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldSize(4), 0);
+    CORRADE_COMPARE(scene.fieldArraySize(4), 0);
+}
+
+void SceneToolsTest::combineAlignment() {
+    const UnsignedShort meshObjects[]{15, 23, 47};
+    const UnsignedByte meshes[]{0, 1, 2};
+    const UnsignedShort translationObjects[]{5}; /* 1 byte padding before */
+    const Vector2d translations[]{{1.5, 3.0}}; /* 4 byte padding before */
+
+    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedShort, 167, Containers::arrayView({
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
+        SceneFieldData{SceneField::Translation, Containers::arrayView(translationObjects), Containers::arrayView(translations)}
+    }));
+
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.objectCount(), 167);
+    CORRADE_COMPARE(scene.fieldCount(), 2);
+
+    CORRADE_COMPARE(scene.fieldName(0), SceneField::Mesh);
+    CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldArraySize(0), 0);
+    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(0),
+        Containers::arrayView(meshObjects),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<UnsignedByte>(0),
+        Containers::arrayView(meshes),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.objects(0).data()), 2, TestSuite::Compare::Divisible);
+    CORRADE_COMPARE(scene.objects(0).data(), scene.data());
+    CORRADE_COMPARE(scene.objects(0).stride()[0], 2);
+    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.field(0).data()), 1, TestSuite::Compare::Divisible);
+    CORRADE_COMPARE(scene.field(0).data(), scene.data() + 3*2);
+    CORRADE_COMPARE(scene.field(0).stride()[0], 1);
+
+    CORRADE_COMPARE(scene.fieldName(1), SceneField::Translation);
+    CORRADE_COMPARE(scene.fieldType(1), SceneFieldType::Vector2d);
+    CORRADE_COMPARE(scene.fieldArraySize(1), 0);
+    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(1),
+        Containers::arrayView(translationObjects),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Vector2d>(1),
+        Containers::arrayView(translations),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.objects(1).data()), 2, TestSuite::Compare::Divisible);
+    CORRADE_COMPARE(scene.objects(1).data(), scene.data() + 3*2 + 3 + 1);
+    CORRADE_COMPARE(scene.objects(1).stride()[0], 2);
+    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.field(1).data()), 8, TestSuite::Compare::Divisible);
+    CORRADE_COMPARE(scene.field(1).data(), scene.data() + 3*2 + 3 + 1 + 2 + 4);
+    CORRADE_COMPARE(scene.field(1).stride()[0], 16);
+}
+
+void SceneToolsTest::combineObjectsShared() {
+    const UnsignedShort meshObjects[]{15, 23, 47};
+    const UnsignedByte meshes[]{0, 1, 2};
+    const Int meshMaterials[]{72, -1, 23};
+
+    const UnsignedShort translationRotationObjects[]{14, 22};
+    const Vector2 translations[]{{-1.0f, 25.3f}, {2.2f, 2.1f}};
+    const Complex rotations[]{Complex::rotation(35.0_degf), Complex::rotation(22.5_degf)};
+
+    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedInt, 173, Containers::arrayView({
+        /* Deliberately in an arbitrary order to avoid false assumptions like
+           fields sharing the same object mapping always being after each
+           other */
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
+        SceneFieldData{SceneField::Translation, Containers::arrayView(translationRotationObjects), Containers::arrayView(translations)},
+        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshObjects), Containers::arrayView(meshMaterials)},
+        SceneFieldData{SceneField::Rotation, Containers::arrayView(translationRotationObjects), Containers::arrayView(rotations)}
+    }));
+
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
+    CORRADE_COMPARE(scene.objectCount(), 173);
+    CORRADE_COMPARE(scene.fieldCount(), 4);
+
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Mesh), 3);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 3);
+    CORRADE_COMPARE(scene.objects(SceneField::Mesh).data(), scene.objects(SceneField::MeshMaterial).data());
+
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Translation), 2);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Rotation), 2);
+    CORRADE_COMPARE(scene.objects(SceneField::Translation).data(), scene.objects(SceneField::Rotation).data());
+}
+
+void SceneToolsTest::combineObjectsPlaceholderFieldPlaceholder() {
+    const UnsignedShort meshObjects[]{15, 23, 47};
+    const UnsignedByte meshes[]{0, 1, 2};
+
+    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedShort, 173, Containers::arrayView({
+        SceneFieldData{SceneField::Camera, Containers::ArrayView<UnsignedByte>{nullptr, 1}, Containers::ArrayView<UnsignedShort>{nullptr, 1}},
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
+        /* Looks like sharing object mapping with the Camera field, but
+           actually both are placeholders */
+        SceneFieldData{SceneField::Light, Containers::ArrayView<UnsignedShort>{nullptr, 2}, Containers::ArrayView<UnsignedInt>{nullptr, 2}},
+        /* Array field */
+        SceneFieldData{sceneFieldCustom(15), Containers::ArrayView<UnsignedShort>{nullptr, 2}, Containers::StridedArrayView2D<Short>{{nullptr, 16}, {2, 4}}},
+    }));
+
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
+    CORRADE_COMPARE(scene.objectCount(), 173);
+    CORRADE_COMPARE(scene.fieldCount(), 4);
+
+    CORRADE_COMPARE(scene.fieldType(SceneField::Camera), SceneFieldType::UnsignedShort);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Camera), 1);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Camera), 0);
+    CORRADE_COMPARE(scene.objects(SceneField::Camera).data(), scene.data());
+    CORRADE_COMPARE(scene.objects(SceneField::Camera).stride()[0], 2);
+    CORRADE_COMPARE(scene.field(SceneField::Camera).data(), scene.data() + 2);
+    CORRADE_COMPARE(scene.field(SceneField::Camera).stride()[0], 2);
+
+    CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Mesh), 0);
+    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(SceneField::Mesh),
+        Containers::arrayView(meshObjects),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<UnsignedByte>(SceneField::Mesh),
+        Containers::arrayView(meshes),
+        TestSuite::Compare::Container);
+
+    CORRADE_COMPARE(scene.fieldType(SceneField::Light), SceneFieldType::UnsignedInt);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::Light), 2);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Light), 0);
+    CORRADE_COMPARE(scene.objects(SceneField::Light).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1);
+    CORRADE_COMPARE(scene.objects(SceneField::Light).stride()[0], 2);
+    CORRADE_COMPARE(scene.field(SceneField::Light).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2);
+    CORRADE_COMPARE(scene.field(SceneField::Light).stride()[0], 4);
+
+    CORRADE_COMPARE(scene.fieldType(sceneFieldCustom(15)), SceneFieldType::Short);
+    CORRADE_COMPARE(scene.fieldSize(sceneFieldCustom(15)), 2);
+    CORRADE_COMPARE(scene.fieldArraySize(sceneFieldCustom(15)), 4);
+    CORRADE_COMPARE(scene.objects(sceneFieldCustom(15)).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2 + 2*4);
+    CORRADE_COMPARE(scene.objects(sceneFieldCustom(15)).stride()[0], 2);
+    CORRADE_COMPARE(scene.field(sceneFieldCustom(15)).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2 + 2*4 + 2*2);
+    CORRADE_COMPARE(scene.field(sceneFieldCustom(15)).stride()[0], 4*2);
+}
+
+void SceneToolsTest::combineObjectSharedFieldPlaceholder() {
+    const UnsignedInt meshObjects[]{15, 23, 47};
+    const UnsignedByte meshes[]{0, 1, 2};
+
+    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedInt, 173, Containers::arrayView({
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
+        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshObjects), Containers::ArrayView<Int>{nullptr, 3}},
+    }));
+
+    CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
+    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
+    CORRADE_COMPARE(scene.objectCount(), 173);
+    CORRADE_COMPARE(scene.fieldCount(), 2);
+
+    CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedByte);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::Mesh), 0);
+    CORRADE_COMPARE_AS(scene.objects<UnsignedInt>(0),
+        Containers::arrayView(meshObjects),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<UnsignedByte>(0),
+        Containers::arrayView(meshes),
+        TestSuite::Compare::Container);
+
+    CORRADE_COMPARE(scene.fieldType(SceneField::MeshMaterial), SceneFieldType::Int);
+    CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 3);
+    CORRADE_COMPARE(scene.fieldArraySize(SceneField::MeshMaterial), 0);
+    CORRADE_COMPARE(scene.objects(SceneField::MeshMaterial).data(), scene.objects(SceneField::Mesh).data());
+    CORRADE_COMPARE_AS(scene.objects<UnsignedInt>(SceneField::MeshMaterial),
+        Containers::arrayView(meshObjects),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE(scene.field(SceneField::MeshMaterial).data(), scene.data() + 3*4 + 3 + 1);
+    CORRADE_COMPARE(scene.field(SceneField::MeshMaterial).stride()[0], 4);
+}
+
+}}}}
+
+CORRADE_TEST_MAIN(Magnum::Trade::Test::SceneToolsTest)

--- a/src/Magnum/Trade/Test/SceneToolsTest.cpp
+++ b/src/Magnum/Trade/Test/SceneToolsTest.cpp
@@ -47,12 +47,12 @@ struct SceneToolsTest: TestSuite::Tester {
 
 struct {
     const char* name;
-    SceneObjectType objectType;
+    SceneMappingType objectType;
 } CombineData[]{
-    {"UnsignedByte output", SceneObjectType::UnsignedByte},
-    {"UnsignedShort output", SceneObjectType::UnsignedShort},
-    {"UnsignedInt output", SceneObjectType::UnsignedInt},
-    {"UnsignedLong output", SceneObjectType::UnsignedLong},
+    {"UnsignedByte output", SceneMappingType::UnsignedByte},
+    {"UnsignedShort output", SceneMappingType::UnsignedShort},
+    {"UnsignedInt output", SceneMappingType::UnsignedInt},
+    {"UnsignedLong output", SceneMappingType::UnsignedLong},
 };
 
 struct {
@@ -86,76 +86,76 @@ void SceneToolsTest::combine() {
     /* Testing the four possible object types, it should be possible to combine
        them */
 
-    const UnsignedInt meshObjects[]{45, 78, 23};
-    const UnsignedByte meshes[]{3, 5, 17};
+    const UnsignedInt meshMappingData[]{45, 78, 23};
+    const UnsignedByte meshFieldData[]{3, 5, 17};
 
-    const UnsignedShort parentObjects[]{33, 25};
-    const Short parents[]{-1, 33};
+    const UnsignedShort parentMappingData[]{33, 25};
+    const Short parentData[]{-1, 33};
 
-    const UnsignedByte translationObjects[]{16};
-    const Vector2d translations[]{{1.5, -0.5}};
+    const UnsignedByte translationMappingData[]{16};
+    const Vector2d translationFieldData[]{{1.5, -0.5}};
 
-    const UnsignedLong fooObjects[]{15, 23};
-    const Int foos[]{0, 1, 2, 3};
+    const UnsignedLong fooMappingData[]{15, 23};
+    const Int fooFieldData[]{0, 1, 2, 3};
 
     SceneData scene = Implementation::sceneCombine(data.objectType, 167, Containers::arrayView({
-        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
-        SceneFieldData{SceneField::Parent, Containers::arrayView(parentObjects), Containers::arrayView(parents)},
-        SceneFieldData{SceneField::Translation, Containers::arrayView(translationObjects), Containers::arrayView(translations)},
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::arrayView(meshFieldData)},
+        SceneFieldData{SceneField::Parent, Containers::arrayView(parentMappingData), Containers::arrayView(parentData)},
+        SceneFieldData{SceneField::Translation, Containers::arrayView(translationMappingData), Containers::arrayView(translationFieldData)},
         /* Array field */
-        SceneFieldData{sceneFieldCustom(15), Containers::arrayView(fooObjects), Containers::StridedArrayView2D<const Int>{foos, {2, 2}}},
+        SceneFieldData{sceneFieldCustom(15), Containers::arrayView(fooMappingData), Containers::StridedArrayView2D<const Int>{fooFieldData, {2, 2}}},
         /* Empty field */
         SceneFieldData{SceneField::Camera, Containers::ArrayView<const UnsignedByte>{}, Containers::ArrayView<const UnsignedShort>{}}
     }));
 
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(scene.objectType(), data.objectType);
-    CORRADE_COMPARE(scene.objectCount(), 167);
+    CORRADE_COMPARE(scene.mappingType(), data.objectType);
+    CORRADE_COMPARE(scene.mappingBound(), 167);
     CORRADE_COMPARE(scene.fieldCount(), 5);
 
     CORRADE_COMPARE(scene.fieldName(0), SceneField::Mesh);
     CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::UnsignedByte);
     CORRADE_COMPARE(scene.fieldArraySize(0), 0);
-    CORRADE_COMPARE_AS(scene.objectsAsArray(0), Containers::arrayView<UnsignedInt>({
+    CORRADE_COMPARE_AS(scene.mappingAsArray(0), Containers::arrayView<UnsignedInt>({
         45, 78, 23
     }), TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedByte>(0),
-        Containers::arrayView(meshes),
+        Containers::arrayView(meshFieldData),
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(1), SceneField::Parent);
     CORRADE_COMPARE(scene.fieldType(1), SceneFieldType::Short);
     CORRADE_COMPARE(scene.fieldArraySize(1), 0);
-    CORRADE_COMPARE_AS(scene.objectsAsArray(1), Containers::arrayView<UnsignedInt>({
+    CORRADE_COMPARE_AS(scene.mappingAsArray(1), Containers::arrayView<UnsignedInt>({
         33, 25
     }), TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<Short>(1),
-        Containers::arrayView(parents),
+        Containers::arrayView(parentData),
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(2), SceneField::Translation);
     CORRADE_COMPARE(scene.fieldType(2), SceneFieldType::Vector2d);
     CORRADE_COMPARE(scene.fieldArraySize(2), 0);
-    CORRADE_COMPARE_AS(scene.objectsAsArray(2),
+    CORRADE_COMPARE_AS(scene.mappingAsArray(2),
         Containers::arrayView<UnsignedInt>({16}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<Vector2d>(2),
-        Containers::arrayView(translations),
+        Containers::arrayView(translationFieldData),
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(3), sceneFieldCustom(15));
     CORRADE_COMPARE(scene.fieldType(3), SceneFieldType::Int);
     CORRADE_COMPARE(scene.fieldArraySize(3), 2);
-    CORRADE_COMPARE_AS(scene.objectsAsArray(3),
+    CORRADE_COMPARE_AS(scene.mappingAsArray(3),
         Containers::arrayView<UnsignedInt>({15, 23}),
         TestSuite::Compare::Container);
     /** @todo clean up once it's possible to compare multidimensional
         containers */
     CORRADE_COMPARE_AS(scene.field<Int[]>(3)[0],
-        (Containers::StridedArrayView2D<const Int>{foos, {2, 2}})[0],
+        (Containers::StridedArrayView2D<const Int>{fooFieldData, {2, 2}})[0],
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<Int[]>(3)[1],
-        (Containers::StridedArrayView2D<const Int>{foos, {2, 2}})[1],
+        (Containers::StridedArrayView2D<const Int>{fooFieldData, {2, 2}})[1],
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(4), SceneField::Camera);
@@ -165,33 +165,33 @@ void SceneToolsTest::combine() {
 }
 
 void SceneToolsTest::combineAlignment() {
-    const UnsignedShort meshObjects[]{15, 23, 47};
-    const UnsignedByte meshes[]{0, 1, 2};
-    const UnsignedShort translationObjects[]{5}; /* 1 byte padding before */
-    const Vector2d translations[]{{1.5, 3.0}}; /* 4 byte padding before */
+    const UnsignedShort meshMappingData[]{15, 23, 47};
+    const UnsignedByte meshFieldData[]{0, 1, 2};
+    const UnsignedShort translationMappingData[]{5}; /* 1 byte padding before */
+    const Vector2d translationFieldData[]{{1.5, 3.0}}; /* 4 byte padding before */
 
-    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedShort, 167, Containers::arrayView({
-        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
-        SceneFieldData{SceneField::Translation, Containers::arrayView(translationObjects), Containers::arrayView(translations)}
+    SceneData scene = Implementation::sceneCombine(SceneMappingType::UnsignedShort, 167, Containers::arrayView({
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::arrayView(meshFieldData)},
+        SceneFieldData{SceneField::Translation, Containers::arrayView(translationMappingData), Containers::arrayView(translationFieldData)}
     }));
 
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(scene.objectCount(), 167);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(scene.mappingBound(), 167);
     CORRADE_COMPARE(scene.fieldCount(), 2);
 
     CORRADE_COMPARE(scene.fieldName(0), SceneField::Mesh);
     CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::UnsignedByte);
     CORRADE_COMPARE(scene.fieldArraySize(0), 0);
-    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(0),
-        Containers::arrayView(meshObjects),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedShort>(0),
+        Containers::arrayView(meshMappingData),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedByte>(0),
-        Containers::arrayView(meshes),
+        Containers::arrayView(meshFieldData),
         TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.objects(0).data()), 2, TestSuite::Compare::Divisible);
-    CORRADE_COMPARE(scene.objects(0).data(), scene.data());
-    CORRADE_COMPARE(scene.objects(0).stride()[0], 2);
+    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.mapping(0).data()), 2, TestSuite::Compare::Divisible);
+    CORRADE_COMPARE(scene.mapping(0).data(), scene.data());
+    CORRADE_COMPARE(scene.mapping(0).stride()[0], 2);
     CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.field(0).data()), 1, TestSuite::Compare::Divisible);
     CORRADE_COMPARE(scene.field(0).data(), scene.data() + 3*2);
     CORRADE_COMPARE(scene.field(0).stride()[0], 1);
@@ -199,60 +199,60 @@ void SceneToolsTest::combineAlignment() {
     CORRADE_COMPARE(scene.fieldName(1), SceneField::Translation);
     CORRADE_COMPARE(scene.fieldType(1), SceneFieldType::Vector2d);
     CORRADE_COMPARE(scene.fieldArraySize(1), 0);
-    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(1),
-        Containers::arrayView(translationObjects),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedShort>(1),
+        Containers::arrayView(translationMappingData),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<Vector2d>(1),
-        Containers::arrayView(translations),
+        Containers::arrayView(translationFieldData),
         TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.objects(1).data()), 2, TestSuite::Compare::Divisible);
-    CORRADE_COMPARE(scene.objects(1).data(), scene.data() + 3*2 + 3 + 1);
-    CORRADE_COMPARE(scene.objects(1).stride()[0], 2);
+    CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.mapping(1).data()), 2, TestSuite::Compare::Divisible);
+    CORRADE_COMPARE(scene.mapping(1).data(), scene.data() + 3*2 + 3 + 1);
+    CORRADE_COMPARE(scene.mapping(1).stride()[0], 2);
     CORRADE_COMPARE_AS(reinterpret_cast<std::ptrdiff_t>(scene.field(1).data()), 8, TestSuite::Compare::Divisible);
     CORRADE_COMPARE(scene.field(1).data(), scene.data() + 3*2 + 3 + 1 + 2 + 4);
     CORRADE_COMPARE(scene.field(1).stride()[0], 16);
 }
 
 void SceneToolsTest::combineObjectsShared() {
-    const UnsignedShort meshObjects[]{15, 23, 47};
-    const UnsignedByte meshes[]{0, 1, 2};
-    const Int meshMaterials[]{72, -1, 23};
+    const UnsignedShort meshMappingData[]{15, 23, 47};
+    const UnsignedByte meshFieldData[]{0, 1, 2};
+    const Int meshMaterialFieldData[]{72, -1, 23};
 
-    const UnsignedShort translationRotationObjects[]{14, 22};
-    const Vector2 translations[]{{-1.0f, 25.3f}, {2.2f, 2.1f}};
-    const Complex rotations[]{Complex::rotation(35.0_degf), Complex::rotation(22.5_degf)};
+    const UnsignedShort translationRotationMappingData[]{14, 22};
+    const Vector2 translationFieldData[]{{-1.0f, 25.3f}, {2.2f, 2.1f}};
+    const Complex rotationFieldData[]{Complex::rotation(35.0_degf), Complex::rotation(22.5_degf)};
 
-    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedInt, 173, Containers::arrayView({
+    SceneData scene = Implementation::sceneCombine(SceneMappingType::UnsignedInt, 173, Containers::arrayView({
         /* Deliberately in an arbitrary order to avoid false assumptions like
            fields sharing the same object mapping always being after each
            other */
-        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
-        SceneFieldData{SceneField::Translation, Containers::arrayView(translationRotationObjects), Containers::arrayView(translations)},
-        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshObjects), Containers::arrayView(meshMaterials)},
-        SceneFieldData{SceneField::Rotation, Containers::arrayView(translationRotationObjects), Containers::arrayView(rotations)}
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::arrayView(meshFieldData)},
+        SceneFieldData{SceneField::Translation, Containers::arrayView(translationRotationMappingData), Containers::arrayView(translationFieldData)},
+        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshMappingData), Containers::arrayView(meshMaterialFieldData)},
+        SceneFieldData{SceneField::Rotation, Containers::arrayView(translationRotationMappingData), Containers::arrayView(rotationFieldData)}
     }));
 
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
-    CORRADE_COMPARE(scene.objectCount(), 173);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedInt);
+    CORRADE_COMPARE(scene.mappingBound(), 173);
     CORRADE_COMPARE(scene.fieldCount(), 4);
 
     CORRADE_COMPARE(scene.fieldSize(SceneField::Mesh), 3);
     CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 3);
-    CORRADE_COMPARE(scene.objects(SceneField::Mesh).data(), scene.objects(SceneField::MeshMaterial).data());
+    CORRADE_COMPARE(scene.mapping(SceneField::Mesh).data(), scene.mapping(SceneField::MeshMaterial).data());
 
     CORRADE_COMPARE(scene.fieldSize(SceneField::Translation), 2);
     CORRADE_COMPARE(scene.fieldSize(SceneField::Rotation), 2);
-    CORRADE_COMPARE(scene.objects(SceneField::Translation).data(), scene.objects(SceneField::Rotation).data());
+    CORRADE_COMPARE(scene.mapping(SceneField::Translation).data(), scene.mapping(SceneField::Rotation).data());
 }
 
 void SceneToolsTest::combineObjectsPlaceholderFieldPlaceholder() {
-    const UnsignedShort meshObjects[]{15, 23, 47};
-    const UnsignedByte meshes[]{0, 1, 2};
+    const UnsignedShort meshMappingData[]{15, 23, 47};
+    const UnsignedByte meshFieldData[]{0, 1, 2};
 
-    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedShort, 173, Containers::arrayView({
+    SceneData scene = Implementation::sceneCombine(SceneMappingType::UnsignedShort, 173, Containers::arrayView({
         SceneFieldData{SceneField::Camera, Containers::ArrayView<UnsignedByte>{nullptr, 1}, Containers::ArrayView<UnsignedShort>{nullptr, 1}},
-        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::arrayView(meshFieldData)},
         /* Looks like sharing object mapping with the Camera field, but
            actually both are placeholders */
         SceneFieldData{SceneField::Light, Containers::ArrayView<UnsignedShort>{nullptr, 2}, Containers::ArrayView<UnsignedInt>{nullptr, 2}},
@@ -261,73 +261,73 @@ void SceneToolsTest::combineObjectsPlaceholderFieldPlaceholder() {
     }));
 
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedShort);
-    CORRADE_COMPARE(scene.objectCount(), 173);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedShort);
+    CORRADE_COMPARE(scene.mappingBound(), 173);
     CORRADE_COMPARE(scene.fieldCount(), 4);
 
     CORRADE_COMPARE(scene.fieldType(SceneField::Camera), SceneFieldType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldSize(SceneField::Camera), 1);
     CORRADE_COMPARE(scene.fieldArraySize(SceneField::Camera), 0);
-    CORRADE_COMPARE(scene.objects(SceneField::Camera).data(), scene.data());
-    CORRADE_COMPARE(scene.objects(SceneField::Camera).stride()[0], 2);
+    CORRADE_COMPARE(scene.mapping(SceneField::Camera).data(), scene.data());
+    CORRADE_COMPARE(scene.mapping(SceneField::Camera).stride()[0], 2);
     CORRADE_COMPARE(scene.field(SceneField::Camera).data(), scene.data() + 2);
     CORRADE_COMPARE(scene.field(SceneField::Camera).stride()[0], 2);
 
     CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedByte);
     CORRADE_COMPARE(scene.fieldArraySize(SceneField::Mesh), 0);
-    CORRADE_COMPARE_AS(scene.objects<UnsignedShort>(SceneField::Mesh),
-        Containers::arrayView(meshObjects),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedShort>(SceneField::Mesh),
+        Containers::arrayView(meshMappingData),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedByte>(SceneField::Mesh),
-        Containers::arrayView(meshes),
+        Containers::arrayView(meshFieldData),
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldType(SceneField::Light), SceneFieldType::UnsignedInt);
     CORRADE_COMPARE(scene.fieldSize(SceneField::Light), 2);
     CORRADE_COMPARE(scene.fieldArraySize(SceneField::Light), 0);
-    CORRADE_COMPARE(scene.objects(SceneField::Light).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1);
-    CORRADE_COMPARE(scene.objects(SceneField::Light).stride()[0], 2);
+    CORRADE_COMPARE(scene.mapping(SceneField::Light).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1);
+    CORRADE_COMPARE(scene.mapping(SceneField::Light).stride()[0], 2);
     CORRADE_COMPARE(scene.field(SceneField::Light).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2);
     CORRADE_COMPARE(scene.field(SceneField::Light).stride()[0], 4);
 
     CORRADE_COMPARE(scene.fieldType(sceneFieldCustom(15)), SceneFieldType::Short);
     CORRADE_COMPARE(scene.fieldSize(sceneFieldCustom(15)), 2);
     CORRADE_COMPARE(scene.fieldArraySize(sceneFieldCustom(15)), 4);
-    CORRADE_COMPARE(scene.objects(sceneFieldCustom(15)).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2 + 2*4);
-    CORRADE_COMPARE(scene.objects(sceneFieldCustom(15)).stride()[0], 2);
+    CORRADE_COMPARE(scene.mapping(sceneFieldCustom(15)).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2 + 2*4);
+    CORRADE_COMPARE(scene.mapping(sceneFieldCustom(15)).stride()[0], 2);
     CORRADE_COMPARE(scene.field(sceneFieldCustom(15)).data(), scene.data() + 2 + 2 + 3*2 + 3 + 1 + 2*2 + 2 + 2*4 + 2*2);
     CORRADE_COMPARE(scene.field(sceneFieldCustom(15)).stride()[0], 4*2);
 }
 
 void SceneToolsTest::combineObjectSharedFieldPlaceholder() {
-    const UnsignedInt meshObjects[]{15, 23, 47};
-    const UnsignedByte meshes[]{0, 1, 2};
+    const UnsignedInt meshMappingData[]{15, 23, 47};
+    const UnsignedByte meshFieldData[]{0, 1, 2};
 
-    SceneData scene = Implementation::sceneCombine(SceneObjectType::UnsignedInt, 173, Containers::arrayView({
-        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::arrayView(meshes)},
-        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshObjects), Containers::ArrayView<Int>{nullptr, 3}},
+    SceneData scene = Implementation::sceneCombine(SceneMappingType::UnsignedInt, 173, Containers::arrayView({
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::arrayView(meshFieldData)},
+        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshMappingData), Containers::ArrayView<Int>{nullptr, 3}},
     }));
 
     CORRADE_COMPARE(scene.dataFlags(), DataFlag::Owned|DataFlag::Mutable);
-    CORRADE_COMPARE(scene.objectType(), SceneObjectType::UnsignedInt);
-    CORRADE_COMPARE(scene.objectCount(), 173);
+    CORRADE_COMPARE(scene.mappingType(), SceneMappingType::UnsignedInt);
+    CORRADE_COMPARE(scene.mappingBound(), 173);
     CORRADE_COMPARE(scene.fieldCount(), 2);
 
     CORRADE_COMPARE(scene.fieldType(SceneField::Mesh), SceneFieldType::UnsignedByte);
     CORRADE_COMPARE(scene.fieldArraySize(SceneField::Mesh), 0);
-    CORRADE_COMPARE_AS(scene.objects<UnsignedInt>(0),
-        Containers::arrayView(meshObjects),
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedInt>(0),
+        Containers::arrayView(meshMappingData),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<UnsignedByte>(0),
-        Containers::arrayView(meshes),
+        Containers::arrayView(meshFieldData),
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldType(SceneField::MeshMaterial), SceneFieldType::Int);
     CORRADE_COMPARE(scene.fieldSize(SceneField::MeshMaterial), 3);
     CORRADE_COMPARE(scene.fieldArraySize(SceneField::MeshMaterial), 0);
-    CORRADE_COMPARE(scene.objects(SceneField::MeshMaterial).data(), scene.objects(SceneField::Mesh).data());
-    CORRADE_COMPARE_AS(scene.objects<UnsignedInt>(SceneField::MeshMaterial),
-        Containers::arrayView(meshObjects),
+    CORRADE_COMPARE(scene.mapping(SceneField::MeshMaterial).data(), scene.mapping(SceneField::Mesh).data());
+    CORRADE_COMPARE_AS(scene.mapping<UnsignedInt>(SceneField::MeshMaterial),
+        Containers::arrayView(meshMappingData),
         TestSuite::Compare::Container);
     CORRADE_COMPARE(scene.field(SceneField::MeshMaterial).data(), scene.data() + 3*4 + 3 + 1);
     CORRADE_COMPARE(scene.field(SceneField::MeshMaterial).stride()[0], 4);
@@ -340,13 +340,13 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
     /* Haha now I can use sceneCombine() to conveniently prepare the initial
        state here, without having to mess with an ArrayTuple */
 
-    const UnsignedShort parentObjects[]{15, 21, 22, 23, 1};
-    const Byte parents[]{-1, -1, 21, 22, -1};
+    const UnsignedShort parentMappingData[]{15, 21, 22, 23, 1};
+    const Byte parentFieldData[]{-1, -1, 21, 22, -1};
 
     /* Two objects have two and three mesh assignments respectively, meaning we
        need three extra */
-    const UnsignedShort meshObjects[]{15, 23, 23, 23, 1, 15, 21};
-    const Containers::Pair<UnsignedInt, Int> meshesMaterials[]{
+    const UnsignedShort meshMappingData[]{15, 23, 23, 23, 1, 15, 21};
+    const Containers::Pair<UnsignedInt, Int> meshMaterialFieldData[]{
         {6, 4},
         {1, 0},
         {2, 3},
@@ -358,13 +358,13 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
 
     /* One camera is attached to an object that already has a mesh, meaning we
        need a third extra object */
-    const UnsignedShort cameraObjects[]{22, 1};
-    const UnsignedInt cameras[]{1, 5};
-    SceneData original = Implementation::sceneCombine(SceneObjectType::UnsignedShort, data.originalObjectCount, Containers::arrayView({
-        SceneFieldData{SceneField::Parent, Containers::arrayView(parentObjects), Containers::arrayView(parents)},
-        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshObjects), Containers::StridedArrayView1D<const UnsignedInt>{meshesMaterials, &meshesMaterials[0].first(), Containers::arraySize(meshesMaterials), sizeof(meshesMaterials[0])}},
-        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshObjects), Containers::StridedArrayView1D<const Int>{meshesMaterials, &meshesMaterials[0].second(), Containers::arraySize(meshesMaterials), sizeof(meshesMaterials[0])}},
-        SceneFieldData{SceneField::Camera, Containers::arrayView(cameraObjects), Containers::arrayView(cameras)},
+    const UnsignedShort cameraMappingData[]{22, 1};
+    const UnsignedInt cameraFieldData[]{1, 5};
+    SceneData original = Implementation::sceneCombine(SceneMappingType::UnsignedShort, data.originalObjectCount, Containers::arrayView({
+        SceneFieldData{SceneField::Parent, Containers::arrayView(parentMappingData), Containers::arrayView(parentFieldData)},
+        SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::StridedArrayView1D<const UnsignedInt>{meshMaterialFieldData, &meshMaterialFieldData[0].first(), Containers::arraySize(meshMaterialFieldData), sizeof(meshMaterialFieldData[0])}},
+        SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshMappingData), Containers::StridedArrayView1D<const Int>{meshMaterialFieldData, &meshMaterialFieldData[0].second(), Containers::arraySize(meshMaterialFieldData), sizeof(meshMaterialFieldData[0])}},
+        SceneFieldData{SceneField::Camera, Containers::arrayView(cameraMappingData), Containers::arrayView(cameraFieldData)},
     }));
 
     SceneData scene = Implementation::sceneConvertToSingleFunctionObjects(original, Containers::arrayView({
@@ -379,7 +379,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
 
     /* There should be three more objects, or the original count preserved if
        it's large enough */
-    CORRADE_COMPARE(scene.objectCount(), data.expectedObjectCount);
+    CORRADE_COMPARE(scene.mappingBound(), data.expectedObjectCount);
 
     /* Object 1 should have a new child that has the camera, as it has a mesh */
     CORRADE_COMPARE_AS(scene.childrenFor(1),

--- a/src/Magnum/Trade/Test/SceneToolsTest.cpp
+++ b/src/Magnum/Trade/Test/SceneToolsTest.cpp
@@ -59,9 +59,17 @@ struct {
     const char* name;
     UnsignedLong originalObjectCount;
     UnsignedLong expectedObjectCount;
+    SceneFieldFlags parentFieldFlagsInput;
+    SceneFieldFlags parentFieldFlagsExpected;
 } ConvertToSingleFunctionObjectsData[]{
-    {"original object count smaller than new", 64, 67},
-    {"original object count larger than new", 96, 96}
+    {"original object count smaller than new", 64, 70, {}, {}},
+    {"original object count larger than new", 96, 96, {}, {}},
+    {"parent field with ordered mapping", 64, 70,
+        SceneFieldFlag::OrderedMapping, SceneFieldFlag::OrderedMapping},
+    {"parent field with implicit mapping", 64, 70,
+        /* The mapping is *not* implicit but we're not using the flag for
+           anything so this should work */
+        SceneFieldFlag::ImplicitMapping, SceneFieldFlag::OrderedMapping}
 };
 
 SceneToolsTest::SceneToolsTest() {
@@ -89,8 +97,8 @@ void SceneToolsTest::combine() {
     const UnsignedInt meshMappingData[]{45, 78, 23};
     const UnsignedByte meshFieldData[]{3, 5, 17};
 
-    const UnsignedShort parentMappingData[]{33, 25};
-    const Short parentData[]{-1, 33};
+    const UnsignedShort parentMappingData[]{0, 1};
+    const Short parentData[]{-1, 0};
 
     const UnsignedByte translationMappingData[]{16};
     const Vector2d translationFieldData[]{{1.5, -0.5}};
@@ -100,10 +108,10 @@ void SceneToolsTest::combine() {
 
     SceneData scene = Implementation::sceneCombine(data.objectType, 167, Containers::arrayView({
         SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::arrayView(meshFieldData)},
-        SceneFieldData{SceneField::Parent, Containers::arrayView(parentMappingData), Containers::arrayView(parentData)},
+        SceneFieldData{SceneField::Parent, Containers::arrayView(parentMappingData), Containers::arrayView(parentData), SceneFieldFlag::ImplicitMapping},
         SceneFieldData{SceneField::Translation, Containers::arrayView(translationMappingData), Containers::arrayView(translationFieldData)},
         /* Array field */
-        SceneFieldData{sceneFieldCustom(15), Containers::arrayView(fooMappingData), Containers::StridedArrayView2D<const Int>{fooFieldData, {2, 2}}},
+        SceneFieldData{sceneFieldCustom(15), Containers::arrayView(fooMappingData), Containers::StridedArrayView2D<const Int>{fooFieldData, {2, 2}}, SceneFieldFlag::OrderedMapping},
         /* Empty field */
         SceneFieldData{SceneField::Camera, Containers::ArrayView<const UnsignedByte>{}, Containers::ArrayView<const UnsignedShort>{}}
     }));
@@ -114,6 +122,7 @@ void SceneToolsTest::combine() {
     CORRADE_COMPARE(scene.fieldCount(), 5);
 
     CORRADE_COMPARE(scene.fieldName(0), SceneField::Mesh);
+    CORRADE_COMPARE(scene.fieldFlags(0), SceneFieldFlags{});
     CORRADE_COMPARE(scene.fieldType(0), SceneFieldType::UnsignedByte);
     CORRADE_COMPARE(scene.fieldArraySize(0), 0);
     CORRADE_COMPARE_AS(scene.mappingAsArray(0), Containers::arrayView<UnsignedInt>({
@@ -124,16 +133,18 @@ void SceneToolsTest::combine() {
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(1), SceneField::Parent);
+    CORRADE_COMPARE(scene.fieldFlags(1), SceneFieldFlag::ImplicitMapping);
     CORRADE_COMPARE(scene.fieldType(1), SceneFieldType::Short);
     CORRADE_COMPARE(scene.fieldArraySize(1), 0);
     CORRADE_COMPARE_AS(scene.mappingAsArray(1), Containers::arrayView<UnsignedInt>({
-        33, 25
+        0, 1
     }), TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.field<Short>(1),
         Containers::arrayView(parentData),
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(2), SceneField::Translation);
+    CORRADE_COMPARE(scene.fieldFlags(2), SceneFieldFlags{});
     CORRADE_COMPARE(scene.fieldType(2), SceneFieldType::Vector2d);
     CORRADE_COMPARE(scene.fieldArraySize(2), 0);
     CORRADE_COMPARE_AS(scene.mappingAsArray(2),
@@ -144,6 +155,7 @@ void SceneToolsTest::combine() {
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(3), sceneFieldCustom(15));
+    CORRADE_COMPARE(scene.fieldFlags(3), SceneFieldFlag::OrderedMapping);
     CORRADE_COMPARE(scene.fieldType(3), SceneFieldType::Int);
     CORRADE_COMPARE(scene.fieldArraySize(3), 2);
     CORRADE_COMPARE_AS(scene.mappingAsArray(3),
@@ -159,6 +171,7 @@ void SceneToolsTest::combine() {
         TestSuite::Compare::Container);
 
     CORRADE_COMPARE(scene.fieldName(4), SceneField::Camera);
+    CORRADE_COMPARE(scene.fieldFlags(4), SceneFieldFlags{});
     CORRADE_COMPARE(scene.fieldType(4), SceneFieldType::UnsignedShort);
     CORRADE_COMPARE(scene.fieldSize(4), 0);
     CORRADE_COMPARE(scene.fieldArraySize(4), 0);
@@ -340,12 +353,12 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
     /* Haha now I can use sceneCombine() to conveniently prepare the initial
        state here, without having to mess with an ArrayTuple */
 
-    const UnsignedShort parentMappingData[]{15, 21, 22, 23, 1};
-    const Byte parentFieldData[]{-1, -1, 21, 22, -1};
+    const UnsignedShort parentMappingData[]{2, 15, 21, 22, 23};
+    const Byte parentFieldData[]{-1, -1, -1, 21, 22};
 
     /* Two objects have two and three mesh assignments respectively, meaning we
        need three extra */
-    const UnsignedShort meshMappingData[]{15, 23, 23, 23, 1, 15, 21};
+    const UnsignedShort meshMappingData[]{15, 23, 23, 23, 2, 15, 21};
     const Containers::Pair<UnsignedInt, Int> meshMaterialFieldData[]{
         {6, 4},
         {1, 0},
@@ -357,14 +370,39 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
     };
 
     /* One camera is attached to an object that already has a mesh, meaning we
-       need a third extra object */
-    const UnsignedShort cameraMappingData[]{22, 1};
+       need a fourth extra object */
+    const UnsignedShort cameraMappingData[]{22, 2};
     const UnsignedInt cameraFieldData[]{1, 5};
+
+    /* Lights don't conflict with anything so they *could* retain the
+       ImplicitMapping flag */
+    const UnsignedShort lightMappingData[]{0, 1};
+    const UnsignedByte lightFieldData[]{15, 23};
+
+    /* Object 0 and 1 has a light, 2 a mesh already, meaning we need a fifth,
+       sixth and seventh extra object and we lose the ImplicitMapping flag. */
+    const UnsignedShort fooMappingData[]{0, 1, 2, 3};
+    const Float fooFieldData[]{1.0f, 2.0f, 3.0f, 4.0f};
+
+    /* This field is not among the fields to convert so it should preserve the
+       ImplicitMapping flag */
+    const UnsignedShort foo2MappingData[]{0, 1};
+    const Byte foo2FieldData[]{-5, -7};
+
+    /* This field shares mapping with foo (and thus has the ImplicitMapping
+       flag), but it's not among the fields to convert. Since the mapping gets
+       changed, it should not retain the ImplicitMapping flag. */
+    const Byte foo3FieldData[]{-1, -2, 7, 2};
+
     SceneData original = Implementation::sceneCombine(SceneMappingType::UnsignedShort, data.originalObjectCount, Containers::arrayView({
-        SceneFieldData{SceneField::Parent, Containers::arrayView(parentMappingData), Containers::arrayView(parentFieldData)},
+        SceneFieldData{SceneField::Parent, Containers::arrayView(parentMappingData), Containers::arrayView(parentFieldData), data.parentFieldFlagsInput},
         SceneFieldData{SceneField::Mesh, Containers::arrayView(meshMappingData), Containers::StridedArrayView1D<const UnsignedInt>{meshMaterialFieldData, &meshMaterialFieldData[0].first(), Containers::arraySize(meshMaterialFieldData), sizeof(meshMaterialFieldData[0])}},
         SceneFieldData{SceneField::MeshMaterial, Containers::arrayView(meshMappingData), Containers::StridedArrayView1D<const Int>{meshMaterialFieldData, &meshMaterialFieldData[0].second(), Containers::arraySize(meshMaterialFieldData), sizeof(meshMaterialFieldData[0])}},
         SceneFieldData{SceneField::Camera, Containers::arrayView(cameraMappingData), Containers::arrayView(cameraFieldData)},
+        SceneFieldData{SceneField::Light, Containers::arrayView(lightMappingData), Containers::arrayView(lightFieldData), SceneFieldFlag::ImplicitMapping},
+        SceneFieldData{sceneFieldCustom(15), Containers::arrayView(fooMappingData), Containers::arrayView(fooFieldData), SceneFieldFlag::ImplicitMapping},
+        SceneFieldData{sceneFieldCustom(16),  Containers::arrayView(foo2MappingData), Containers::arrayView(foo2FieldData), SceneFieldFlag::ImplicitMapping},
+        SceneFieldData{sceneFieldCustom(17),  Containers::arrayView(fooMappingData), Containers::arrayView(foo3FieldData), SceneFieldFlag::ImplicitMapping}
     }));
 
     SceneData scene = Implementation::sceneConvertToSingleFunctionObjects(original, Containers::arrayView({
@@ -373,6 +411,12 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
            get automatically updated as they share the same object mapping.
            OTOH including them would break the output. */
         SceneField::Camera,
+        /* A field with implicit mapping that doesn't conflict with anything so
+           it *could* retain the flag */
+        SceneField::Light,
+        /* A field with implicit mapping, which loses the flag because entries
+           get reassigned */
+        sceneFieldCustom(15),
         /* Include also a field that's not present -- it should get skipped */
         SceneField::ImporterState
     }), 63);
@@ -381,14 +425,31 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
        it's large enough */
     CORRADE_COMPARE(scene.mappingBound(), data.expectedObjectCount);
 
-    /* Object 1 should have a new child that has the camera, as it has a mesh */
-    CORRADE_COMPARE_AS(scene.childrenFor(1),
-        Containers::arrayView<UnsignedInt>({66}),
+    /* Object 0 should have new children with "foo", as it has a light */
+    CORRADE_COMPARE_AS(scene.childrenFor(0),
+        Containers::arrayView<UnsignedInt>({67}),
         TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(scene.meshesMaterialsFor(1),
+    CORRADE_COMPARE_AS(scene.lightsFor(0),
+        Containers::arrayView<UnsignedInt>({15}),
+        TestSuite::Compare::Container);
+
+    /* Object 1 should have a new child with "foo", as it has a light */
+    CORRADE_COMPARE_AS(scene.childrenFor(1),
+        Containers::arrayView<UnsignedInt>({68}),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.lightsFor(1),
+        Containers::arrayView<UnsignedInt>({23}),
+        TestSuite::Compare::Container);
+
+    /* Object 2 should have a new child with the camera and "foo", as it has a
+       mesh */
+    CORRADE_COMPARE_AS(scene.childrenFor(2),
+        Containers::arrayView<UnsignedInt>({66, 69}),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.meshesMaterialsFor(2),
         (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({{7, 2}})),
         TestSuite::Compare::Container);
-    CORRADE_COMPARE_AS(scene.camerasFor(1),
+    CORRADE_COMPARE_AS(scene.camerasFor(2),
         Containers::arrayView<UnsignedInt>({}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.camerasFor(66),
@@ -422,36 +483,95 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
         TestSuite::Compare::Container);
 
     /* To be extra sure, verify the actual data. Parents have a few objects
-       added, the rest is the same */
+       added, the rest is the same. Because new objects are added at the end,
+       the ordered flag is preserved if present. */
     CORRADE_COMPARE_AS(scene.parentsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({
+        {2, -1},
         {15, -1},
         {21, -1},
         {22, 21},
         {23, 22},
-        {1, -1},
         {63, 23},
         {64, 23},
         {65, 15},
-        {66, 1}
+        {66, 2},
+        {67, 0},
+        {68, 1},
+        {69, 2},
     })), TestSuite::Compare::Container);
+    CORRADE_COMPARE(scene.fieldFlags(SceneField::Parent), data.parentFieldFlagsExpected);
 
     /* Meshes / materials have certain objects reassigned, field data stay the
-       same */
+       same. There was no flag before so neither is after. */
     CORRADE_COMPARE_AS(scene.meshesMaterialsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Containers::Pair<UnsignedInt, Int>>>({
         {15, {6, 4}},
         {23, {1, 0}},
         {63, {2, 3}},
         {64, {4, 2}},
-        {1, {7, 2}},
+        {2, {7, 2}},
         {65, {3, 1}},
         {21, {5, -1}}
     })), TestSuite::Compare::Container);
+    CORRADE_COMPARE(scene.fieldFlags(SceneField::Mesh), SceneFieldFlags{});
+    CORRADE_COMPARE(scene.fieldFlags(SceneField::MeshMaterial), SceneFieldFlags{});
 
-    /* Cameras have certain objects reassigned, field data stay the same */
+    /* Cameras have certain objects reassigned, field data stay the same. There
+       was no flag before so neither is after. */
     CORRADE_COMPARE_AS(scene.camerasAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, UnsignedInt>>({
         {22, 1},
         {66, 5}
     })), TestSuite::Compare::Container);
+    CORRADE_COMPARE(scene.fieldFlags(SceneField::Camera), SceneFieldFlags{});
+
+    /* Lights stay the same, thus the implicit flag could be preserved. It's
+       not currently, though. */
+    CORRADE_COMPARE_AS(scene.lightsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, UnsignedInt>>({
+        {0, 15},
+        {1, 23}
+    })), TestSuite::Compare::Container);
+    {
+        CORRADE_EXPECT_FAIL("Logic for preserving flags of untouched fields is rather complex and thus not implemented yet.");
+        CORRADE_COMPARE(scene.fieldFlags(SceneField::Light), SceneFieldFlag::ImplicitMapping);
+    } {
+        CORRADE_COMPARE(scene.fieldFlags(SceneField::Light), SceneFieldFlags{});
+    }
+
+    /* A custom field gets the last object reassigned, field data stay the
+       same. The implicit flag gets turned to nothing after that. */
+    CORRADE_COMPARE_AS(scene.mappingAsArray(sceneFieldCustom(15)), (Containers::arrayView<UnsignedInt>({
+        67, 68, 69, 3
+    })), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Float>(sceneFieldCustom(15)),
+        Containers::arrayView(fooFieldData),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE(scene.fieldFlags(sceneFieldCustom(15)), SceneFieldFlags{});
+
+    /* A custom field that is not among fields to convert so it preserves the
+       flag */
+    CORRADE_COMPARE_AS(scene.mappingAsArray(sceneFieldCustom(16)), (Containers::arrayView<UnsignedInt>({
+        0, 1
+    })), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Byte>(sceneFieldCustom(16)),
+        Containers::arrayView(foo2FieldData),
+        TestSuite::Compare::Container);
+    {
+        CORRADE_EXPECT_FAIL("Logic for preserving flags of untouched fields is rather complex and thus not implemented yet.");
+        CORRADE_COMPARE(scene.fieldFlags(sceneFieldCustom(16)), SceneFieldFlag::ImplicitMapping);
+    } {
+        CORRADE_COMPARE(scene.fieldFlags(sceneFieldCustom(16)), SceneFieldFlags{});
+    }
+
+    /* A custom field that is not among fields to convert but it shares the
+       mapping with a field that is and that gets changed. The implicit flag
+       should thus get removed here as well. */
+    CORRADE_COMPARE_AS(scene.mappingAsArray(sceneFieldCustom(17)), (Containers::arrayView<UnsignedInt>({
+        67, 68, 69, 3
+    })), TestSuite::Compare::Container);
+    CORRADE_COMPARE_AS(scene.field<Byte>(sceneFieldCustom(17)),
+        Containers::arrayView(foo3FieldData),
+        TestSuite::Compare::Container);
+    CORRADE_COMPARE(scene.fieldFlags(sceneFieldCustom(17)), SceneFieldFlags{});
+
 }
 
 }}}}

--- a/src/Magnum/Trade/Test/SceneToolsTest.cpp
+++ b/src/Magnum/Trade/Test/SceneToolsTest.cpp
@@ -427,7 +427,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
 
     /* Object 0 should have new children with "foo", as it has a light */
     CORRADE_COMPARE_AS(scene.childrenFor(0),
-        Containers::arrayView<UnsignedInt>({67}),
+        Containers::arrayView<UnsignedLong>({67}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.lightsFor(0),
         Containers::arrayView<UnsignedInt>({15}),
@@ -435,7 +435,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
 
     /* Object 1 should have a new child with "foo", as it has a light */
     CORRADE_COMPARE_AS(scene.childrenFor(1),
-        Containers::arrayView<UnsignedInt>({68}),
+        Containers::arrayView<UnsignedLong>({68}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.lightsFor(1),
         Containers::arrayView<UnsignedInt>({23}),
@@ -444,7 +444,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
     /* Object 2 should have a new child with the camera and "foo", as it has a
        mesh */
     CORRADE_COMPARE_AS(scene.childrenFor(2),
-        Containers::arrayView<UnsignedInt>({66, 69}),
+        Containers::arrayView<UnsignedLong>({66, 69}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.meshesMaterialsFor(2),
         (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({{7, 2}})),
@@ -458,7 +458,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
 
     /* Object 15 should have a new child that has the second mesh */
     CORRADE_COMPARE_AS(scene.childrenFor(15),
-        Containers::arrayView<UnsignedInt>({65}),
+        Containers::arrayView<UnsignedLong>({65}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.meshesMaterialsFor(15),
         (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({{6, 4}})),
@@ -470,7 +470,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
     /* Object 23 should have two new children that have the second and third
        mesh */
     CORRADE_COMPARE_AS(scene.childrenFor(23),
-        Containers::arrayView<UnsignedInt>({63, 64}),
+        Containers::arrayView<UnsignedLong>({63, 64}),
         TestSuite::Compare::Container);
     CORRADE_COMPARE_AS(scene.meshesMaterialsFor(23),
         (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({{1, 0}})),

--- a/src/Magnum/Trade/Test/SceneToolsTest.cpp
+++ b/src/Magnum/Trade/Test/SceneToolsTest.cpp
@@ -90,7 +90,7 @@ void SceneToolsTest::combine() {
     const UnsignedByte meshes[]{3, 5, 17};
 
     const UnsignedShort parentObjects[]{33, 25};
-    const Short parents[]{-1, 0};
+    const Short parents[]{-1, 33};
 
     const UnsignedByte translationObjects[]{16};
     const Vector2d translations[]{{1.5, -0.5}};
@@ -341,7 +341,7 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
        state here, without having to mess with an ArrayTuple */
 
     const UnsignedShort parentObjects[]{15, 21, 22, 23, 1};
-    const Byte parents[]{-1, -1, 1, 2, -1};
+    const Byte parents[]{-1, -1, 21, 22, -1};
 
     /* Two objects have two and three mesh assignments respectively, meaning we
        need three extra */
@@ -426,13 +426,13 @@ void SceneToolsTest::convertToSingleFunctionObjects() {
     CORRADE_COMPARE_AS(scene.parentsAsArray(), (Containers::arrayView<Containers::Pair<UnsignedInt, Int>>({
         {15, -1},
         {21, -1},
-        {22, 1},
-        {23, 2},
+        {22, 21},
+        {23, 22},
         {1, -1},
-        {63, 3},
-        {64, 3},
-        {65, 0},
-        {66, 4}
+        {63, 23},
+        {64, 23},
+        {65, 15},
+        {66, 1}
     })), TestSuite::Compare::Container);
 
     /* Meshes / materials have certain objects reassigned, field data stay the

--- a/src/Magnum/Trade/Trade.h
+++ b/src/Magnum/Trade/Trade.h
@@ -100,7 +100,7 @@ class PbrSpecularGlossinessMaterialData;
 class PhongMaterialData;
 class TextureData;
 
-enum class SceneObjectType: UnsignedByte;
+enum class SceneMappingType: UnsignedByte;
 enum class SceneField: UnsignedInt;
 enum class SceneFieldType: UnsignedShort;
 class SceneFieldData;

--- a/src/Magnum/Trade/Trade.h
+++ b/src/Magnum/Trade/Trade.h
@@ -99,6 +99,11 @@ class PbrMetallicRoughnessMaterialData;
 class PbrSpecularGlossinessMaterialData;
 class PhongMaterialData;
 class TextureData;
+
+enum class SceneObjectType: UnsignedByte;
+enum class SceneField: UnsignedInt;
+enum class SceneFieldType: UnsignedShort;
+class SceneFieldData;
 class SceneData;
 
 template<UnsignedInt> class SkinData;

--- a/src/Magnum/Trade/Trade.h
+++ b/src/Magnum/Trade/Trade.h
@@ -103,6 +103,8 @@ class TextureData;
 enum class SceneMappingType: UnsignedByte;
 enum class SceneField: UnsignedInt;
 enum class SceneFieldType: UnsignedShort;
+enum class SceneFieldFlag: UnsignedByte;
+typedef Containers::EnumSet<SceneFieldFlag> SceneFieldFlags;
 class SceneFieldData;
 class SceneData;
 

--- a/src/Magnum/Trade/Trade.h
+++ b/src/Magnum/Trade/Trade.h
@@ -89,11 +89,11 @@ class MeshData;
 #ifdef MAGNUM_BUILD_DEPRECATED
 class CORRADE_DEPRECATED("use MeshData instead") MeshData2D;
 class CORRADE_DEPRECATED("use MeshData instead") MeshData3D;
+class CORRADE_DEPRECATED("use SceneData instead") MeshObjectData2D;
+class CORRADE_DEPRECATED("use SceneData instead") MeshObjectData3D;
+class CORRADE_DEPRECATED("use SceneData instead") ObjectData2D;
+class CORRADE_DEPRECATED("use SceneData instead") ObjectData3D;
 #endif
-class MeshObjectData2D;
-class MeshObjectData3D;
-class ObjectData2D;
-class ObjectData3D;
 class PbrClearCoatMaterialData;
 class PbrMetallicRoughnessMaterialData;
 class PbrSpecularGlossinessMaterialData;

--- a/src/MagnumPlugins/AnyImageImporter/AnyImageImporter.cpp
+++ b/src/MagnumPlugins/AnyImageImporter/AnyImageImporter.cpp
@@ -280,4 +280,4 @@ Containers::Optional<ImageData3D> AnyImageImporter::doImage3D(const UnsignedInt 
 }}
 
 CORRADE_PLUGIN_REGISTER(AnyImageImporter, Magnum::Trade::AnyImageImporter,
-    "cz.mosra.magnum.Trade.AbstractImporter/0.3.4")
+    "cz.mosra.magnum.Trade.AbstractImporter/0.4")

--- a/src/MagnumPlugins/AnySceneImporter/AnySceneImporter.cpp
+++ b/src/MagnumPlugins/AnySceneImporter/AnySceneImporter.cpp
@@ -38,8 +38,6 @@
 #include "Magnum/Trade/LightData.h"
 #include "Magnum/Trade/MaterialData.h"
 #include "Magnum/Trade/MeshData.h"
-#include "Magnum/Trade/ObjectData2D.h"
-#include "Magnum/Trade/ObjectData3D.h"
 #include "Magnum/Trade/SceneData.h"
 #include "Magnum/Trade/SkinData.h"
 #include "Magnum/Trade/TextureData.h"
@@ -47,9 +45,12 @@
 
 #ifdef MAGNUM_BUILD_DEPRECATED
 #define _MAGNUM_NO_DEPRECATED_MESHDATA /* So it doesn't yell here */
+#define _MAGNUM_NO_DEPRECATED_OBJECTDATA /* So it doesn't yell here */
 
 #include "Magnum/Trade/MeshData2D.h"
 #include "Magnum/Trade/MeshData3D.h"
+#include "Magnum/Trade/ObjectData2D.h"
+#include "Magnum/Trade/ObjectData3D.h"
 #endif
 
 namespace Magnum { namespace Trade {
@@ -174,8 +175,11 @@ Containers::Optional<AnimationData> AnySceneImporter::doAnimation(const Unsigned
 Int AnySceneImporter::doDefaultScene() const { return _in->defaultScene(); }
 
 UnsignedInt AnySceneImporter::doSceneCount() const { return _in->sceneCount(); }
+UnsignedLong AnySceneImporter::doObjectCount() const { return _in->objectCount(); }
 Int AnySceneImporter::doSceneForName(const std::string& name) { return _in->sceneForName(name); }
+Long AnySceneImporter::doObjectForName(const std::string& name) { return _in->objectForName(name); }
 std::string AnySceneImporter::doSceneName(const UnsignedInt id) { return _in->sceneName(id); }
+std::string AnySceneImporter::doObjectName(const UnsignedLong id) { return _in->objectName(id); }
 Containers::Optional<SceneData> AnySceneImporter::doScene(const UnsignedInt id) { return _in->scene(id); }
 
 UnsignedInt AnySceneImporter::doLightCount() const { return _in->lightCount(); }
@@ -188,6 +192,8 @@ Int AnySceneImporter::doCameraForName(const std::string& name) { return _in->cam
 std::string AnySceneImporter::doCameraName(const UnsignedInt id) { return _in->cameraName(id); }
 Containers::Optional<CameraData> AnySceneImporter::doCamera(const UnsignedInt id) { return _in->camera(id); }
 
+#ifdef MAGNUM_BUILD_DEPRECATED
+CORRADE_IGNORE_DEPRECATED_PUSH
 UnsignedInt AnySceneImporter::doObject2DCount() const { return _in->object2DCount(); }
 Int AnySceneImporter::doObject2DForName(const std::string& name) { return _in->object2DForName(name); }
 std::string AnySceneImporter::doObject2DName(const UnsignedInt id) { return _in->object2DName(id); }
@@ -197,6 +203,8 @@ UnsignedInt AnySceneImporter::doObject3DCount() const { return _in->object3DCoun
 Int AnySceneImporter::doObject3DForName(const std::string& name) { return _in->object3DForName(name); }
 std::string AnySceneImporter::doObject3DName(const UnsignedInt id) { return _in->object3DName(id); }
 Containers::Pointer<ObjectData3D> AnySceneImporter::doObject3D(const UnsignedInt id) { return _in->object3D(id); }
+CORRADE_IGNORE_DEPRECATED_POP
+#endif
 
 UnsignedInt AnySceneImporter::doSkin2DCount() const { return _in->skin2DCount(); }
 Int AnySceneImporter::doSkin2DForName(const std::string& name) { return _in->skin2DForName(name); }

--- a/src/MagnumPlugins/AnySceneImporter/AnySceneImporter.cpp
+++ b/src/MagnumPlugins/AnySceneImporter/AnySceneImporter.cpp
@@ -269,4 +269,4 @@ Containers::Optional<ImageData3D> AnySceneImporter::doImage3D(const UnsignedInt 
 }}
 
 CORRADE_PLUGIN_REGISTER(AnySceneImporter, Magnum::Trade::AnySceneImporter,
-    "cz.mosra.magnum.Trade.AbstractImporter/0.3.4")
+    "cz.mosra.magnum.Trade.AbstractImporter/0.4")

--- a/src/MagnumPlugins/AnySceneImporter/AnySceneImporter.h
+++ b/src/MagnumPlugins/AnySceneImporter/AnySceneImporter.h
@@ -167,8 +167,11 @@ class MAGNUM_ANYSCENEIMPORTER_EXPORT AnySceneImporter: public AbstractImporter {
         MAGNUM_ANYSCENEIMPORTER_LOCAL Int doDefaultScene() const override;
 
         MAGNUM_ANYSCENEIMPORTER_LOCAL UnsignedInt doSceneCount() const override;
+        MAGNUM_ANYSCENEIMPORTER_LOCAL UnsignedLong doObjectCount() const override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL Int doSceneForName(const std::string& name) override;
+        MAGNUM_ANYSCENEIMPORTER_LOCAL Long doObjectForName(const std::string& name) override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL std::string doSceneName(UnsignedInt id) override;
+        MAGNUM_ANYSCENEIMPORTER_LOCAL std::string doObjectName(UnsignedLong id) override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL Containers::Optional<SceneData> doScene(UnsignedInt id) override;
 
         MAGNUM_ANYSCENEIMPORTER_LOCAL UnsignedInt doLightCount() const override;
@@ -181,15 +184,21 @@ class MAGNUM_ANYSCENEIMPORTER_EXPORT AnySceneImporter: public AbstractImporter {
         MAGNUM_ANYSCENEIMPORTER_LOCAL std::string doCameraName(UnsignedInt id) override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL Containers::Optional<CameraData> doCamera(UnsignedInt id) override;
 
+        #ifdef MAGNUM_BUILD_DEPRECATED
         MAGNUM_ANYSCENEIMPORTER_LOCAL UnsignedInt doObject2DCount() const override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL Int doObject2DForName(const std::string& name) override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL std::string doObject2DName(UnsignedInt id) override;
+        CORRADE_IGNORE_DEPRECATED_PUSH
         MAGNUM_ANYSCENEIMPORTER_LOCAL Containers::Pointer<ObjectData2D> doObject2D(UnsignedInt id) override;
+        CORRADE_IGNORE_DEPRECATED_POP
 
         MAGNUM_ANYSCENEIMPORTER_LOCAL UnsignedInt doObject3DCount() const override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL Int doObject3DForName(const std::string& name) override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL std::string doObject3DName(UnsignedInt id) override;
+        CORRADE_IGNORE_DEPRECATED_PUSH
         MAGNUM_ANYSCENEIMPORTER_LOCAL Containers::Pointer<ObjectData3D> doObject3D(UnsignedInt id) override;
+        CORRADE_IGNORE_DEPRECATED_POP
+        #endif
 
         MAGNUM_ANYSCENEIMPORTER_LOCAL UnsignedInt doSkin2DCount() const override;
         MAGNUM_ANYSCENEIMPORTER_LOCAL Int doSkin2DForName(const std::string& name) override;

--- a/src/MagnumPlugins/ObjImporter/ObjImporter.cpp
+++ b/src/MagnumPlugins/ObjImporter/ObjImporter.cpp
@@ -487,4 +487,4 @@ Containers::Optional<MeshData> ObjImporter::doMesh(UnsignedInt id, UnsignedInt) 
 }}
 
 CORRADE_PLUGIN_REGISTER(ObjImporter, Magnum::Trade::ObjImporter,
-    "cz.mosra.magnum.Trade.AbstractImporter/0.3.4")
+    "cz.mosra.magnum.Trade.AbstractImporter/0.4")

--- a/src/MagnumPlugins/TgaImporter/TgaImporter.cpp
+++ b/src/MagnumPlugins/TgaImporter/TgaImporter.cpp
@@ -209,4 +209,4 @@ Containers::Optional<ImageData2D> TgaImporter::doImage2D(UnsignedInt, UnsignedIn
 }}
 
 CORRADE_PLUGIN_REGISTER(TgaImporter, Magnum::Trade::TgaImporter,
-    "cz.mosra.magnum.Trade.AbstractImporter/0.3.4")
+    "cz.mosra.magnum.Trade.AbstractImporter/0.4")


### PR DESCRIPTION
Final bit in the series of MeshData / MaterialData / ... reworks that brings pure data-oriented joy to scene hierarchies in a way that should be flexible enough to be fed into / serialized from common ECS frameworks like entt or flecs.

"MVP":

- [x] Base implementation, tests
  - only unique fields
  - field arrays
  - custom fields
  - convenience type-converting functions
  - support for non-owned and offset-only data and `SceneFieldData` having the same layout on 32 and 64 bits (preparing for #427)
- [x] Per-field flags ("object mapping is sorted", "object mapping is ~~trivial~~ implicit", "field is offset-only")
  - [x] allow object mapping to be omitted if implicit
  - [x] "field is trivial", special-casing so one doesn't need to provide `-1` for scenes that contain just root nodes
- [x] OOP-like interface
  - [x] "get me a mesh/light/... for this object", returning an Optional for unique fields and `Array` otherwise (~~or -1 / identity transform for the "usual" properties like parent and transform? how to distinguish objects that are outside of a hierarchy & without transformations then?~~ postponed)
    - [x] that means one additional convenience API for every convenience accessor, ugh -- could these be handled by a single API, for example by one that takes a list of objects for which we want the property? yes, a shared `fooIntoInternal()` helper
    - [x] ~~OTOH we could provide an iterating API where one would have to switch & cast on the type, handle all possible field types and ...~~ ugh, nope, this is not the way
  - [x] ~~"get all fields that this object has", could be useful for debugging~~ slow as hell, users should instead directly ask for meshes/lights/...
  - [x] "get top-level objects", "get children of an object" ... basically goes through the Parents array and picks objects from there, is a O(n^2) operation, better ideas?
    - [x] "get parent of an object", returns `Optional<Int>` used for checking which scenes does an object belong to -- if `-1`, the object is top-level, if `NullOpt` the object does not belong to this scene
  - [x] speed up the lookup using the sorted/trivial per-field flags
- [x] Tighten and clarify naming ~~("object index" vs "object mapping" vs ??, "field" vs "entry of a field", `SceneObjectType` vs `SceneIndexType`, better idea for `objectCount(SceneField)` that describes "how many entries a field has", since one object can have more than one field entry it's not really "object count", entry count?)~~ object mapping and "field"
- [x] document / figure out what actually an "object ID" is, and how it's meant to be worked with when animations / skins reference it (do I go through all scenes to figure out which one it belongs to? what if multiple scenes reference it?), though it was the exact same issue before)
  - it should also be mentioned that a single object ID can reference both a 2D and a 3D object and the two can reference the same thing or not at all, and the ID can be shared among scenes or not (which affects how the output glTF will look like), and IT NEEDS SOME SANITY RULES
- [x] the `*Into()` / `*AsArray()` helpers should probably give out objects as well?
  - so one can loop over them in a single less-verbose expression
  - so the common assertions get done only once
  - allow the object output view be null in `*Into()`
- [x] docs for filling/usage including OOP-like access
- [x] `SceneFieldType::Pointer` and `SceneFieldType::MutablePointer`, with arbitrary `field<T*>()` accepted for those (same as with MaterialData)
- [x] `SceneField::ImporterState` for per-object importer state, of a `Pointer` type -- needed for compat with existing code
- [x] How do we actually export files with multiple scenes? Since each `SceneData` basically references the exact same node hierarchy, with all its data... 
  - it's just a specifics of glTF / COLLADA and not all file formats in general; glTF material variants extension makes it possible to have the same nodes appear different in different scenes, and what we have now is a further generalization of that
  - the glTF exporter will need to take care of this (e.g. by picking node info only from the first scene that references it, ignoring the (potentially conflicting) duplicate info)
- [x] One of the goals for this representation was to be able to efficiently store a state of a particle system (hundreds of thousands of positions + colors...), however with the restrictions that there can be only one instance of a particular field (so I can't have a separate packed 16-bit Translation field just for the particle system), or requiring that if there's a Scaling then all objects that have a Translation need to have a Scaling as well, it's not efficient anymore
  - ~~could the Archetype support mentioned below solve this (with some additional restrictions)?~~
  - ~~or should I just introduce custom fields for such case, missing out on the opportunity to deal with them through the common interfaces?~~
  - or eventually have ~~sub-scene references, where the sub-scene uses a different field set and encoding?~~ scene layers like with materials, where there can be a subrange of fields for each layer, and the fields can repeat?
  - ~~or some "<Whatever> field, variant 2" that allows certain sub-parts of the scene to use custom encoding?~~ that's no different than a sub-scene / sub-layer
  - or eventually lift the restriction of having the same object mapping and reduce just to sorted (so the combined transform etc can still be processed in linear time)
- [x] ~~More systematic way to deal with 64-bit object IDs and references. We need them to store arbitrary object handles, but the convenience APIs all have 32-bit as it's very unlikely that there actually will *ever* be >4G objects.~~ postponed
  - [x] Switching the `fooFor()` to 64-bit probably makes sense tho
  - One possible option would be to introduce some "object ID hash" field that would provide (contiguous?) remapping of the object ID to 32-bit values, and the `Into()` and `AsArray()` accessors would return this remapping instead of the original (and the data provider would be forced to provide such field?). But then again it'd cause issues with for example animation references that would still reference the original 64-bit value, there one would have to look up the hash first...
- [x] ~~change `mappingBound()` to a Range? / rename to `mappingRange()`?~~ postponed

Hooking up into the rest:

- [x] a standalone tool that converts the `SceneData` to have each object just one mesh/light/camera/skin, to support classic workflows and make the backwards-compat wrappers easier to write 
  - will get evenually publicly exposed in the new `SceneTools` library
- [x] Write deprecated backward-compat wrappers for `SceneData::children2D()` / `children3D()`
- [x] Deprecate `object2D()` / `object3D()` in `AbstractImporter`, write backwards-compat functions that extract this out of the new SceneData using the (slow) per-object convenience APIs
  - [x] also handle the expansion of multi-mesh objects using the tool above
- [x] `AbstractImporter::objectForName()` / `objectName()` (drop the 2D/3D distinction), works on objects up to ~~`SceneData::objectCount()`~~ `AbstractImporter::objectCount()`
  - [x] bump the interface string to avoid ABI-break-related crashes
  - [x] ~~huh... but how to distinguish between scenes and have it robust w/o having to retrieve scenedata first? or have `objectForName(scene, name)` and `objectCount(scene)` on the importer directly? ahhhh~~ there's a global object count (which is needed anyway since animations, skins etc reference objects globally also)
  - [x] ~~or drop this and store names in SceneData directly? might be wasteful if the users don't need that, doesn't allow searching... OTOH it'd be cool to have a builtin possibility to put them there so the SceneData can be made self-contained~~ nope, handle externally
- [x] `Trade::AnimationData` need to have a 64-bit object ID now
- [x] `AbstractImporter::sceneFieldName()` / `sceneFieldForName()` for custom fields
- [x] `SceneField::SkinId` needs to be distinguished for 2D and 3D, I suppose? Or have a `is2D()` / `is3D()` getter on the SceneData itself, ~~which looks for transformation fields and then decides? What if neither is available?~~ checked and populated in the constructor, skin fields require a transformation field to disambiguate the dimensionality
- [x] How do we deal with objects that have multiple meshes assigned, how does one understand skins there? is the same skin applied to all meshes? ~~or just to the first and it's expected that extra meshes have extra skins?~~ -- same skin for all meshes
  - [x] Make this field get copied when converting to single-functioning objects for backwards compatibility
- [x] `SceneField::MeshMaterial` needs to be signed because otherwise it's impossible to represent meshes without materials (as it has to have the same object mapping as meshes)
- [x] Adapt AnySceneImporter
- [x] ~~Adapt ObjImporter~~ it doesn't have any scene / material assignment yet, nothing to do
- [x] Adapt TinyGltfImporter
  - [x] ~~Currently it fails if there's no scene that'd list the root nodes, implement a fallback (with a warning) that collects all root nodes instead~~ postponed, needs a BitArray
  - [x] ~~And consequently warn also if there are scenes but also loose nodes not referenced by any of them~~ postponed, needs a BitArray
- [x] Adapt CgltfImporter
  - [x] ~~same handling as TinyGltf for scene-less files~~ postponed
- [x] Adapt AssimpImporter
  - [x] ~~might need the same handling as TinyGltf for scene-less files~~ nope, nodes are there only if a scene is
- [x] Adapt OpenGexImporter
  - [x] ~~might need the same handling as TinyGltf for scene-less files~~ nope, there's just one implicit scene
- [x] Adapt PrimitiveImporter (it has both 2D and 3D scenes!), a nice use case for constexpr SceneData
- [x] Adapt plugins to make use of per-field flags, ideally everything at least Ordered, implicit object mappings omitted
- [x] update docs for all plugins, mention which fields are always present, which not, what types, shared object mapping, ordering/triviality...
- [x] add to `magnum-sceneconverter --info` (listing what fields a scene has and how many objects is for each)
- [x] adapt `DartIntegration`
- [x] adapt the viewer example
- [x] adapt `magnum-player`
  
Followup tasks:
  
- [x] ~~`SceneFieldType::String`, internally represented as begin+size pairs, with the data being taken from the data blob, or as offsets if the field is offset-only; begin+size instead of implicit offset array in orde to allow the same string being shared between multiple fields~~ postponed
- [x] It should assert that all transformations are either 2D or 3D ~~or allow 2D transforms used for 3D and vice versa, like MeshData does for positions~~ no (at least for now), conversion complexity not worth the 0.001% use case
- [x] ~~Support the `Bool` type~~ postponed
- [x] ~~Support storing direct (non-owned) pointers to `MeshData`, `MaterialData` if one so desires (could be useful for the upcoming `SceneTools` library as well)~~ postponed
- [x] ~~Support sparse fields (highest bit of a 32-/64-bit object index used to distinguish "dead" entries), for easier (de)serialization of live systems~~ postponed
- [x] ~~Additional per-field flags ("field is sparse", "field is ordered", ...), flags for describing field data in additon to object data~~ postponed
- [x] ~~`SceneField::Present` / `Belongs` / ... ? which is a bit array and enumerates which objects belong to the scene~~ postponed
- [x] ~~`SceneField::InstanceMesh` to support glTF's [EXT_mesh_gpu_instancing](https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md)~~ postponed
  - [x] ~~`CollisionMesh`?~~ postponed
- [x] ~~Mesh view properties (index/vertex offset and count, instance offset and count), all should share the same object mapping; all should be retrievable using a single convenience API that fills a few separate views~~ currently doable via custom fields, postponed to when importer support is there
  - [x] Provide a corresponding overload to `GL::AbstractShaderProgram::draw()` that takes raw data instead of a ton of `GL::MeshView` references -- c2ecaa6abf641c7cf44668bb46afa53667770b75
    - [x] ~~Adapt the method chaining overload in all builtin shaders for that (make a macro!!)~~ postponed
- [x] ~~Material texture transform + layer properties that get applied on top of the referenced material~~ postponed
- [x] ~~Instead of failing, synthesize parent + transform info in the `AsArray()` helpers if not present -- `-1` / identity for all objects? need to think about how to distinguish transformation-less objects in this case~~ not really possible, transformless objects are common (plus the type distinguishes between 2D and 3D), non-node objects are also a thing now
  - [x] same for (now signed) `MeshMaterial`, all `-1`s
- [x] ~~`transformationObjectsAsArray()` helper that picks object mapping for `Transformation` / TRS fields depending on which of them is available, currently this has to be done by the user and is error-prone~~ solved by the `Into` / `AsArray` helpers returning the object mapping as well
- [x] ~~Real-world test sharing the data with entt/flecs?~~ i don't see why this new way would be worse than the cursed OOP API that was there before
  - [x] ~~`EnttIntegration` using https://github.com/skypjack/entt/wiki/Crash-Course:-entity-component-system#snapshot-complete-vs-continuous ?~~ postponed
  - [x] The `SceneField` probably should be 32-bit to have enough bits for arbitrarily allocated entity IDs (hopefully that's enough and we don't need 64)
  
Open Qs:

- [x] Storing octrees / kD trees -- the `Parent` field currently denotes that an object is a hierarchical node; so any other (custom) field could be assigned to objects to denote those are octree cells; encoding of the octree is up to the user
- [x] ~~Storing child information (inverse of the parent information) -- allows users to pick better representation for given task, `parentsAsArray()` / `childrenAsArray()` then falls back to querying the information from the other field if the primary is not available~~ postponed
- [x] ~~`SceneFieldType::SceneField`? e.g. for a potential accelerating `SceneField::InverseMapping` field that maps object IDs to fields (i.e., is sorted by object ID, or is trivial and sparse ...)~~ can't see why this would be useful anymore
- [x] ~~Think more about `SceneField::Parent`, if it really needs to be self-referencing (what else the object mapping view would be? the exact same view?), and if it could be restricted to transforms only~~ not self-referencing, but the Parent field implies the object is a node
  - [x] ~~rename `Parent` to `ParentNode`? to make room for parent octree cell etc~~ postponed
- [x] ~~Support sparse object IDs (for easier (de)serialization of live systems, again)~~ postponed
- [x] ~~Support more than one array per field (for easy storage of ["archetypes"-like ECS state](https://ajmmertens.medium.com/building-an-ecs-2-archetypes-and-vectorization-fe21690805f9))~~ postponed
