### PR TITLE
Fix invalid iterator access in Device.cpp / Instance.cpp

### DIFF
--- a/src/Magnum/Vk/Device.cpp
+++ b/src/Magnum/Vk/Device.cpp
@@ -861,7 +861,7 @@ template<class T> void Device::initializeExtensions(const Containers::ArrayView<
             const auto found = std::lower_bound(knownExtensions.begin(), knownExtensions.end(), extension, [](const Extension& a, const T& b) {
                 return a.string() < static_cast<const Containers::StringView&>(b);
             });
-            if(found->string() != extension) continue;
+            if(found == knownExtensions.end() || found->string() != extension) continue;
             _enabledExtensions.set(found->index(), true);
         }
     }

--- a/src/Magnum/Vk/Instance.cpp
+++ b/src/Magnum/Vk/Instance.cpp
@@ -358,7 +358,7 @@ template<class T> void Instance::initializeExtensions(const Containers::ArrayVie
             const auto found = std::lower_bound(knownExtensions.begin(), knownExtensions.end(), extension, [](const InstanceExtension& a, const T& b) {
                 return a.string() < static_cast<const Containers::StringView&>(b);
             });
-            if(found->string() != extension) continue;
+            if(found == knownExtensions.end() || found->string() != extension) continue;
             _extensionStatus.set(found->index(), true);
         }
     }


### PR DESCRIPTION
Hi @mosra, thanks for the awesome library.

I've been using the Vulkan addons for Magnum and I ran into a crash with address sanitizer enabled on Visual Studio 2022. Pretty simple fix. 