### PR TITLE
GL: add Framebuffer::InvalidationAttachment::DepthStencil

### DIFF
--- a/src/Magnum/GL/Framebuffer.cpp
+++ b/src/Magnum/GL/Framebuffer.cpp
@@ -73,6 +73,9 @@ const Framebuffer::BufferAttachment Framebuffer::BufferAttachment::DepthStencil 
 #if !(defined(MAGNUM_TARGET_WEBGL) && defined(MAGNUM_TARGET_GLES2))
 const Framebuffer::InvalidationAttachment Framebuffer::InvalidationAttachment::Depth = Framebuffer::InvalidationAttachment(GL_DEPTH_ATTACHMENT);
 const Framebuffer::InvalidationAttachment Framebuffer::InvalidationAttachment::Stencil = Framebuffer::InvalidationAttachment(GL_STENCIL_ATTACHMENT);
+#ifndef MAGNUM_TARGET_GLES2
+const Framebuffer::InvalidationAttachment Framebuffer::InvalidationAttachment::DepthStencil = Framebuffer::InvalidationAttachment(GL_DEPTH_STENCIL_ATTACHMENT);
+#endif
 #endif
 
 Int Framebuffer::maxColorAttachments() {

--- a/src/Magnum/GL/Framebuffer.h
+++ b/src/Magnum/GL/Framebuffer.h
@@ -256,6 +256,21 @@ class MAGNUM_GL_EXPORT Framebuffer: public AbstractFramebuffer, public AbstractO
                  */
                 static const InvalidationAttachment Stencil;
 
+                #ifndef MAGNUM_TARGET_GLES2
+                /**
+                 * @brief Invalidate both depth and stencil buffer
+                 * @m_since_latest
+                 *
+                 * @m_keywords{GL_DEPTH_STENCIL_ATTACHMENT}
+                 * @requires_gles30 Combined depth and stencil attachment is
+                 *      not available in OpenGL ES 2.0. Invalidate both
+                 *      @ref InvalidationAttachment::Depth and
+                 *      @ref InvalidationAttachment::Stencil instead.
+                 * @todo Support this in ES2 (invalidate both depth and stencil internally)
+                 */
+                static const InvalidationAttachment DepthStencil;
+                #endif
+
                 /** @brief Invalidate color buffer */
                 constexpr /*implicit*/ InvalidationAttachment(Framebuffer::ColorAttachment attachment): attachment(GLenum(attachment)) {}
 

--- a/src/Magnum/GL/Test/FramebufferGLTest.cpp
+++ b/src/Magnum/GL/Test/FramebufferGLTest.cpp
@@ -126,6 +126,9 @@ struct FramebufferGLTest: OpenGLTester {
     void invalidate();
     #endif
     #ifndef MAGNUM_TARGET_GLES2
+    void invalidateCombinedDepthStencil();
+    #endif
+    #ifndef MAGNUM_TARGET_GLES2
     void invalidateSub();
     #endif
     void read();
@@ -267,6 +270,9 @@ FramebufferGLTest::FramebufferGLTest() {
               #endif
               #if !(defined(MAGNUM_TARGET_GLES2) && defined(MAGNUM_TARGET_WEBGL))
               &FramebufferGLTest::invalidate,
+              #endif
+              #ifndef MAGNUM_TARGET_GLES2
+              &FramebufferGLTest::invalidateCombinedDepthStencil,
               #endif
               #ifndef MAGNUM_TARGET_GLES2
               &FramebufferGLTest::invalidateSub,
@@ -1399,6 +1405,40 @@ void FramebufferGLTest::invalidate() {
 
     framebuffer.invalidate({Framebuffer::InvalidationAttachment::Depth, Framebuffer::ColorAttachment(0)});
 
+    MAGNUM_VERIFY_NO_GL_ERROR();
+
+    #ifndef MAGNUM_TARGET_GLES2
+    /* Invalidating combined bits should work as well even if there's just stencil alone */
+    framebuffer.invalidate({Framebuffer::InvalidationAttachment::DepthStencil});
+                            
+    MAGNUM_VERIFY_NO_GL_ERROR();
+    #endif
+}
+#endif
+
+#ifndef MAGNUM_TARGET_GLES2
+void FramebufferGLTest::invalidateCombinedDepthStencil() {
+    #ifndef MAGNUM_TARGET_GLES
+    if(!Context::current().isExtensionSupported<Extensions::ARB::framebuffer_object>())
+        CORRADE_SKIP(Extensions::ARB::framebuffer_object::string() << "is not supported.");
+    #endif
+
+    Renderbuffer depthStencil;
+    depthStencil.setStorage(RenderbufferFormat::Depth24Stencil8, Vector2i(128));
+
+    Framebuffer framebuffer({{}, Vector2i(128)});
+    framebuffer.attachRenderbuffer(Framebuffer::BufferAttachment::DepthStencil, depthStencil);
+
+    MAGNUM_VERIFY_NO_GL_ERROR();
+
+    framebuffer.invalidate({Framebuffer::InvalidationAttachment::DepthStencil});
+
+    MAGNUM_VERIFY_NO_GL_ERROR();
+
+    /* Invalidating separate bits should work as well */
+    framebuffer.invalidate({Framebuffer::InvalidationAttachment::Depth,
+                            Framebuffer::InvalidationAttachment::Stencil});
+                            
     MAGNUM_VERIFY_NO_GL_ERROR();
 }
 #endif


### PR DESCRIPTION
Small quality-of-life improvement. May not make any real difference in the driver since the [relevant extension](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_discard_framebuffer.txt) mentions that you can invalidate a packed depth-stencil attachment by invalidating *either* of the two, but it's useful for code expressiveness.