### PR TITLE
Include <string> to fix errors in AbstractSceneConverter and Abstract…

### DIFF
--- a/src/Magnum/Trade/AbstractImageConverter.h
+++ b/src/Magnum/Trade/AbstractImageConverter.h
@@ -31,6 +31,8 @@
 
 #include <Corrade/PluginManager/AbstractManagingPlugin.h>
 
+#include <string>
+
 #include "Magnum/Magnum.h"
 #include "Magnum/Trade/Trade.h"
 #include "Magnum/Trade/visibility.h"

--- a/src/Magnum/Trade/AbstractSceneConverter.h
+++ b/src/Magnum/Trade/AbstractSceneConverter.h
@@ -32,6 +32,8 @@
 
 #include <Corrade/PluginManager/AbstractManagingPlugin.h>
 
+#include <string>
+
 #include "Magnum/Magnum.h"
 #include "Magnum/Trade/Trade.h"
 #include "Magnum/Trade/visibility.h"


### PR DESCRIPTION
…ImageConverter when compiling when defined MAGNUM_BUILD_DEPRECATED.