### PR TITLE
Utility: use Corrade String and StringView in ConfigurationValue

### DIFF
--- a/src/Magnum/DebugTools/FrameProfiler.cpp
+++ b/src/Magnum/DebugTools/FrameProfiler.cpp
@@ -682,14 +682,14 @@ namespace Corrade { namespace Utility {
 using namespace Magnum;
 
 #ifdef MAGNUM_TARGET_GL
-std::string ConfigurationValue<DebugTools::FrameProfilerGL::Value>::toString(const DebugTools::FrameProfilerGL::Value value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<DebugTools::FrameProfilerGL::Value>::toString(const DebugTools::FrameProfilerGL::Value value, ConfigurationValueFlags) {
     const UnsignedInt bit = Math::log2(UnsignedShort(value));
     if(1 << bit == UnsignedShort(value))
         return DebugTools::FrameProfilerGLValueNames[bit];
     return "";
 }
 
-DebugTools::FrameProfilerGL::Value ConfigurationValue<DebugTools::FrameProfilerGL::Value>::fromString(const std::string& value, ConfigurationValueFlags) {
+DebugTools::FrameProfilerGL::Value ConfigurationValue<DebugTools::FrameProfilerGL::Value>::fromString(Containers::StringView value, ConfigurationValueFlags) {
     for(std::size_t i = 0; i != Containers::arraySize(DebugTools::FrameProfilerGLValueNames); ++i)
         if(DebugTools::FrameProfilerGLValueNames[i] == value)
             return DebugTools::FrameProfilerGL::Value(1 << i);
@@ -697,7 +697,7 @@ DebugTools::FrameProfilerGL::Value ConfigurationValue<DebugTools::FrameProfilerG
     return DebugTools::FrameProfilerGL::Value{};
 }
 
-std::string ConfigurationValue<DebugTools::FrameProfilerGL::Values>::toString(const DebugTools::FrameProfilerGL::Values value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<DebugTools::FrameProfilerGL::Values>::toString(const DebugTools::FrameProfilerGL::Values value, ConfigurationValueFlags) {
     std::string out;
 
     for(std::size_t i = 0; i != Containers::arraySize(DebugTools::FrameProfilerGLValueNames); ++i) {
@@ -711,8 +711,8 @@ std::string ConfigurationValue<DebugTools::FrameProfilerGL::Values>::toString(co
     return out;
 }
 
-DebugTools::FrameProfilerGL::Values ConfigurationValue<DebugTools::FrameProfilerGL::Values>::fromString(const std::string& value, ConfigurationValueFlags) {
-    const std::vector<std::string> bits = Utility::String::splitWithoutEmptyParts(value);
+DebugTools::FrameProfilerGL::Values ConfigurationValue<DebugTools::FrameProfilerGL::Values>::fromString(Containers::StringView value, ConfigurationValueFlags) {
+    const Containers::Array<Containers::StringView> bits = value.splitWithoutEmptyParts();
 
     DebugTools::FrameProfilerGL::Values values;
     for(const std::string& bit: bits)

--- a/src/Magnum/DebugTools/FrameProfiler.h
+++ b/src/Magnum/DebugTools/FrameProfiler.h
@@ -735,14 +735,14 @@ template<> struct MAGNUM_DEBUGTOOLS_EXPORT ConfigurationValue<Magnum::DebugTools
      *
      * If the value is invalid, returns an empty string.
      */
-    static std::string toString(Magnum::DebugTools::FrameProfilerGL::Value value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::DebugTools::FrameProfilerGL::Value value, ConfigurationValueFlags);
 
     /**
      * @brief Reads enum value as a string
      *
      * If the string is invalid, returns a zero (invalid) value.
      */
-    static Magnum::DebugTools::FrameProfilerGL::Value fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::DebugTools::FrameProfilerGL::Value fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 /**
@@ -758,7 +758,7 @@ template<> struct MAGNUM_DEBUGTOOLS_EXPORT ConfigurationValue<Magnum::DebugTools
      * Writes the enum set as a sequence of flag names separated by spaces. If
      * the value is invalid, returns an empty string.
      */
-    static std::string toString(Magnum::DebugTools::FrameProfilerGL::Values value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::DebugTools::FrameProfilerGL::Values value, ConfigurationValueFlags);
 
     /**
      * @brief Reads enum set value as a string
@@ -766,7 +766,7 @@ template<> struct MAGNUM_DEBUGTOOLS_EXPORT ConfigurationValue<Magnum::DebugTools
      * Assumes the string is a sequence of flag names separated by spaces. If
      * the value is invalid, returns an empty set.
      */
-    static Magnum::DebugTools::FrameProfilerGL::Values fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::DebugTools::FrameProfilerGL::Values fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 #endif
 

--- a/src/Magnum/Math/ConfigurationValue.h
+++ b/src/Magnum/Math/ConfigurationValue.h
@@ -30,7 +30,7 @@
  * @m_since{2019,10}
  */
 
-#include <string>
+#include <Corrade/Containers/String.h>
 #include <Corrade/Utility/ConfigurationValue.h>
 
 #include "Magnum/Math/Angle.h"
@@ -57,12 +57,12 @@ template<class T> struct ConfigurationValue<Magnum::Math::Deg<T>> {
     ConfigurationValue() = delete;
 
     /** @brief Writes degrees as a number */
-    static std::string toString(const Magnum::Math::Deg<T>& value, ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::Deg<T>& value, ConfigurationValueFlags flags) {
         return ConfigurationValue<T>::toString(T(value), flags);
     }
 
     /** @brief Reads degrees as a number */
-    static Magnum::Math::Deg<T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::Deg<T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         return Magnum::Math::Deg<T>(ConfigurationValue<T>::fromString(stringValue, flags));
     }
 };
@@ -72,12 +72,12 @@ template<class T> struct ConfigurationValue<Magnum::Math::Rad<T>> {
     ConfigurationValue() = delete;
 
     /** @brief Writes degrees as a number */
-    static std::string toString(const Magnum::Math::Rad<T>& value, ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::Rad<T>& value, ConfigurationValueFlags flags) {
         return ConfigurationValue<T>::toString(T(value), flags);
     }
 
     /** @brief Reads degrees as a number */
-    static Magnum::Math::Rad<T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::Rad<T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         return Magnum::Math::Rad<T>(ConfigurationValue<T>::fromString(stringValue, flags));
     }
 };
@@ -87,33 +87,34 @@ template<std::size_t size, class T> struct ConfigurationValue<Magnum::Math::Vect
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::Vector<size, T>& value, ConfigurationValueFlags flags) {
-        std::string output;
+    static Containers::String toString(const Magnum::Math::Vector<size, T>& value, ConfigurationValueFlags flags) {
+        Containers::String output;
 
         for(std::size_t i = 0; i != size; ++i) {
-            if(!output.empty()) output += ' ';
-            output += ConfigurationValue<T>::toString(value[i], flags);
+            if(!output.isEmpty()) output = output + " ";
+            output = output + ConfigurationValue<T>::toString(value[i], flags);
         }
 
         return output;
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::Vector<size, T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::Vector<size, T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         Magnum::Math::Vector<size, T> result;
 
-        std::size_t oldpos = 0, pos = std::string::npos, i = 0;
+        Containers::StringView next, cursor = stringValue;
+        std::size_t i = 0;
         do {
-            pos = stringValue.find(' ', oldpos);
-            std::string part = stringValue.substr(oldpos, pos-oldpos);
+            next = cursor.find(" ");
+            Containers::StringView part = cursor.exceptSuffix(next);
 
-            if(!part.empty()) {
+            if(!part.isEmpty()) {
                 result[i] = ConfigurationValue<T>::fromString(part, flags);
                 ++i;
             }
 
-            oldpos = pos+1;
-        } while(pos != std::string::npos && i != size);
+            cursor = cursor.exceptPrefix(next);
+        } while(cursor);
 
         return result;
     }
@@ -158,13 +159,13 @@ template<std::size_t cols, std::size_t rows, class T> struct ConfigurationValue<
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::RectangularMatrix<cols, rows, T>& value, ConfigurationValueFlags flags) {
-        std::string output;
+    static Containers::String toString(const Magnum::Math::RectangularMatrix<cols, rows, T>& value, ConfigurationValueFlags flags) {
+        Containers::String output;
 
         for(std::size_t row = 0; row != rows; ++row) {
             for(std::size_t col = 0; col != cols; ++col) {
-                if(!output.empty()) output += ' ';
-                output += ConfigurationValue<T>::toString(value[col][row], flags);
+                if(!output.isEmpty()) output = output + " ";
+                output = output + ConfigurationValue<T>::toString(value[col][row], flags);
             }
         }
 
@@ -172,21 +173,22 @@ template<std::size_t cols, std::size_t rows, class T> struct ConfigurationValue<
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::RectangularMatrix<cols, rows, T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::RectangularMatrix<cols, rows, T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         Magnum::Math::RectangularMatrix<cols, rows, T> result;
 
-        std::size_t oldpos = 0, pos = std::string::npos, i = 0;
+        Containers::StringView next, cursor = stringValue;
+        std::size_t i = 0;
         do {
-            pos = stringValue.find(' ', oldpos);
-            std::string part = stringValue.substr(oldpos, pos-oldpos);
+            next = cursor.find(" ");
+            Containers::StringView part = cursor.exceptSuffix(next);
 
-            if(!part.empty()) {
+            if(!part.isEmpty()) {
                 result[i%cols][i/cols] = ConfigurationValue<T>::fromString(part, flags);
                 ++i;
             }
 
-            oldpos = pos+1;
-        } while(pos != std::string::npos && i != cols*rows);
+            cursor = cursor.exceptPrefix(next);
+        } while(cursor);
 
         return result;
     }
@@ -234,13 +236,13 @@ template<Magnum::UnsignedInt dimensions, class T> struct ConfigurationValue<Magn
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::Range<dimensions, T>& value, const ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::Range<dimensions, T>& value, const ConfigurationValueFlags flags) {
         return ConfigurationValue<Magnum::Math::Vector<dimensions*2, T>>::toString(
             reinterpret_cast<const Magnum::Math::Vector<dimensions*2, T>&>(value), flags);
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::Range<dimensions, T> fromString(const std::string& stringValue, const ConfigurationValueFlags flags) {
+    static Magnum::Math::Range<dimensions, T> fromString(Containers::StringView stringValue, const ConfigurationValueFlags flags) {
         const auto vec = ConfigurationValue<Magnum::Math::Vector<dimensions*2, T>>::fromString(stringValue, flags);
         return *reinterpret_cast<const Magnum::Math::Range<dimensions, T>*>(vec.data());
     }
@@ -267,12 +269,12 @@ template<class T> struct ConfigurationValue<Magnum::Math::Complex<T>> {
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::Complex<T>& value, ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::Complex<T>& value, ConfigurationValueFlags flags) {
         return ConfigurationValue<Magnum::Math::Vector<2, T>>::toString(reinterpret_cast<const Magnum::Math::Vector<2, T>&>(value), flags);
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::Complex<T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::Complex<T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         const Magnum::Math::Vector<2, T> value = ConfigurationValue<Magnum::Math::Vector<2, T>>::fromString(stringValue, flags);
         return reinterpret_cast<const Magnum::Math::Complex<T>&>(value);
     }
@@ -283,12 +285,12 @@ template<class T> struct ConfigurationValue<Magnum::Math::DualComplex<T>> {
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::DualComplex<T>& value, ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::DualComplex<T>& value, ConfigurationValueFlags flags) {
         return ConfigurationValue<Magnum::Math::Vector<4, T>>::toString(reinterpret_cast<const Magnum::Math::Vector<4, T>&>(value), flags);
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::DualComplex<T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::DualComplex<T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         const Magnum::Math::Vector<4, T> value = ConfigurationValue<Magnum::Math::Vector<4, T>>::fromString(stringValue, flags);
         return reinterpret_cast<const Magnum::Math::DualComplex<T>&>(value);
     }
@@ -302,12 +304,12 @@ template<class T> struct ConfigurationValue<Magnum::Math::Quaternion<T>> {
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::Quaternion<T>& value, ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::Quaternion<T>& value, ConfigurationValueFlags flags) {
         return ConfigurationValue<Magnum::Math::Vector<4, T>>::toString(reinterpret_cast<const Magnum::Math::Vector<4, T>&>(value), flags);
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::Quaternion<T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::Quaternion<T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         const Magnum::Math::Vector<4, T> value = ConfigurationValue<Magnum::Math::Vector<4, T>>::fromString(stringValue, flags);
         return reinterpret_cast<const Magnum::Math::Quaternion<T>&>(value);
     }
@@ -321,12 +323,12 @@ template<class T> struct ConfigurationValue<Magnum::Math::DualQuaternion<T>> {
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::DualQuaternion<T>& value, ConfigurationValueFlags flags) {
+    static Containers::String toString(const Magnum::Math::DualQuaternion<T>& value, ConfigurationValueFlags flags) {
         return ConfigurationValue<Magnum::Math::Vector<8, T>>::toString(reinterpret_cast<const Magnum::Math::Vector<8, T>&>(value), flags);
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::DualQuaternion<T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::DualQuaternion<T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         const Magnum::Math::Vector<8, T> value = ConfigurationValue<Magnum::Math::Vector<8, T>>::fromString(stringValue, flags);
         return reinterpret_cast<const Magnum::Math::DualQuaternion<T>&>(value);
     }
@@ -343,13 +345,13 @@ template<Magnum::UnsignedInt order, Magnum::UnsignedInt dimensions, class T> str
     ConfigurationValue() = delete;
 
     /** @brief Writes elements separated with spaces */
-    static std::string toString(const Magnum::Math::Bezier<order, dimensions, T>& value, ConfigurationValueFlags flags) {
-        std::string output;
+    static Containers::String toString(const Magnum::Math::Bezier<order, dimensions, T>& value, ConfigurationValueFlags flags) {
+        Containers::String output;
 
         for(std::size_t o = 0; o != order + 1; ++o) {
             for(std::size_t i = 0; i != dimensions; ++i) {
-                if(!output.empty()) output += ' ';
-                output += ConfigurationValue<T>::toString(value[o][i], flags);
+                if(!output.isEmpty()) output = output + " ";
+                output = output + ConfigurationValue<T>::toString(value[o][i], flags);
             }
         }
 
@@ -357,21 +359,22 @@ template<Magnum::UnsignedInt order, Magnum::UnsignedInt dimensions, class T> str
     }
 
     /** @brief Reads elements separated with whitespace */
-    static Magnum::Math::Bezier<order, dimensions, T> fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Magnum::Math::Bezier<order, dimensions, T> fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         Magnum::Math::Bezier<order, dimensions, T> result;
 
-        std::size_t oldpos = 0, pos = std::string::npos, i = 0;
+        Containers::StringView next, cursor = stringValue;
+        std::size_t i = 0;
         do {
-            pos = stringValue.find(' ', oldpos);
-            std::string part = stringValue.substr(oldpos, pos-oldpos);
+            next = cursor.find(" ");
+            Containers::StringView part = cursor.exceptSuffix(next);
 
-            if(!part.empty()) {
+            if(!part.isEmpty()) {
                 result[i/dimensions][i%dimensions] = ConfigurationValue<T>::fromString(part, flags);
                 ++i;
             }
 
-            oldpos = pos+1;
-        } while(pos != std::string::npos);
+            cursor = cursor.exceptPrefix(next);
+        } while(cursor);
 
         return result;
     }

--- a/src/Magnum/Mesh.cpp
+++ b/src/Magnum/Mesh.cpp
@@ -25,7 +25,7 @@
 
 #include "Mesh.h"
 
-#include <string>
+#include <Corrade/Containers/String.h>
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>
@@ -105,28 +105,28 @@ UnsignedInt meshIndexTypeSize(const MeshIndexType type) {
 
 namespace Corrade { namespace Utility {
 
-std::string ConfigurationValue<Magnum::MeshPrimitive>::toString(Magnum::MeshPrimitive value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Magnum::MeshPrimitive>::toString(Magnum::MeshPrimitive value, ConfigurationValueFlags) {
     if(Magnum::UnsignedInt(value) - 1 < Containers::arraySize(Magnum::MeshPrimitiveNames))
         return Magnum::MeshPrimitiveNames[Magnum::UnsignedInt(value) - 1];
 
     return {};
 }
 
-Magnum::MeshPrimitive ConfigurationValue<Magnum::MeshPrimitive>::fromString(const std::string& stringValue, ConfigurationValueFlags) {
+Magnum::MeshPrimitive ConfigurationValue<Magnum::MeshPrimitive>::fromString(Containers::StringView stringValue, ConfigurationValueFlags) {
     for(std::size_t i = 0; i != Containers::arraySize(Magnum::MeshPrimitiveNames); ++i)
         if(stringValue == Magnum::MeshPrimitiveNames[i]) return Magnum::MeshPrimitive(i + 1);
 
     return {};
 }
 
-std::string ConfigurationValue<Magnum::MeshIndexType>::toString(Magnum::MeshIndexType value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Magnum::MeshIndexType>::toString(Magnum::MeshIndexType value, ConfigurationValueFlags) {
     if(Magnum::UnsignedInt(value) - 1 < Containers::arraySize(Magnum::MeshIndexTypeNames))
         return Magnum::MeshIndexTypeNames[Magnum::UnsignedInt(value) - 1];
 
     return {};
 }
 
-Magnum::MeshIndexType ConfigurationValue<Magnum::MeshIndexType>::fromString(const std::string& stringValue, ConfigurationValueFlags) {
+Magnum::MeshIndexType ConfigurationValue<Magnum::MeshIndexType>::fromString(Containers::StringView stringValue, ConfigurationValueFlags) {
     for(std::size_t i = 0; i != Containers::arraySize(Magnum::MeshIndexTypeNames); ++i)
         if(stringValue == Magnum::MeshIndexTypeNames[i]) return Magnum::MeshIndexType(i + 1);
 

--- a/src/Magnum/Mesh.h
+++ b/src/Magnum/Mesh.h
@@ -30,7 +30,6 @@
  */
 
 #include <Corrade/Utility/Assert.h>
-#include <Corrade/Utility/StlForwardString.h>
 
 #include "Magnum/Magnum.h"
 #include "Magnum/visibility.h"
@@ -365,14 +364,14 @@ template<> struct MAGNUM_EXPORT ConfigurationValue<Magnum::MeshPrimitive> {
      *
      * If the value is invalid, returns empty string.
      */
-    static std::string toString(Magnum::MeshPrimitive value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::MeshPrimitive value, ConfigurationValueFlags);
 
     /**
      * @brief Reads enum value as string
      *
      * If the value is invalid, returns a zero (invalid) primitive.
      */
-    static Magnum::MeshPrimitive fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::MeshPrimitive fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 /** @configurationvalue{Magnum::MeshIndexType} */
@@ -384,14 +383,14 @@ template<> struct MAGNUM_EXPORT ConfigurationValue<Magnum::MeshIndexType> {
      *
      * If the value is invalid, returns empty string.
      */
-    static std::string toString(Magnum::MeshIndexType value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::MeshIndexType value, ConfigurationValueFlags);
 
     /**
      * @brief Read enum value as string
      *
      * If the value is invalid, returns a zero (invalid) type.
      */
-    static Magnum::MeshIndexType fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::MeshIndexType fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 }}

--- a/src/Magnum/PixelFormat.cpp
+++ b/src/Magnum/PixelFormat.cpp
@@ -25,7 +25,7 @@
 
 #include "PixelFormat.h"
 
-#include <string>
+#include <Corrade/Containers/String.h>
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>
@@ -556,14 +556,14 @@ Debug& operator<<(Debug& debug, const CompressedPixelFormat value) {
 
 namespace Corrade { namespace Utility {
 
-std::string ConfigurationValue<Magnum::PixelFormat>::toString(Magnum::PixelFormat value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Magnum::PixelFormat>::toString(Magnum::PixelFormat value, ConfigurationValueFlags) {
     if(Magnum::UnsignedInt(value) - 1 < Containers::arraySize(Magnum::PixelFormatNames))
         return Magnum::PixelFormatNames[Magnum::UnsignedInt(value) - 1];
 
     return {};
 }
 
-Magnum::PixelFormat ConfigurationValue<Magnum::PixelFormat>::fromString(const std::string& stringValue, ConfigurationValueFlags) {
+Magnum::PixelFormat ConfigurationValue<Magnum::PixelFormat>::fromString(Containers::StringView stringValue, ConfigurationValueFlags) {
     /** @todo This is extremely slow with >100 values. Do a binary search on a
         sorted index list instead (extracted into a common utility) */
     for(std::size_t i = 0; i != Containers::arraySize(Magnum::PixelFormatNames); ++i)
@@ -572,14 +572,14 @@ Magnum::PixelFormat ConfigurationValue<Magnum::PixelFormat>::fromString(const st
     return {};
 }
 
-std::string ConfigurationValue<Magnum::CompressedPixelFormat>::toString(Magnum::CompressedPixelFormat value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Magnum::CompressedPixelFormat>::toString(Magnum::CompressedPixelFormat value, ConfigurationValueFlags) {
     if(Magnum::UnsignedInt(value) - 1 < Containers::arraySize(Magnum::CompressedPixelFormatNames))
         return Magnum::CompressedPixelFormatNames[Magnum::UnsignedInt(value) - 1];
 
     return {};
 }
 
-Magnum::CompressedPixelFormat ConfigurationValue<Magnum::CompressedPixelFormat>::fromString(const std::string& stringValue, ConfigurationValueFlags) {
+Magnum::CompressedPixelFormat ConfigurationValue<Magnum::CompressedPixelFormat>::fromString(Containers::StringView stringValue, ConfigurationValueFlags) {
     /** @todo This is extremely slow with >100 values. Do a binary search on a
         sorted index list instead (extracted into a common utility) */
     for(std::size_t i = 0; i != Containers::arraySize(Magnum::CompressedPixelFormatNames); ++i)

--- a/src/Magnum/PixelFormat.h
+++ b/src/Magnum/PixelFormat.h
@@ -30,7 +30,6 @@
  */
 
 #include <Corrade/Utility/Assert.h>
-#include <Corrade/Utility/StlForwardString.h>
 
 #include "Magnum/Magnum.h"
 #include "Magnum/visibility.h"
@@ -2491,14 +2490,14 @@ template<> struct MAGNUM_EXPORT ConfigurationValue<Magnum::PixelFormat> {
      *
      * If the value is invalid, returns empty string.
      */
-    static std::string toString(Magnum::PixelFormat value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::PixelFormat value, ConfigurationValueFlags);
 
     /**
      * @brief Reads enum value as string
      *
      * If the value is invalid, returns a zero (invalid) format.
      */
-    static Magnum::PixelFormat fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::PixelFormat fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 /**
@@ -2513,14 +2512,14 @@ template<> struct MAGNUM_EXPORT ConfigurationValue<Magnum::CompressedPixelFormat
      *
      * If the value is invalid, returns empty string.
      */
-    static std::string toString(Magnum::CompressedPixelFormat value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::CompressedPixelFormat value, ConfigurationValueFlags);
 
     /**
      * @brief Read enum value as string
      *
      * If the value is invalid, returns a zero (invalid) format.
      */
-    static Magnum::CompressedPixelFormat fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::CompressedPixelFormat fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 }}

--- a/src/Magnum/VertexFormat.cpp
+++ b/src/Magnum/VertexFormat.cpp
@@ -25,7 +25,7 @@
 
 #include "VertexFormat.h"
 
-#include <string>
+#include <Corrade/Containers/String.h>
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>
@@ -930,14 +930,14 @@ Debug& operator<<(Debug& debug, const VertexFormat value) {
 
 namespace Corrade { namespace Utility {
 
-std::string ConfigurationValue<Magnum::VertexFormat>::toString(Magnum::VertexFormat value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Magnum::VertexFormat>::toString(Magnum::VertexFormat value, ConfigurationValueFlags) {
     if(Magnum::UnsignedInt(value) - 1 < Containers::arraySize(Magnum::VertexFormatNames))
         return Magnum::VertexFormatNames[Magnum::UnsignedInt(value) - 1];
 
     return {};
 }
 
-Magnum::VertexFormat ConfigurationValue<Magnum::VertexFormat>::fromString(const std::string& stringValue, ConfigurationValueFlags) {
+Magnum::VertexFormat ConfigurationValue<Magnum::VertexFormat>::fromString(Containers::StringView stringValue, ConfigurationValueFlags) {
     for(std::size_t i = 0; i != Containers::arraySize(Magnum::VertexFormatNames); ++i)
         if(stringValue == Magnum::VertexFormatNames[i]) return Magnum::VertexFormat(i + 1);
 

--- a/src/Magnum/VertexFormat.h
+++ b/src/Magnum/VertexFormat.h
@@ -30,7 +30,6 @@
  */
 
 #include <Corrade/Utility/Assert.h>
-#include <Corrade/Utility/StlForwardString.h>
 
 #include "Magnum/Magnum.h"
 #include "Magnum/visibility.h"
@@ -1473,14 +1472,14 @@ template<> struct MAGNUM_EXPORT ConfigurationValue<Magnum::VertexFormat> {
      *
      * If the value is invalid, returns empty string.
      */
-    static std::string toString(Magnum::VertexFormat value, ConfigurationValueFlags);
+    static Containers::String toString(Magnum::VertexFormat value, ConfigurationValueFlags);
 
     /**
      * @brief Read enum value as string
      *
      * If the value is invalid, returns a zero (invalid) format.
      */
-    static Magnum::VertexFormat fromString(const std::string& stringValue, ConfigurationValueFlags);
+    static Magnum::VertexFormat fromString(Containers::StringView stringValue, ConfigurationValueFlags);
 };
 
 }}


### PR DESCRIPTION
Hello !
We're trying to optimize our compile times and I noticed that StlForwardString.h is actually very heavy on MSVC because it just directly includes <string>, so I thought let's go and try to clean this up.
Let me know if I'm going at this correctly 😅

Associated Corrade PR: https://github.com/mosra/corrade/pull/146