### PR TITLE
Platform: add missing modifier and command keys to Sdl2Application

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -83,7 +83,7 @@ Sdl2Application::InputEvent::Modifiers fixedModifiers(Uint16 mod) {
     if(modifiers & Sdl2Application::InputEvent::Modifier::Shift) modifiers |= Sdl2Application::InputEvent::Modifier::Shift;
     if(modifiers & Sdl2Application::InputEvent::Modifier::Ctrl) modifiers |= Sdl2Application::InputEvent::Modifier::Ctrl;
     if(modifiers & Sdl2Application::InputEvent::Modifier::Alt) modifiers |= Sdl2Application::InputEvent::Modifier::Alt;
-    if(modifiers & Sdl2Application::InputEvent::Modifier::Super) modifiers |= Sdl2Application::InputEvent::Modifier::Alt;
+    if(modifiers & Sdl2Application::InputEvent::Modifier::Super) modifiers |= Sdl2Application::InputEvent::Modifier::Super;
     return modifiers;
 }
 

--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -2408,6 +2408,41 @@ class Sdl2Application::KeyEvent: public Sdl2Application::InputEvent {
             Y = SDLK_y,                 /**< Letter Y */
             Z = SDLK_z,                 /**< Letter Z */
 
+            /**
+             * Caps lock
+             * @m_since_latest
+             */
+            CapsLock = SDLK_CAPSLOCK,
+
+            /**
+             * Scroll lock
+             * @m_since_latest
+             */
+            ScrollLock = SDLK_SCROLLLOCK,
+
+            /**
+             * Num lock
+             * @m_since_latest
+             */
+            NumLock = SDLK_NUMLOCKCLEAR,
+            /**
+             * Print screen
+             * @m_since_latest
+             */
+            PrintScreen = SDLK_PRINTSCREEN,
+
+            /**
+             * Pause
+             * @m_since_latest
+             */
+            Pause = SDLK_PAUSE,
+
+            /**
+             * Menu
+             * @m_since_latest
+             */
+            Menu = SDLK_APPLICATION,
+
             NumZero = SDLK_KP_0,            /**< Numpad zero */
             NumOne = SDLK_KP_1,             /**< Numpad one */
             NumTwo = SDLK_KP_2,             /**< Numpad two */


### PR DESCRIPTION
These keys already exist in `GlfwApplication` and `EmscriptenApplication`, enum names are taken from there. Key codes exist as far back as [SDL 2.0](https://github.com/libsdl-org/SDL/blob/release-2.0.0/include/SDL_keycode.h).