### PR TITLE
GL: new "angle-instanced-attributes-always-draw-instanced" workaround

### DIFF
--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -139,6 +139,11 @@ See also:
 -   A new @cpp "android-generic-hostname-might-be-swiftshader" @ce workaround
     needed for testing against Android Emulator SwiftShader GPU. See
     @ref opengl-workarounds for more information.
+-   A new @cpp "angle-instanced-attributes-always-draw-instanced" @ce
+    workaround for ANGLE's draw validation bug, where it complained about
+    instanced buffers being too small when drawing such mesh as non-instanced.
+    See @ref opengl-workarounds for more information, see also
+    [mosra/magnum#539](https://github.com/mosra/magnum/pull/539).
 
 @subsubsection changelog-latest-new-math Math library
 

--- a/src/Magnum/GL/Implementation/driverSpecific.cpp
+++ b/src/Magnum/GL/Implementation/driverSpecific.cpp
@@ -64,6 +64,18 @@ constexpr Containers::StringView KnownWorkarounds[]{
 "angle-chatty-shader-compiler"_s,
 #endif
 
+#ifdef MAGNUM_TARGET_GLES
+/* ANGLE has a buggy bounds validation when drawing a mesh with instanced
+   attributes added (with divisor set) using non-instanced glDraw*() APIs (in
+   particular, when instance count is 1). This should be allowed according to
+   the GL spec, which describes e.g. glDrawElements() as a special case of
+   the "virtual" glDrawElementsOneInstance(). To work around the validation
+   bug, gl*Draw*Instanced() is used unconditionally for all meshes that have
+   instanced attributes. A test that triggers this issue is in
+   MeshGLTest::drawInstancedAttributeSingleInstance(). */
+"angle-instanced-attributes-always-draw-instanced"_s,
+#endif
+
 #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
 /* Calling glBufferData(), glMapBuffer(), glMapBufferRange() or glUnmapBuffer()
    on ANY buffer when ANY buffer is attached to a currently bound

--- a/src/Magnum/GL/Mesh.cpp
+++ b/src/Magnum/GL/Mesh.cpp
@@ -792,7 +792,13 @@ void Mesh::drawInternal(Int count, Int baseVertex, Int instanceCount, GLintptr i
     (this->*state.bindImplementation)();
 
     /* Non-instanced mesh */
-    if(instanceCount == 1) {
+    if(instanceCount == 1
+        #ifdef MAGNUM_TARGET_GLES
+        /* See the "angle-instanced-attributes-always-draw-instanced"
+           workaround */
+        && !_instanced
+        #endif
+    ) {
         /* Non-indexed mesh */
         if(!_indexBuffer.id()) {
             glDrawArrays(GLenum(_primitive), baseVertex, count);
@@ -1168,6 +1174,19 @@ void Mesh::attributePointerImplementationVAODSAIntelWindows(AttributeLayout&& at
         return attributePointerImplementationVAODSA(std::move(attribute));
 }
 #endif
+#endif
+
+#ifdef MAGNUM_TARGET_GLES
+/* See the "angle-instanced-attributes-always-draw-instanced" workaround for
+   these two */
+void Mesh::attributePointerImplementationDefaultAngleAlwaysInstanced(AttributeLayout&& attribute) {
+    if(attribute.divisor) _instanced = true;
+    return attributePointerImplementationDefault(std::move(attribute));
+}
+void Mesh::attributePointerImplementationVAOAngleAlwaysInstanced(AttributeLayout&& attribute) {
+    if(attribute.divisor) _instanced = true;
+    return attributePointerImplementationVAO(std::move(attribute));
+}
 #endif
 
 void Mesh::vertexAttribPointer(AttributeLayout& attribute) {

--- a/src/Magnum/GL/Mesh.h
+++ b/src/Magnum/GL/Mesh.h
@@ -1278,6 +1278,10 @@ class MAGNUM_GL_EXPORT Mesh: public AbstractObject {
         void MAGNUM_GL_LOCAL attributePointerImplementationVAODSAIntelWindows(AttributeLayout&& attribute);
         #endif
         #endif
+        #ifdef MAGNUM_TARGET_GLES
+        void MAGNUM_GL_LOCAL attributePointerImplementationDefaultAngleAlwaysInstanced(AttributeLayout&& attribute);
+        void MAGNUM_GL_LOCAL attributePointerImplementationVAOAngleAlwaysInstanced(AttributeLayout&& attribute);
+        #endif
         void MAGNUM_GL_LOCAL vertexAttribPointer(AttributeLayout& attribute);
 
         #ifndef MAGNUM_TARGET_GLES
@@ -1358,6 +1362,10 @@ class MAGNUM_GL_EXPORT Mesh: public AbstractObject {
         /* Whether the _attributes storage was constructed (it's not when the
            object is constructed using NoCreate). Also fits in the gap. */
         bool _constructed{};
+        #ifdef MAGNUM_TARGET_GLES
+        /* See the "angle-instanced-attributes-always-draw-instanced" workaround */
+        bool _instanced{};
+        #endif
         Int _count{}, _baseVertex{}, _instanceCount{1};
         #ifndef MAGNUM_TARGET_GLES2
         UnsignedInt _baseInstance{};

--- a/src/Magnum/GL/Test/MeshGLTest.cpp
+++ b/src/Magnum/GL/Test/MeshGLTest.cpp
@@ -993,6 +993,7 @@ FloatShader::FloatShader(const std::string& type, const std::string& conversion)
         "out mediump " + type + " valueInterpolated;\n"
         "void main() {\n"
         "    valueInterpolated = value;\n"
+        "    gl_PointSize = 1.0;\n"
         "    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);\n"
         "}\n");
     frag.addSource(
@@ -1044,6 +1045,7 @@ IntegerShader::IntegerShader(const std::string& type) {
                    "flat out mediump " + type + " valueInterpolated;\n"
                    "void main() {\n"
                    "    valueInterpolated = value;\n"
+                   "    gl_PointSize = 1.0;\n"
                    "    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);\n"
                    "}\n");
     frag.addSource("flat in mediump " + type + " valueInterpolated;\n"
@@ -1078,6 +1080,7 @@ DoubleShader::DoubleShader(const std::string& type, const std::string& outputTyp
         "out " + outputType + " valueInterpolated;\n"
         "void main() {\n"
         "    valueInterpolated = " + conversion + ";\n"
+        "    gl_PointSize = 1.0;\n"
         "    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);\n"
         "}\n");
     frag.addSource("in " + outputType + " valueInterpolated;\n"
@@ -2114,6 +2117,7 @@ MultipleShader::MultipleShader() {
         "out mediump vec4 valueInterpolated;\n"
         "void main() {\n"
         "    valueInterpolated = position + vec4(normal, 0.0) + vec4(textureCoordinates, 0.0, 0.0);\n"
+        "    gl_PointSize = 1.0;\n"
         "    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);\n"
         "}\n");
     frag.addSource(
@@ -3746,6 +3750,7 @@ MultiDrawShader::MultiDrawShader(bool vertexId, bool drawId) {
         "out mediump float valueInterpolated;\n"
         "void main() {\n"
         "    valueInterpolated = value[vertexOrDrawId];\n"
+        "    gl_PointSize = 1.0;\n"
         "    gl_Position = vec4(position, 0.0, 1.0);\n"
         "}\n");
     frag.addSource(
@@ -4563,6 +4568,7 @@ MultiDrawInstancedShader::MultiDrawInstancedShader(bool vertexId, bool drawId
         #else
         "    valueInterpolated = value[vertexOrDrawIdOrInstanceOffset + int(instanceId)];\n"
         #endif
+        "    gl_PointSize = 1.0;\n"
         "    gl_Position = vec4(positionX, positionY, 0.0, 1.0);\n"
         "}\n");
     frag.addSource(

--- a/src/Magnum/GL/Test/MeshGLTest.cpp
+++ b/src/Magnum/GL/Test/MeshGLTest.cpp
@@ -3,6 +3,7 @@
 
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
                 2020, 2021 Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2022 Pablo Escobar <mail@rvrs.in>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -182,6 +183,7 @@ struct MeshGLTest: OpenGLTester {
     void addVertexBufferInstancedDouble();
     #endif
     void resetDivisorAfterInstancedDraw();
+    void drawInstancedAttributeSingleInstance();
 
     void multiDraw();
     void multiDrawSparseArrays();
@@ -670,7 +672,8 @@ MeshGLTest::MeshGLTest() {
               #ifndef MAGNUM_TARGET_GLES
               &MeshGLTest::addVertexBufferInstancedDouble,
               #endif
-              &MeshGLTest::resetDivisorAfterInstancedDraw});
+              &MeshGLTest::resetDivisorAfterInstancedDraw,
+              &MeshGLTest::drawInstancedAttributeSingleInstance});
 
     addInstancedTests({&MeshGLTest::multiDraw,
                        &MeshGLTest::multiDrawSparseArrays,
@@ -3702,6 +3705,66 @@ void MeshGLTest::resetDivisorAfterInstancedDraw() {
 
         CORRADE_COMPARE(Containers::arrayCast<UnsignedByte>(framebuffer.read({{}, Vector2i{1}}, {PixelFormat::RGBA, PixelType::UnsignedByte}).data())[0], 48);
     }
+}
+
+void MeshGLTest::drawInstancedAttributeSingleInstance() {
+    #ifndef MAGNUM_TARGET_GLES
+    if(!Context::current().isExtensionSupported<Extensions::ARB::draw_instanced>())
+        CORRADE_SKIP(Extensions::ARB::draw_instanced::string() << "is not supported.");
+    if(!Context::current().isExtensionSupported<Extensions::ARB::instanced_arrays>())
+        CORRADE_SKIP(Extensions::ARB::instanced_arrays::string() << "is not supported.");
+    #elif defined(MAGNUM_TARGET_GLES2)
+    #ifndef MAGNUM_TARGET_WEBGL
+    if(!Context::current().isExtensionSupported<Extensions::ANGLE::instanced_arrays>() &&
+       !Context::current().isExtensionSupported<Extensions::EXT::instanced_arrays>() &&
+       !Context::current().isExtensionSupported<Extensions::NV::instanced_arrays>())
+        CORRADE_SKIP("Required extension is not supported.");
+    #else
+    if(!Context::current().isExtensionSupported<Extensions::ANGLE::instanced_arrays>())
+        CORRADE_SKIP(Extensions::ANGLE::instanced_arrays::string() << "is not supported.");
+    #endif
+    #endif
+
+    typedef Attribute<0, Float> Attribute;
+
+    const Float data[]{
+        Math::unpack<Float, UnsignedByte>(96)
+    };
+    Buffer buffer;
+    /* The ANGLE validation error can be only reproduced with DynamicDraw used
+       here, not StaticDraw. Interesting. */
+    buffer.setData(data, BufferUsage::DynamicDraw);
+
+    Renderbuffer renderbuffer;
+    renderbuffer.setStorage(
+        #ifndef MAGNUM_TARGET_GLES2
+        RenderbufferFormat::RGBA8,
+        #else
+        RenderbufferFormat::RGBA4,
+        #endif
+        Vector2i(1));
+    Framebuffer framebuffer{{{}, Vector2i(1)}};
+    framebuffer.attachRenderbuffer(Framebuffer::ColorAttachment{0}, renderbuffer)
+               .bind();
+
+    FloatShader shader{"float", "vec4(valueInterpolated, 0.0, 0.0, 0.0)"};
+
+    MAGNUM_VERIFY_NO_GL_ERROR();
+
+    /* Create a mesh with (implicitly) one instance and the buffer added as
+       instanced. Drawing it 16 times should always draw 96 with no error.
+       On ANGLE w/o the "angle-instanced-attributes-always-draw-instanced"
+       workaround this would trigger a validation error where it would complain
+       that the 4-byte buffer is not large enough to draw 16 vertices. */
+    Mesh mesh;
+    mesh.addVertexBufferInstanced(buffer, 1, 0, Attribute{})
+        .setPrimitive(MeshPrimitive::Points)
+        .setCount(16);
+    shader.draw(mesh);
+
+    MAGNUM_VERIFY_NO_GL_ERROR();
+
+    CORRADE_COMPARE(Containers::arrayCast<UnsignedByte>(framebuffer.read({{}, Vector2i{1}}, {PixelFormat::RGBA, PixelType::UnsignedByte}).data())[0], 96);
 }
 
 struct MultiDrawShader: AbstractShaderProgram {


### PR DESCRIPTION
Because the bugs keep piling up faster than I'm able to find solutions, sigh.

The original problem, as reported by @kleisauke: Pressing <kbd>S</kbd> and shooting the first sphere in the [web Bullet example](https://magnum.graphics/showcase/bullet/) gives a `Vertex buffer is not big enough for the draw call.` WebGL error -- an ANGLE-specific bug where instanced attributes don't get bounds-checked properly with non-instanced `glDraw*()`. The workaround is to use `glDraw*Instanced()` unconditionally if instanced attributes are present. 

I'm hesitant to do this unconditionally because who knows what other bugs or perf drops on other implementations / ANGLE backends this would uncover.

The workaround implementation is correct and was verified to work, however I'm stuck on crafting a regression test case to prevent this from resurfacing again in the future. Things left to do:

- [x] fix MeshGLTest to actually produce *something* on ANGLE+D3D, currently it's all zeros (should I set `gl_PointSize`?!)
- [x] the attempt to reproduce this problem in the test didn't really work (not leading to a GL error if workaround is not enabled), fix (was it due to the above issue? but i suppose the validation would still happen there, no?)