### PR TITLE
ShaderProgram: Add glUniform for single value calls using non-v variants

### DIFF
--- a/src/Magnum/GL/AbstractShaderProgram.cpp
+++ b/src/Magnum/GL/AbstractShaderProgram.cpp
@@ -662,6 +662,282 @@ UnsignedInt AbstractShaderProgram::uniformBlockIndexInternal(const Containers::A
 }
 #endif
 
+void AbstractShaderProgram::setUniform(const Int location, Float value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform1fImplementation
+    #else
+    uniform1fImplementationDefault
+    #endif
+        (_id, location, value);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform1fImplementationDefault(const GLuint id, const GLint location, GLfloat v0) {
+    use(id);
+    glUniform1f(location, v0);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<2, Float>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform2fImplementation
+    #else
+    uniform2fImplementationDefault
+    #endif
+        (_id, location, value[0], value[1]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform2fImplementationDefault(const GLuint id, const GLint location, GLfloat v0, GLfloat v1) {
+    use(id);
+    glUniform2f(location, v0, v1);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<3, Float>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform3fImplementation
+    #else
+    uniform3fImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform3fImplementationDefault(const GLuint id, const GLint location, GLfloat v0, GLfloat v1, GLfloat v2) {
+    use(id);
+    glUniform3f(location, v0, v1, v2);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<4, Float>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform4fImplementation
+    #else
+    uniform4fImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2], value[3]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform4fImplementationDefault(const GLuint id, const GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3) {
+    use(id);
+    glUniform4f(location, v0, v1, v2, v3);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, Int value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform1iImplementation
+    #else
+    uniform1iImplementationDefault
+    #endif
+        (_id, location, value);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform1iImplementationDefault(const GLuint id, const GLint location, GLint v0) {
+    use(id);
+    glUniform1i(location, v0);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<2, Int>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform2iImplementation
+    #else
+    uniform2iImplementationDefault
+    #endif
+        (_id, location, value[0], value[1]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform2iImplementationDefault(const GLuint id, const GLint location, GLint v0, GLint v1) {
+    use(id);
+    glUniform2i(location, v0, v1);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<3, Int>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform3iImplementation
+    #else
+    uniform3iImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform3iImplementationDefault(const GLuint id, const GLint location, GLint v0, GLint v1, GLint v2) {
+    use(id);
+    glUniform3i(location, v0, v1, v2);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<4, Int>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform4iImplementation
+    #else
+    uniform4iImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2], value[3]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform4iImplementationDefault(const GLuint id, const GLint location, GLint v0, GLint v1, GLint v2, GLint v3) {
+    use(id);
+    glUniform4i(location, v0, v1, v2, v3);
+}
+
+#ifndef MAGNUM_TARGET_GLES2
+void AbstractShaderProgram::setUniform(const Int location, UnsignedInt value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform1uiImplementation
+    #else
+    uniform1uiImplementationDefault
+    #endif
+        (_id, location, value);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform1uiImplementationDefault(const GLuint id, const GLint location, GLuint v0) {
+    use(id);
+    glUniform1ui(location, v0);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<2, UnsignedInt>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform2uiImplementation
+    #else
+    uniform2uiImplementationDefault
+    #endif
+        (_id, location, value[0], value[1]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform2uiImplementationDefault(const GLuint id, const GLint location, GLuint v0, GLuint v1) {
+    use(id);
+    glUniform2ui(location, v0, v1);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<3, UnsignedInt>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform3uiImplementation
+    #else
+    uniform3uiImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform3uiImplementationDefault(const GLuint id, const GLint location, GLuint v0, GLuint v1, GLuint v2) {
+    use(id);
+    glUniform3ui(location, v0, v1, v2);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<4, UnsignedInt>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform4uiImplementation
+    #else
+    uniform4uiImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2], value[3]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform4uiImplementationDefault(const GLuint id, const GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3) {
+    use(id);
+    glUniform4ui(location, v0, v1, v2, v3);
+}
+#endif
+
+#ifndef MAGNUM_TARGET_GLES
+void AbstractShaderProgram::setUniform(const Int location, Double value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform1dImplementation
+    #else
+    uniform1dImplementationDefault
+    #endif
+        (_id, location, value);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform1dImplementationDefault(const GLuint id, const GLint location, GLdouble v0) {
+    use(id);
+    glUniform1d(location, v0);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<2, Double>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform2dImplementation
+    #else
+    uniform2dImplementationDefault
+    #endif
+        (_id, location, value[0], value[1]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform2dImplementationDefault(const GLuint id, const GLint location, GLdouble v0, GLdouble v1) {
+    use(id);
+    glUniform2d(location, v0, v1);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<3, Double>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform3dImplementation
+    #else
+    uniform3dImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform3dImplementationDefault(const GLuint id, const GLint location, GLdouble v0, GLdouble v1, GLdouble v2) {
+    use(id);
+    glUniform3d(location, v0, v1, v2);
+}
+
+void AbstractShaderProgram::setUniform(const Int location, const Math::Vector<4, Double>& value) {
+    #ifndef MAGNUM_TARGET_WEBGL
+    Context::current().state().shaderProgram.uniform4dImplementation
+    #else
+    uniform4dImplementationDefault
+    #endif
+        (_id, location, value[0], value[1], value[2], value[3]);
+}
+
+#ifdef MAGNUM_TARGET_WEBGL
+inline
+#endif
+void AbstractShaderProgram::uniform4dImplementationDefault(const GLuint id, const GLint location, GLdouble v0, GLdouble v1, GLdouble v2, GLdouble v3) {
+    use(id);
+    glUniform4d(location, v0, v1, v2, v3);
+}
+#endif
+
 void AbstractShaderProgram::setUniform(const Int location, const Containers::ArrayView<const Float> values) {
     #ifndef MAGNUM_TARGET_WEBGL
     Context::current().state().shaderProgram.uniform1fvImplementation

--- a/src/Magnum/GL/AbstractShaderProgram.h
+++ b/src/Magnum/GL/AbstractShaderProgram.h
@@ -1501,6 +1501,10 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
         }
         #endif
 
+        template<std::size_t cols, std::size_t rows, class T> void setUniform(Int location, const Math::RectangularMatrix<cols, rows, T>& value) {
+            setUniform(location, {&value, 1});
+        }
+
         /**
          * @brief Set uniform value
          * @param location      Uniform location
@@ -1511,31 +1515,42 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          * information.
          * @see @ref uniformLocation()
          */
-        #ifdef DOXYGEN_GENERATING_OUTPUT
-        template<class T> inline void setUniform(Int location, const T& value);
-        #else
-        void setUniform(Int location, Float value) {
-            setUniform(location, {&value, 1});
-        }
-        void setUniform(Int location, Int value) {
-            setUniform(location, {&value, 1});
-        }
+        void setUniform(Int location, Float value);
+        void setUniform(Int location, const Math::Vector<2, Float>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<3, Float>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<4, Float>& value); /**< @overload */
+
+        /**
+         * @copydoc setUniform(Int, Float)
+         */
+        void setUniform(Int location, Int value);
+        void setUniform(Int location, const Math::Vector<2, Int>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<3, Int>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<4, Int>& value); /**< @overload */
+
         #ifndef MAGNUM_TARGET_GLES2
-        void setUniform(Int location, UnsignedInt value) {
-            setUniform(location, {&value, 1});
-        }
+        /**
+         * @copydoc setUniform(Int, Float)
+         * @requires_gl30 Extension @gl_extension{EXT,gpu_shader4}
+         * @requires_gles30 Only signed integers are available in OpenGL ES 2.0.
+         * @requires_webgl20 Only signed integers are available in WebGL 1.0.
+         */
+        void setUniform(Int location, UnsignedInt value);
+        void setUniform(Int location, const Math::Vector<2, UnsignedInt>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<3, UnsignedInt>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<4, UnsignedInt>& value); /**< @overload */
         #endif
+
         #ifndef MAGNUM_TARGET_GLES
-        void setUniform(Int location, Double value) {
-            setUniform(location, {&value, 1});
-        }
-        #endif
-        template<std::size_t size, class T> void setUniform(Int location, const Math::Vector<size, T>& value) {
-            setUniform(location, {&value, 1});
-        }
-        template<std::size_t cols, std::size_t rows, class T> void setUniform(Int location, const Math::RectangularMatrix<cols, rows, T>& value) {
-            setUniform(location, {&value, 1});
-        }
+        /**
+         * @copydoc setUniform(Int, Float)
+         * @requires_gl40 Extension @gl_extension{ARB,gpu_shader_fp64}
+         * @requires_gl Only floats are available in OpenGL ES or WebGL.
+         */
+        void setUniform(Int location, Double value);
+        void setUniform(Int location, const Math::Vector<2, Double>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<3, Double>& value); /**< @overload */
+        void setUniform(Int location, const Math::Vector<4, Double>& value); /**< @overload */
         #endif
 
         /**
@@ -1680,21 +1695,37 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
         MAGNUM_GL_LOCAL static void APIENTRY uniform2fvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLfloat* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform3fvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLfloat* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform4fvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLfloat* values);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform1fImplementationDefault(GLuint id, GLint location, GLfloat v0);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform2fImplementationDefault(GLuint id, GLint location, GLfloat v0, GLfloat v1);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform3fImplementationDefault(GLuint id, GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform4fImplementationDefault(GLuint id, GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3);
         MAGNUM_GL_LOCAL static void APIENTRY uniform1ivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLint* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform2ivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLint* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform3ivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLint* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform4ivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLint* values);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform1iImplementationDefault(GLuint id, GLint location, GLint v0);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform2iImplementationDefault(GLuint id, GLint location, GLint v0, GLint v1);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform3iImplementationDefault(GLuint id, GLint location, GLint v0, GLint v1, GLint v2);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform4iImplementationDefault(GLuint id, GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
         #ifndef MAGNUM_TARGET_GLES2
         MAGNUM_GL_LOCAL static void APIENTRY uniform1uivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLuint* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform2uivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLuint* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform3uivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLuint* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform4uivImplementationDefault(GLuint id, GLint location, GLsizei count, const GLuint* values);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform1uiImplementationDefault(GLuint id, GLint location, GLuint v0);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform2uiImplementationDefault(GLuint id, GLint location, GLuint v0, GLuint v1);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform3uiImplementationDefault(GLuint id, GLint location, GLuint v0, GLuint v1, GLuint v2);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform4uiImplementationDefault(GLuint id, GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
         #endif
         #ifndef MAGNUM_TARGET_GLES
         MAGNUM_GL_LOCAL static void APIENTRY uniform1dvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLdouble* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform2dvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLdouble* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform3dvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLdouble* values);
         MAGNUM_GL_LOCAL static void APIENTRY uniform4dvImplementationDefault(GLuint id, GLint location, GLsizei count, const GLdouble* values);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform1dImplementationDefault(GLuint id, GLint location, GLdouble v0);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform2dImplementationDefault(GLuint id, GLint location, GLdouble v0, GLdouble v1);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform3dImplementationDefault(GLuint id, GLint location, GLdouble v0, GLdouble v1, GLdouble v2);
+        MAGNUM_GL_LOCAL static void APIENTRY uniform4dImplementationDefault(GLuint id, GLint location, GLdouble v0, GLdouble v1, GLdouble v2, GLdouble v3);
         #endif
 
         MAGNUM_GL_LOCAL static void APIENTRY uniformMatrix2fvImplementationDefault(GLuint id, GLint location, GLsizei count, GLboolean transpose, const GLfloat* values);

--- a/src/Magnum/GL/Implementation/ShaderProgramState.cpp
+++ b/src/Magnum/GL/Implementation/ShaderProgramState.cpp
@@ -95,19 +95,35 @@ ShaderProgramState::ShaderProgramState(Context& context, Containers::StaticArray
         uniform2fvImplementation = glProgramUniform2fv;
         uniform3fvImplementation = glProgramUniform3fv;
         uniform4fvImplementation = glProgramUniform4fv;
+        uniform1fImplementation = glProgramUniform1f;
+        uniform2fImplementation = glProgramUniform2f;
+        uniform3fImplementation = glProgramUniform3f;
+        uniform4fImplementation = glProgramUniform4f;
         uniform1ivImplementation = glProgramUniform1iv;
         uniform2ivImplementation = glProgramUniform2iv;
         uniform3ivImplementation = glProgramUniform3iv;
         uniform4ivImplementation = glProgramUniform4iv;
+        uniform1iImplementation = glProgramUniform1i;
+        uniform2iImplementation = glProgramUniform2i;
+        uniform3iImplementation = glProgramUniform3i;
+        uniform4iImplementation = glProgramUniform4i;
         uniform1uivImplementation = glProgramUniform1uiv;
         uniform2uivImplementation = glProgramUniform2uiv;
         uniform3uivImplementation = glProgramUniform3uiv;
         uniform4uivImplementation = glProgramUniform4uiv;
+        uniform1uiImplementation = glProgramUniform1ui;
+        uniform2uiImplementation = glProgramUniform2ui;
+        uniform3uiImplementation = glProgramUniform3ui;
+        uniform4uiImplementation = glProgramUniform4ui;
         #ifndef MAGNUM_TARGET_GLES
         uniform1dvImplementation = glProgramUniform1dv;
         uniform2dvImplementation = glProgramUniform2dv;
         uniform3dvImplementation = glProgramUniform3dv;
         uniform4dvImplementation = glProgramUniform4dv;
+        uniform1dImplementation = glProgramUniform1d;
+        uniform2dImplementation = glProgramUniform2d;
+        uniform3dImplementation = glProgramUniform3d;
+        uniform4dImplementation = glProgramUniform4d;
         #endif
 
         uniformMatrix2fvImplementation = glProgramUniformMatrix2fv;
@@ -142,15 +158,27 @@ ShaderProgramState::ShaderProgramState(Context& context, Containers::StaticArray
         uniform2fvImplementation = glProgramUniform2fvEXT;
         uniform3fvImplementation = glProgramUniform3fvEXT;
         uniform4fvImplementation = glProgramUniform4fvEXT;
+        uniform1fImplementation = glProgramUniform1fEXT;
+        uniform2fImplementation = glProgramUniform2fEXT;
+        uniform3fImplementation = glProgramUniform3fEXT;
+        uniform4fImplementation = glProgramUniform4fEXT;
         uniform1ivImplementation = glProgramUniform1ivEXT;
         uniform2ivImplementation = glProgramUniform2ivEXT;
         uniform3ivImplementation = glProgramUniform3ivEXT;
         uniform4ivImplementation = glProgramUniform4ivEXT;
+        uniform1iImplementation = glProgramUniform1iEXT;
+        uniform2iImplementation = glProgramUniform2iEXT;
+        uniform3iImplementation = glProgramUniform3iEXT;
+        uniform4iImplementation = glProgramUniform4iEXT;
         #ifndef MAGNUM_TARGET_GLES2
         uniform1uivImplementation = glProgramUniform1uivEXT;
         uniform2uivImplementation = glProgramUniform2uivEXT;
         uniform3uivImplementation = glProgramUniform3uivEXT;
         uniform4uivImplementation = glProgramUniform4uivEXT;
+        uniform1uiImplementation = glProgramUniform1uiEXT;
+        uniform2uiImplementation = glProgramUniform2uiEXT;
+        uniform3uiImplementation = glProgramUniform3uiEXT;
+        uniform4uiImplementation = glProgramUniform4uiEXT;
         #endif
 
         uniformMatrix2fvImplementation = glProgramUniformMatrix2fvEXT;
@@ -171,21 +199,37 @@ ShaderProgramState::ShaderProgramState(Context& context, Containers::StaticArray
         uniform2fvImplementation = &AbstractShaderProgram::uniform2fvImplementationDefault;
         uniform3fvImplementation = &AbstractShaderProgram::uniform3fvImplementationDefault;
         uniform4fvImplementation = &AbstractShaderProgram::uniform4fvImplementationDefault;
+        uniform1fImplementation = &AbstractShaderProgram::uniform1fImplementationDefault;
+        uniform2fImplementation = &AbstractShaderProgram::uniform2fImplementationDefault;
+        uniform3fImplementation = &AbstractShaderProgram::uniform3fImplementationDefault;
+        uniform4fImplementation = &AbstractShaderProgram::uniform4fImplementationDefault;
         uniform1ivImplementation = &AbstractShaderProgram::uniform1ivImplementationDefault;
         uniform2ivImplementation = &AbstractShaderProgram::uniform2ivImplementationDefault;
         uniform3ivImplementation = &AbstractShaderProgram::uniform3ivImplementationDefault;
         uniform4ivImplementation = &AbstractShaderProgram::uniform4ivImplementationDefault;
+        uniform1iImplementation = &AbstractShaderProgram::uniform1iImplementationDefault;
+        uniform2iImplementation = &AbstractShaderProgram::uniform2iImplementationDefault;
+        uniform3iImplementation = &AbstractShaderProgram::uniform3iImplementationDefault;
+        uniform4iImplementation = &AbstractShaderProgram::uniform4iImplementationDefault;
         #ifndef MAGNUM_TARGET_GLES2
         uniform1uivImplementation = &AbstractShaderProgram::uniform1uivImplementationDefault;
         uniform2uivImplementation = &AbstractShaderProgram::uniform2uivImplementationDefault;
         uniform3uivImplementation = &AbstractShaderProgram::uniform3uivImplementationDefault;
         uniform4uivImplementation = &AbstractShaderProgram::uniform4uivImplementationDefault;
+        uniform1uiImplementation = &AbstractShaderProgram::uniform1uiImplementationDefault;
+        uniform2uiImplementation = &AbstractShaderProgram::uniform2uiImplementationDefault;
+        uniform3uiImplementation = &AbstractShaderProgram::uniform3uiImplementationDefault;
+        uniform4uiImplementation = &AbstractShaderProgram::uniform4uiImplementationDefault;
         #endif
         #ifndef MAGNUM_TARGET_GLES
         uniform1dvImplementation = &AbstractShaderProgram::uniform1dvImplementationDefault;
         uniform2dvImplementation = &AbstractShaderProgram::uniform2dvImplementationDefault;
         uniform3dvImplementation = &AbstractShaderProgram::uniform3dvImplementationDefault;
         uniform4dvImplementation = &AbstractShaderProgram::uniform4dvImplementationDefault;
+        uniform1dImplementation = &AbstractShaderProgram::uniform1dImplementationDefault;
+        uniform2dImplementation = &AbstractShaderProgram::uniform2dImplementationDefault;
+        uniform3dImplementation = &AbstractShaderProgram::uniform3dImplementationDefault;
+        uniform4dImplementation = &AbstractShaderProgram::uniform4dImplementationDefault;
         #endif
 
         uniformMatrix2fvImplementation = &AbstractShaderProgram::uniformMatrix2fvImplementationDefault;

--- a/src/Magnum/GL/Implementation/ShaderProgramState.h
+++ b/src/Magnum/GL/Implementation/ShaderProgramState.h
@@ -53,21 +53,37 @@ struct ShaderProgramState {
     void(APIENTRY *uniform2fvImplementation)(GLuint, GLint, GLsizei, const GLfloat*);
     void(APIENTRY *uniform3fvImplementation)(GLuint, GLint, GLsizei, const GLfloat*);
     void(APIENTRY *uniform4fvImplementation)(GLuint, GLint, GLsizei, const GLfloat*);
+    void(APIENTRY *uniform1fImplementation)(GLuint, GLint, GLfloat);
+    void(APIENTRY *uniform2fImplementation)(GLuint, GLint, GLfloat, GLfloat);
+    void(APIENTRY *uniform3fImplementation)(GLuint, GLint, GLfloat, GLfloat, GLfloat);
+    void(APIENTRY *uniform4fImplementation)(GLuint, GLint, GLfloat, GLfloat, GLfloat, GLfloat);
     void(APIENTRY *uniform1ivImplementation)(GLuint, GLint, GLsizei, const GLint*);
     void(APIENTRY *uniform2ivImplementation)(GLuint, GLint, GLsizei, const GLint*);
     void(APIENTRY *uniform3ivImplementation)(GLuint, GLint, GLsizei, const GLint*);
     void(APIENTRY *uniform4ivImplementation)(GLuint, GLint, GLsizei, const GLint*);
+    void(APIENTRY *uniform1iImplementation)(GLuint, GLint, GLint);
+    void(APIENTRY *uniform2iImplementation)(GLuint, GLint, GLint, GLint);
+    void(APIENTRY *uniform3iImplementation)(GLuint, GLint, GLint, GLint, GLint);
+    void(APIENTRY *uniform4iImplementation)(GLuint, GLint, GLint, GLint, GLint, GLint);
     #ifndef MAGNUM_TARGET_GLES2
     void(APIENTRY *uniform1uivImplementation)(GLuint, GLint, GLsizei, const GLuint*);
     void(APIENTRY *uniform2uivImplementation)(GLuint, GLint, GLsizei, const GLuint*);
     void(APIENTRY *uniform3uivImplementation)(GLuint, GLint, GLsizei, const GLuint*);
     void(APIENTRY *uniform4uivImplementation)(GLuint, GLint, GLsizei, const GLuint*);
+    void(APIENTRY *uniform1uiImplementation)(GLuint, GLint, GLuint);
+    void(APIENTRY *uniform2uiImplementation)(GLuint, GLint, GLuint, GLuint);
+    void(APIENTRY *uniform3uiImplementation)(GLuint, GLint, GLuint, GLuint, GLuint);
+    void(APIENTRY *uniform4uiImplementation)(GLuint, GLint, GLuint, GLuint, GLuint, GLuint);
     #endif
     #ifndef MAGNUM_TARGET_GLES
     void(APIENTRY *uniform1dvImplementation)(GLuint, GLint, GLsizei, const GLdouble*);
     void(APIENTRY *uniform2dvImplementation)(GLuint, GLint, GLsizei, const GLdouble*);
     void(APIENTRY *uniform3dvImplementation)(GLuint, GLint, GLsizei, const GLdouble*);
     void(APIENTRY *uniform4dvImplementation)(GLuint, GLint, GLsizei, const GLdouble*);
+    void(APIENTRY *uniform1dImplementation)(GLuint, GLint, GLdouble);
+    void(APIENTRY *uniform2dImplementation)(GLuint, GLint, GLdouble, GLdouble);
+    void(APIENTRY *uniform3dImplementation)(GLuint, GLint, GLdouble, GLdouble, GLdouble);
+    void(APIENTRY *uniform4dImplementation)(GLuint, GLint, GLdouble, GLdouble, GLdouble, GLdouble);
     #endif
 
     void(APIENTRY *uniformMatrix2fvImplementation)(GLuint, GLint, GLsizei, GLboolean, const GLfloat*);


### PR DESCRIPTION
After discussion in this issue: https://github.com/mosra/magnum/issues/591
Here is a draft of adding the `setUniform` calls mapping to non-v variants of `glUniform` functions :)