### PR TITLE
GL: Switch TransformFeedback attachBuffers to use ArrayView

### DIFF
--- a/doc/snippets/MagnumGL.cpp
+++ b/doc/snippets/MagnumGL.cpp
@@ -27,6 +27,7 @@
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/Iterable.h>
 #include <Corrade/Containers/Reference.h>
+#include <Corrade/Containers/Triple.h>
 #include <Corrade/TestSuite/Tester.h>
 
 #include "Magnum/Image.h"
@@ -195,9 +196,10 @@ MyShader& setTransformFeedback(GL::TransformFeedback& feedback, Int totalCount,
     GL::Buffer& positions, GLintptr positionsOffset, GL::Buffer& data,
     GLintptr dataOffset)
 {
+    using BufferOffset = Containers::Triple<GL::Buffer*, GLintptr, GLsizeiptr>;
     feedback.attachBuffers(0, {
-        std::make_tuple(&positions, positionsOffset, totalCount*sizeof(Vector3)),
-        std::make_tuple(&data, dataOffset, totalCount*sizeof(Vector2ui))
+        BufferOffset{&positions, positionsOffset, (GLsizeiptr)totalCount*sizeof(Vector3)},
+        BufferOffset{&data, dataOffset, (GLsizeiptr)totalCount*sizeof(Vector2ui)}
     });
     return *this;
 }

--- a/doc/snippets/MagnumGL.cpp
+++ b/doc/snippets/MagnumGL.cpp
@@ -196,10 +196,9 @@ MyShader& setTransformFeedback(GL::TransformFeedback& feedback, Int totalCount,
     GL::Buffer& positions, GLintptr positionsOffset, GL::Buffer& data,
     GLintptr dataOffset)
 {
-    using BufferOffset = Containers::Triple<GL::Buffer*, GLintptr, GLsizeiptr>;
     feedback.attachBuffers(0, {
-        BufferOffset{&positions, positionsOffset, (GLsizeiptr)totalCount*sizeof(Vector3)},
-        BufferOffset{&data, dataOffset, (GLsizeiptr)totalCount*sizeof(Vector2ui)}
+        {&positions, positionsOffset, GLsizeiptr(totalCount*sizeof(Vector3))},
+        {&data, dataOffset, GLsizeiptr(totalCount*sizeof(Vector2ui))}
     });
     return *this;
 }

--- a/src/Magnum/GL/Buffer.cpp
+++ b/src/Magnum/GL/Buffer.cpp
@@ -151,13 +151,11 @@ void Buffer::unbind(const Target target, const UnsignedInt firstIndex, const std
     Context::current().state().buffer.bindBasesImplementation(target, firstIndex, {nullptr, count});
 }
 
-/** @todoc const std::initializer_list makes Doxygen grumpy */
-void Buffer::bind(const Target target, const UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
+void Buffer::bind(const Target target, const UnsignedInt firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     Context::current().state().buffer.bindRangesImplementation(target, firstIndex, {buffers.begin(), buffers.size()});
 }
 
-/** @todoc const std::initializer_list makes Doxygen grumpy */
-void Buffer::bind(const Target target, const UnsignedInt firstIndex, std::initializer_list<Buffer*> buffers) {
+void Buffer::bind(const Target target, const UnsignedInt firstIndex, Containers::ArrayView<Buffer* const> buffers) {
     Context::current().state().buffer.bindBasesImplementation(target, firstIndex, {buffers.begin(), buffers.size()});
 }
 
@@ -406,7 +404,6 @@ void Buffer::bindImplementationMulti(const Target target, const GLuint firstInde
 }
 #endif
 
-/** @todoc const Containers::ArrayView makes Doxygen grumpy */
 void Buffer::bindImplementationFallback(const Target target, const GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     for(std::size_t i = 0; i != buffers.size(); ++i) {
         if(buffers && std::get<0>(buffers[i]))
@@ -416,7 +413,6 @@ void Buffer::bindImplementationFallback(const Target target, const GLuint firstI
 }
 
 #ifndef MAGNUM_TARGET_GLES
-/** @todoc const Containers::ArrayView makes Doxygen grumpy */
 void Buffer::bindImplementationMulti(const Target target, const GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     /** @todo use ArrayTuple */
     Containers::Array<GLuint> ids{buffers ? buffers.size() : 0};

--- a/src/Magnum/GL/Buffer.cpp
+++ b/src/Magnum/GL/Buffer.cpp
@@ -26,9 +26,6 @@
 
 #include "Buffer.h"
 
-#ifdef MAGNUM_BUILD_DEPRECATED
-#include <tuple>
-#endif
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Triple.h>
 #ifndef MAGNUM_TARGET_WEBGL
@@ -161,17 +158,6 @@ void Buffer::bind(const Target target, const UnsignedInt firstIndex, Containers:
 void Buffer::bind(const Target target, const UnsignedInt firstIndex, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     Context::current().state().buffer.bindRangesImplementation(target, firstIndex, {buffers.begin(), buffers.size()});
 }
-
-#ifdef MAGNUM_BUILD_DEPRECATED
-void Buffer::bind(const Target target, const UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
-    Containers::Array<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> copy{NoInit, buffers.size()};
-    for(std::size_t i = 0, max = buffers.size(); i != max; ++i) {
-        const auto& t = *(buffers.begin() + i);
-        copy[i] = {std::get<0>(t), std::get<1>(t), std::get<2>(t)};
-    }
-    bind(target, firstIndex, copy);
-}
-#endif
 
 void Buffer::bind(const Target target, const UnsignedInt firstIndex, Containers::ArrayView<Buffer* const> buffers) {
     Context::current().state().buffer.bindBasesImplementation(target, firstIndex, {buffers.begin(), buffers.size()});

--- a/src/Magnum/GL/Buffer.h
+++ b/src/Magnum/GL/Buffer.h
@@ -44,8 +44,6 @@
 /* For label() / setLabel(), which used to be a std::string. Not ideal for the
    return type, but at least something. */
 #include <Corrade/Containers/StringStl.h>
-/* For deprecated bind(..., std::initializer_list<std::tuple>) */
-#include <Corrade/Utility/StlForwardTuple.h>
 #endif
 
 namespace Magnum { namespace GL {
@@ -772,14 +770,6 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
 
         /** @overload */
         static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
-
-        #ifdef MAGNUM_BUILD_DEPRECATED
-        /**
-         * @m_deprecated_since_latest Use @ref bind(Target, UnsignedInt, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>)
-         *      instead.
-         */
-        static CORRADE_DEPRECATED("use the Containers::Triple overload instead") void bind(Target target, UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
-        #endif
 
         /**
          * @brief Bind buffers to given range of indexed targets

--- a/src/Magnum/GL/Buffer.h
+++ b/src/Magnum/GL/Buffer.h
@@ -31,10 +31,10 @@
  */
 
 #include <cstddef>
+#include <utility>
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Containers/EnumSet.h>
 #include <Corrade/Utility/Assert.h>
-#include <Corrade/Utility/StlForwardTuple.h>
 
 #include "Magnum/Tags.h"
 #include "Magnum/GL/AbstractObject.h"
@@ -44,6 +44,8 @@
 /* For label() / setLabel(), which used to be a std::string. Not ideal for the
    return type, but at least something. */
 #include <Corrade/Containers/StringStl.h>
+/* For deprecated bind(..., std::initializer_list<std::tuple>) */
+#include <Corrade/Utility/StlForwardTuple.h>
 #endif
 
 namespace Magnum { namespace GL {
@@ -766,12 +768,18 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
          *      WebGL 1.0, see particular @ref Target values for version
          *      requirements.
          */
-        static void bind(Target target, UnsignedInt firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        static void bind(Target target, UnsignedInt firstIndex, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
 
         /** @overload */
-        static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
-            return bind(target, firstIndex, Containers::arrayView(buffers));
-        }
+        static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+
+        #ifdef MAGNUM_BUILD_DEPRECATED
+        /**
+         * @m_deprecated_since_latest Use @ref bind(Target, UnsignedInt, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>)
+         *      instead.
+         */
+        static CORRADE_DEPRECATED("use the Containers::Triple overload instead") void bind(Target target, UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        #endif
 
         /**
          * @brief Bind buffers to given range of indexed targets
@@ -1012,7 +1020,7 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
          * @note This function is meant to be used only internally from
          *      @ref AbstractShaderProgram subclasses. See its documentation
          *      for more information.
-         * @see @ref bind(Target, UnsignedInt, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>>),
+         * @see @ref bind(Target, UnsignedInt, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>),
          *      @ref maxAtomicCounterBindings(), @ref maxShaderStorageBindings(),
          *      @ref maxUniformBindings(), @ref shaderStorageOffsetAlignment(),
          *      @ref uniformOffsetAlignment(), @ref TransformFeedback::attachBuffer(),
@@ -1337,9 +1345,9 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
         static void MAGNUM_GL_LOCAL bindImplementationMulti(Target target, GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers);
         #endif
 
-        static void MAGNUM_GL_LOCAL bindImplementationFallback(Target target, GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        static void MAGNUM_GL_LOCAL bindImplementationFallback(Target target, GLuint firstIndex, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
         #ifndef MAGNUM_TARGET_GLES
-        static void MAGNUM_GL_LOCAL bindImplementationMulti(Target target, GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        static void MAGNUM_GL_LOCAL bindImplementationMulti(Target target, GLuint firstIndex, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
         #endif
 
         static void MAGNUM_GL_LOCAL copyImplementationDefault(Buffer& read, Buffer& write, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size);

--- a/src/Magnum/GL/Buffer.h
+++ b/src/Magnum/GL/Buffer.h
@@ -766,7 +766,12 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
          *      WebGL 1.0, see particular @ref Target values for version
          *      requirements.
          */
-        static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        static void bind(Target target, UnsignedInt firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+
+        /** @overload */
+        static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
+            return bind(target, firstIndex, Containers::arrayView(buffers));
+        }
 
         /**
          * @brief Bind buffers to given range of indexed targets
@@ -796,7 +801,12 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
          *      WebGL 1.0, see particular @ref Target values for version
          *      requirements.
          */
-        static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<Buffer*> buffers);
+        static void bind(Target target, UnsignedInt firstIndex, Containers::ArrayView<Buffer* const> buffers);
+
+        /** @overload */
+        static void bind(Target target, UnsignedInt firstIndex, std::initializer_list<Buffer*> buffers) {
+            return bind(target, firstIndex, Containers::arrayView(buffers));
+        }
 
         /**
          * @brief Copy one buffer to another
@@ -1002,7 +1012,7 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
          * @note This function is meant to be used only internally from
          *      @ref AbstractShaderProgram subclasses. See its documentation
          *      for more information.
-         * @see @ref bind(Target, UnsignedInt, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>>),
+         * @see @ref bind(Target, UnsignedInt, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>>),
          *      @ref maxAtomicCounterBindings(), @ref maxShaderStorageBindings(),
          *      @ref maxUniformBindings(), @ref shaderStorageOffsetAlignment(),
          *      @ref uniformOffsetAlignment(), @ref TransformFeedback::attachBuffer(),
@@ -1028,7 +1038,7 @@ class MAGNUM_GL_EXPORT Buffer: public AbstractObject {
          * @note This function is meant to be used only internally from
          *      @ref AbstractShaderProgram subclasses. See its documentation
          *      for more information.
-         * @see @ref bind(Target, UnsignedInt, std::initializer_list<Buffer*>),
+         * @see @ref bind(Target, UnsignedInt, Containers::ArrayView<Buffer* const>),
          *      @ref maxAtomicCounterBindings(), @ref maxShaderStorageBindings(),
          *      @ref maxUniformBindings(), @ref TransformFeedback::attachBuffer(),
          *      @fn_gl_keyword{BindBufferBase}

--- a/src/Magnum/GL/Implementation/BufferState.h
+++ b/src/Magnum/GL/Implementation/BufferState.h
@@ -51,7 +51,7 @@ struct BufferState {
 
     #ifndef MAGNUM_TARGET_GLES2
     void(*bindBasesImplementation)(Buffer::Target, UnsignedInt, Containers::ArrayView<Buffer* const>);
-    void(*bindRangesImplementation)(Buffer::Target, UnsignedInt, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>>);
+    void(*bindRangesImplementation)(Buffer::Target, UnsignedInt, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>);
     void(*copyImplementation)(Buffer&, Buffer&, GLintptr, GLintptr, GLsizeiptr);
     #endif
     void(Buffer::*createImplementation)();

--- a/src/Magnum/GL/Implementation/TransformFeedbackState.h
+++ b/src/Magnum/GL/Implementation/TransformFeedbackState.h
@@ -63,7 +63,7 @@ struct TransformFeedbackState {
     void(TransformFeedback::*createImplementation)();
     void(TransformFeedback::*attachRangeImplementation)(GLuint, Buffer&, GLintptr, GLsizeiptr);
     void(TransformFeedback::*attachBaseImplementation)(GLuint, Buffer&);
-    void(TransformFeedback::*attachRangesImplementation)(GLuint, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>>);
+    void(TransformFeedback::*attachRangesImplementation)(GLuint, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>);
     void(TransformFeedback::*attachBasesImplementation)(GLuint, Containers::ArrayView<Buffer* const>);
 };
 

--- a/src/Magnum/GL/Implementation/TransformFeedbackState.h
+++ b/src/Magnum/GL/Implementation/TransformFeedbackState.h
@@ -63,8 +63,8 @@ struct TransformFeedbackState {
     void(TransformFeedback::*createImplementation)();
     void(TransformFeedback::*attachRangeImplementation)(GLuint, Buffer&, GLintptr, GLsizeiptr);
     void(TransformFeedback::*attachBaseImplementation)(GLuint, Buffer&);
-    void(TransformFeedback::*attachRangesImplementation)(GLuint, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>>);
-    void(TransformFeedback::*attachBasesImplementation)(GLuint, std::initializer_list<Buffer*>);
+    void(TransformFeedback::*attachRangesImplementation)(GLuint, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>>);
+    void(TransformFeedback::*attachBasesImplementation)(GLuint, Containers::ArrayView<Buffer* const>);
 };
 
 }}}

--- a/src/Magnum/GL/Test/BufferGLTest.cpp
+++ b/src/Magnum/GL/Test/BufferGLTest.cpp
@@ -254,10 +254,9 @@ void BufferGLTest::bindRange() {
 
     MAGNUM_VERIFY_NO_GL_ERROR();
 
-    using BufferOffset = Containers::Triple<Buffer*, GLintptr, GLsizeiptr>;
     Buffer::bind(Buffer::Target::Uniform, 7, {
-        BufferOffset{&buffer, 256, 13}, {},
-        BufferOffset{&buffer, 768, 64}});
+        {&buffer, 256, 13}, {},
+        {&buffer, 768, 64}});
 
     MAGNUM_VERIFY_NO_GL_ERROR();
 }

--- a/src/Magnum/GL/Test/BufferGLTest.cpp
+++ b/src/Magnum/GL/Test/BufferGLTest.cpp
@@ -24,9 +24,9 @@
 */
 
 #include <array>
-#include <tuple>
 #include <vector>
 #include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/Triple.h>
 #include <Corrade/TestSuite/Compare/Container.h>
 
 #include "Magnum/GL/Buffer.h"
@@ -254,10 +254,10 @@ void BufferGLTest::bindRange() {
 
     MAGNUM_VERIFY_NO_GL_ERROR();
 
-    /** @todo C++14: get rid of std::make_tuple */
+    using BufferOffset = Containers::Triple<Buffer*, GLintptr, GLsizeiptr>;
     Buffer::bind(Buffer::Target::Uniform, 7, {
-        std::make_tuple(&buffer, 256, 13), {},
-        std::make_tuple(&buffer, 768, 64)});
+        BufferOffset{&buffer, 256, 13}, {},
+        BufferOffset{&buffer, 768, 64}});
 
     MAGNUM_VERIFY_NO_GL_ERROR();
 }

--- a/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
+++ b/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
@@ -23,8 +23,9 @@
     DEALINGS IN THE SOFTWARE.
 */
 
-#include <tuple>
 #include <Corrade/Containers/Iterable.h>
+#include <Corrade/Containers/Reference.h>
+#include <Corrade/Containers/Triple.h>
 
 #include "Magnum/Image.h"
 #include "Magnum/GL/AbstractShaderProgram.h"
@@ -488,9 +489,10 @@ void TransformFeedbackGLTest::attachRanges() {
         .setCount(2);
 
     TransformFeedback feedback;
+    using BufferOffset = Containers::Triple<Buffer*, GLintptr, GLsizeiptr>;
     feedback.attachBuffers(0, {
-        std::make_tuple(&output1, 256, 2*sizeof(Vector2)),
-        std::make_tuple(&output2, 512, 2*sizeof(Float))
+        BufferOffset{&output1, 256, 2*sizeof(Vector2)},
+        BufferOffset{&output2, 512, 2*sizeof(Float)}
     });
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
+++ b/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
@@ -489,10 +489,9 @@ void TransformFeedbackGLTest::attachRanges() {
         .setCount(2);
 
     TransformFeedback feedback;
-    using BufferOffset = Containers::Triple<Buffer*, GLintptr, GLsizeiptr>;
     feedback.attachBuffers(0, {
-        BufferOffset{&output1, 256, 2*sizeof(Vector2)},
-        BufferOffset{&output2, 512, 2*sizeof(Float)}
+        {&output1, 256, 2*sizeof(Vector2)},
+        {&output2, 512, 2*sizeof(Float)}
     });
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/GL/TransformFeedback.cpp
+++ b/src/Magnum/GL/TransformFeedback.cpp
@@ -26,9 +26,6 @@
 #include "TransformFeedback.h"
 
 #ifndef MAGNUM_TARGET_GLES2
-#ifdef MAGNUM_BUILD_DEPRECATED
-#include <tuple>
-#endif
 #ifndef MAGNUM_TARGET_WEBGL
 #include <Corrade/Containers/String.h>
 #endif
@@ -219,17 +216,6 @@ TransformFeedback& TransformFeedback::attachBuffers(const UnsignedInt firstIndex
     (this->*Context::current().state().transformFeedback.attachRangesImplementation)(firstIndex, Containers::arrayView(buffers));
     return *this;
 }
-
-#ifdef MAGNUM_BUILD_DEPRECATED
-TransformFeedback& TransformFeedback::attachBuffers(UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
-    Containers::Array<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> copy{NoInit, buffers.size()};
-    for(std::size_t i = 0, max = buffers.size(); i != max; ++i) {
-        const auto& t = *(buffers.begin() + i);
-        copy[i] = {std::get<0>(t), std::get<1>(t), std::get<2>(t)};
-    }
-    return attachBuffers(firstIndex, copy);
-}
-#endif
 
 TransformFeedback& TransformFeedback::attachBuffers(const UnsignedInt firstIndex, Containers::ArrayView<Buffer* const> buffers) {
     (this->*Context::current().state().transformFeedback.attachBasesImplementation)(firstIndex, buffers);

--- a/src/Magnum/GL/TransformFeedback.cpp
+++ b/src/Magnum/GL/TransformFeedback.cpp
@@ -207,27 +207,23 @@ void TransformFeedback::attachImplementationDSA(const GLuint index, Buffer& buff
 }
 #endif
 
-/** @todoc const std::initializer_list makes Doxygen grumpy */
-TransformFeedback& TransformFeedback::attachBuffers(const UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
+TransformFeedback& TransformFeedback::attachBuffers(const UnsignedInt firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     (this->*Context::current().state().transformFeedback.attachRangesImplementation)(firstIndex, buffers);
     return *this;
 }
 
-/** @todoc const std::initializer_list makes Doxygen grumpy */
-TransformFeedback& TransformFeedback::attachBuffers(const UnsignedInt firstIndex, std::initializer_list<Buffer*> buffers) {
+TransformFeedback& TransformFeedback::attachBuffers(const UnsignedInt firstIndex, Containers::ArrayView<Buffer* const> buffers) {
     (this->*Context::current().state().transformFeedback.attachBasesImplementation)(firstIndex, buffers);
     return *this;
 }
 
-/** @todoc const std::initializer_list makes Doxygen grumpy */
-void TransformFeedback::attachImplementationFallback(const GLuint firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
+void TransformFeedback::attachImplementationFallback(const GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     bindInternal();
     Buffer::bind(Buffer::Target(GL_TRANSFORM_FEEDBACK_BUFFER), firstIndex, buffers);
 }
 
 #ifndef MAGNUM_TARGET_GLES
-/** @todoc const Containers::ArrayView makes Doxygen grumpy */
-void TransformFeedback::attachImplementationDSA(const GLuint firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
+void TransformFeedback::attachImplementationDSA(const GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
     for(std::size_t i = 0; i != buffers.size(); ++i) {
         Buffer* buffer;
         GLintptr offset;
@@ -239,15 +235,13 @@ void TransformFeedback::attachImplementationDSA(const GLuint firstIndex, std::in
 }
 #endif
 
-/** @todoc const Containers::ArrayView makes Doxygen grumpy */
-void TransformFeedback::attachImplementationFallback(const GLuint firstIndex, std::initializer_list<Buffer*> buffers) {
+void TransformFeedback::attachImplementationFallback(const GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers) {
     bindInternal();
     Buffer::bind(Buffer::Target(GL_TRANSFORM_FEEDBACK_BUFFER), firstIndex, buffers);
 }
 
 #ifndef MAGNUM_TARGET_GLES
-/** @todoc const Containers::ArrayView makes Doxygen grumpy */
-void TransformFeedback::attachImplementationDSA(const GLuint firstIndex, std::initializer_list<Buffer*> buffers) {
+void TransformFeedback::attachImplementationDSA(const GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers) {
     for(std::size_t i = 0; i != buffers.size(); ++i)
         glTransformFeedbackBufferBase(_id, firstIndex + i, *(buffers.begin() + i) ? (*(buffers.begin() + i))->id() : 0);
 }

--- a/src/Magnum/GL/TransformFeedback.h
+++ b/src/Magnum/GL/TransformFeedback.h
@@ -340,7 +340,12 @@ class MAGNUM_GL_EXPORT TransformFeedback: public AbstractObject {
          *      eventually @fn_gl{BindTransformFeedback} and
          *      @fn_gl_keyword{BindBuffersRange} or @fn_gl_keyword{BindBufferRange}
          */
-        TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        TransformFeedback& attachBuffers(UnsignedInt firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+
+        /** @overload */
+        TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
+            return attachBuffers(firstIndex, Containers::arrayView(buffers));
+        }
 
         /**
          * @brief Attach buffers
@@ -363,7 +368,12 @@ class MAGNUM_GL_EXPORT TransformFeedback: public AbstractObject {
          *      eventually @fn_gl{BindTransformFeedback} and
          *      @fn_gl_keyword{BindBuffersBase} or @fn_gl_keyword{BindBufferBase}
          */
-        TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<Buffer*> buffers);
+        TransformFeedback& attachBuffers(UnsignedInt firstIndex, Containers::ArrayView<Buffer* const> buffers);
+
+        /** @overload */
+        TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<Buffer*> buffers) {
+            return attachBuffers(firstIndex, Containers::arrayView(buffers));
+        }
 
         /**
          * @brief Begin transform feedback
@@ -429,11 +439,11 @@ class MAGNUM_GL_EXPORT TransformFeedback: public AbstractObject {
         void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint index, Buffer& buffer);
         #endif
 
-        void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
-        void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, std::initializer_list<Buffer*> buffers);
+        void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers);
         #ifndef MAGNUM_TARGET_GLES
-        void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
-        void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, std::initializer_list<Buffer*> buffers);
+        void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers);
         #endif
 
         GLuint _id;

--- a/src/Magnum/GL/TransformFeedback.h
+++ b/src/Magnum/GL/TransformFeedback.h
@@ -31,8 +31,8 @@
  */
 #endif
 
+#include <utility>
 #include <Corrade/Containers/ArrayView.h>
-#include <Corrade/Utility/StlForwardTuple.h>
 
 #include "Magnum/Tags.h"
 #include "Magnum/GL/AbstractObject.h"
@@ -42,6 +42,8 @@
 /* For label() / setLabel(), which used to be a std::string. Not ideal for the
    return type, but at least something. */
 #include <Corrade/Containers/StringStl.h>
+/* For deprecated bind(..., std::initializer_list<std::tuple>) */
+#include <Corrade/Utility/StlForwardTuple.h>
 #endif
 
 #ifndef MAGNUM_TARGET_GLES2
@@ -340,12 +342,18 @@ class MAGNUM_GL_EXPORT TransformFeedback: public AbstractObject {
          *      eventually @fn_gl{BindTransformFeedback} and
          *      @fn_gl_keyword{BindBuffersRange} or @fn_gl_keyword{BindBufferRange}
          */
-        TransformFeedback& attachBuffers(UnsignedInt firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        TransformFeedback& attachBuffers(UnsignedInt firstIndex, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
 
         /** @overload */
-        TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers) {
-            return attachBuffers(firstIndex, Containers::arrayView(buffers));
-        }
+        TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+
+        #ifdef MAGNUM_BUILD_DEPRECATED
+        /**
+         * @m_deprecated_since_latest Use @ref attachBuffers(UnsignedInt, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>)
+         *      instead.
+         */
+        CORRADE_DEPRECATED("use the Containers::Triple overload instead") TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        #endif
 
         /**
          * @brief Attach buffers
@@ -439,10 +447,10 @@ class MAGNUM_GL_EXPORT TransformFeedback: public AbstractObject {
         void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint index, Buffer& buffer);
         #endif
 
-        void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
         void MAGNUM_GL_LOCAL attachImplementationFallback(GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers);
         #ifndef MAGNUM_TARGET_GLES
-        void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, Containers::ArrayView<const std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
+        void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, Containers::ArrayView<const Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
         void MAGNUM_GL_LOCAL attachImplementationDSA(GLuint firstIndex, Containers::ArrayView<Buffer* const> buffers);
         #endif
 

--- a/src/Magnum/GL/TransformFeedback.h
+++ b/src/Magnum/GL/TransformFeedback.h
@@ -42,8 +42,6 @@
 /* For label() / setLabel(), which used to be a std::string. Not ideal for the
    return type, but at least something. */
 #include <Corrade/Containers/StringStl.h>
-/* For deprecated bind(..., std::initializer_list<std::tuple>) */
-#include <Corrade/Utility/StlForwardTuple.h>
 #endif
 
 #ifndef MAGNUM_TARGET_GLES2
@@ -346,14 +344,6 @@ class MAGNUM_GL_EXPORT TransformFeedback: public AbstractObject {
 
         /** @overload */
         TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>> buffers);
-
-        #ifdef MAGNUM_BUILD_DEPRECATED
-        /**
-         * @m_deprecated_since_latest Use @ref attachBuffers(UnsignedInt, std::initializer_list<Containers::Triple<Buffer*, GLintptr, GLsizeiptr>>)
-         *      instead.
-         */
-        CORRADE_DEPRECATED("use the Containers::Triple overload instead") TransformFeedback& attachBuffers(UnsignedInt firstIndex, std::initializer_list<std::tuple<Buffer*, GLintptr, GLsizeiptr>> buffers);
-        #endif
 
         /**
          * @brief Attach buffers


### PR DESCRIPTION
Hello !

We are hitting an issue which is that the `TransformFeedback::attachBuffers` API is quite inpractical to use. Since it only takes a `std::initializer_list`, there is no way to attach or detach a number of buffers that is not known at compîle time.

In addition to that, there is no `detachBuffers`, so you have to use the mentioned `attachBuffers` to detach your buffers, but again, you can only pass a compile-time sized list to it, so in any situation when you don't know the size at compile time, you're basically unable to detach the buffers correctly, save from writing an ugly compile-time jump table redirecting to the correct sized initializer list.

So I'm suggesting to just take an `ArrayView` in all those functions, which I don't see any disadvantages to, but if you see one please let me know of what other approach you would have in mind to enhance this API for this use case :)

One advantage of taking `ArrayView`, on the other hand, would be that, if the user really wants to pass initializer lists to those functions, they still can, but the burden of including `initializer_list` now lies on the includer and not on the `TransformFeedback.h` header (although I do think I might have forgotten to remove it from there)

As an additional improvement I think we could use an actual Struct instead of `std::tuple` for the size-offset variant, but I didn't go the extra mile of doing that. Would also be happy to, though, if you think that's a good idea

I'm leaving it as a draft for now until I hear what you think :)

EDIT: Re-reading the PR I realize I had to modify `Buffer::bind` as well, which I had forgotten. I don't know how widely it is used in general, to deduce if this would be an okay change or not, so happy to hear your thoughts.