### PR TITLE
Math: workaround constexpr conversion operator on MSVC

### DIFF
--- a/src/Magnum/Math/Test/BezierTest.cpp
+++ b/src/Magnum/Math/Test/BezierTest.cpp
@@ -209,7 +209,11 @@ void BezierTest::convert() {
     constexpr QuadraticBezier2D c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = QBezier2D(b);
+#else
     constexpr QBezier2D d(b);
+#endif
     CORRADE_COMPARE(d.x0, a.x0);
     CORRADE_COMPARE(d.x1, a.x1);
     CORRADE_COMPARE(d.y0, a.y0);

--- a/src/Magnum/Math/Test/ColorTest.cpp
+++ b/src/Magnum/Math/Test/ColorTest.cpp
@@ -455,7 +455,11 @@ void ColorTest::convert() {
     Color3 c3(a3);
     CORRADE_COMPARE(c3, b3);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d3 = Vec3(b3);
+#else
     constexpr Vec3 d3(b3);
+#endif
     CORRADE_COMPARE(d3.x, a3.x);
     CORRADE_COMPARE(d3.y, a3.y);
     CORRADE_COMPARE(d3.z, a3.z);
@@ -469,7 +473,11 @@ void ColorTest::convert() {
     Color4 c4(a4);
     CORRADE_COMPARE(c4, b4);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d4 = Vec4(b4);
+#else
     constexpr Vec4 d4(b4);
+#endif
     CORRADE_COMPARE(d4.x, a4.x);
     CORRADE_COMPARE(d4.y, a4.y);
     CORRADE_COMPARE(d4.z, a4.z);

--- a/src/Magnum/Math/Test/ComplexTest.cpp
+++ b/src/Magnum/Math/Test/ComplexTest.cpp
@@ -274,7 +274,11 @@ void ComplexTest::convert() {
     constexpr Complex c(a);
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Cmpl(b);
+#else
     constexpr Cmpl d(b);
+#endif
     CORRADE_COMPARE(d.re, a.re);
     CORRADE_COMPARE(d.im, a.im);
 

--- a/src/Magnum/Math/Test/DualComplexTest.cpp
+++ b/src/Magnum/Math/Test/DualComplexTest.cpp
@@ -267,7 +267,11 @@ void DualComplexTest::convert() {
     constexpr DualComplex c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = DualCmpl(b);
+#else
     constexpr DualCmpl d(b);
+#endif
     CORRADE_COMPARE(d.re, a.re);
     CORRADE_COMPARE(d.im, a.im);
     CORRADE_COMPARE(d.x, a.x);

--- a/src/Magnum/Math/Test/DualQuaternionTest.cpp
+++ b/src/Magnum/Math/Test/DualQuaternionTest.cpp
@@ -296,7 +296,11 @@ void DualQuaternionTest::convert() {
     constexpr DualQuaternion c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = DualQuat(b);
+#else
     constexpr DualQuat d(b);
+#endif
     CORRADE_COMPARE(d.re.x, a.re.x);
     CORRADE_COMPARE(d.re.y, a.re.y);
     CORRADE_COMPARE(d.re.z, a.re.z);

--- a/src/Magnum/Math/Test/FrustumTest.cpp
+++ b/src/Magnum/Math/Test/FrustumTest.cpp
@@ -298,7 +298,11 @@ void FrustumTest::convert() {
     constexpr Frustum c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Frstm(b);
+#else
     constexpr Frstm d(b);
+#endif
     CORRADE_COMPARE_AS(Corrade::Containers::arrayView(d.data),
         Corrade::Containers::arrayView(a.data),
         Corrade::TestSuite::Compare::Container);

--- a/src/Magnum/Math/Test/Matrix3Test.cpp
+++ b/src/Magnum/Math/Test/Matrix3Test.cpp
@@ -313,10 +313,14 @@ void Matrix3Test::convert() {
     constexpr Matrix3 c(b);
     CORRADE_COMPARE(c, b);
 
-    #ifndef CORRADE_MSVC2015_COMPATIBILITY /* Why can't be conversion constexpr? */
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Mat3(b);
+#else
+#ifndef CORRADE_MSVC2015_COMPATIBILITY /* Why can't be conversion constexpr? */
     constexpr
-    #endif
+#endif
     Mat3 d(b);
+#endif
     for(std::size_t i = 0; i != 9; ++i)
         CORRADE_COMPARE(d.a[0], a.a[0]);
 

--- a/src/Magnum/Math/Test/Matrix4Test.cpp
+++ b/src/Magnum/Math/Test/Matrix4Test.cpp
@@ -369,10 +369,14 @@ void Matrix4Test::convert() {
     constexpr Matrix4 c(b);
     CORRADE_COMPARE(c, b);
 
-    #ifndef CORRADE_MSVC2015_COMPATIBILITY /* Why can't be conversion constexpr? */
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Mat4(b);
+#else
+#ifndef CORRADE_MSVC2015_COMPATIBILITY /* Why can't be conversion constexpr? */
     constexpr
-    #endif
+#endif
     Mat4 d(b);
+#endif
     for(std::size_t i = 0; i != 16; ++i)
         CORRADE_COMPARE(d.a[i], a.a[i]);
 

--- a/src/Magnum/Math/Test/MatrixTest.cpp
+++ b/src/Magnum/Math/Test/MatrixTest.cpp
@@ -311,7 +311,11 @@ void MatrixTest::convert() {
     constexpr Matrix3x3 c(b);
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Mat3(b);
+#else
     constexpr Mat3 d(b);
+#endif
     for(std::size_t i = 0; i != 9; ++i)
         CORRADE_COMPARE(d.a[i], a.a[i]);
 

--- a/src/Magnum/Math/Test/QuaternionTest.cpp
+++ b/src/Magnum/Math/Test/QuaternionTest.cpp
@@ -311,7 +311,11 @@ void QuaternionTest::convert() {
     constexpr Quaternion c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Quat(b);
+#else
     constexpr Quat d(b);
+#endif
     CORRADE_COMPARE(d.x, a.x);
     CORRADE_COMPARE(d.y, a.y);
     CORRADE_COMPARE(d.z, a.z);

--- a/src/Magnum/Math/Test/RangeTest.cpp
+++ b/src/Magnum/Math/Test/RangeTest.cpp
@@ -398,17 +398,29 @@ void RangeTest::convert() {
     CORRADE_COMPARE(i, e);
     CORRADE_COMPARE(j, f);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto k = Dim(d);
+#else
     constexpr Dim k(d);
+#endif
     CORRADE_COMPARE(k.offset, a.offset);
     CORRADE_COMPARE(k.size, a.size);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto l = Rect(e);
+#else
     constexpr Rect l(e);
+#endif
     CORRADE_COMPARE(l.x, b.x);
     CORRADE_COMPARE(l.y, b.y);
     CORRADE_COMPARE(l.w, b.w);
     CORRADE_COMPARE(l.h, b.h);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto m = Box(f);
+#else
     constexpr Box m(f);
+#endif
     CORRADE_COMPARE(m.x, c.x);
     CORRADE_COMPARE(m.y, c.y);
     CORRADE_COMPARE(m.z, c.z);

--- a/src/Magnum/Math/Test/RectangularMatrixTest.cpp
+++ b/src/Magnum/Math/Test/RectangularMatrixTest.cpp
@@ -392,7 +392,11 @@ void RectangularMatrixTest::convert() {
     constexpr Matrix2x3 c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Mat2x3(b);
+#else
     constexpr Mat2x3 d(b);
+#endif
     for(std::size_t i = 0; i != 5; ++i)
         CORRADE_COMPARE(d.a[i], a.a[i]);
 

--- a/src/Magnum/Math/Test/Vector2Test.cpp
+++ b/src/Magnum/Math/Test/Vector2Test.cpp
@@ -187,7 +187,11 @@ void Vector2Test::convert() {
     constexpr Vector2 c(a);
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Vec2(b);
+#else
     constexpr Vec2 d(b);
+#endif
     CORRADE_COMPARE(d.x, a.x);
     CORRADE_COMPARE(d.y, a.y);
 

--- a/src/Magnum/Math/Test/Vector3Test.cpp
+++ b/src/Magnum/Math/Test/Vector3Test.cpp
@@ -195,7 +195,11 @@ void Vector3Test::convert() {
     constexpr Vector3 c(a);
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Vec3(b);
+#else
     constexpr Vec3 d(b);
+#endif
     CORRADE_COMPARE(d.x, a.x);
     CORRADE_COMPARE(d.y, a.y);
     CORRADE_COMPARE(d.z, a.z);

--- a/src/Magnum/Math/Test/Vector4Test.cpp
+++ b/src/Magnum/Math/Test/Vector4Test.cpp
@@ -216,7 +216,11 @@ void Vector4Test::convert() {
     constexpr Vector4 c(a);
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Vec4(b);
+#else
     constexpr Vec4 d(b);
+#endif
     CORRADE_COMPARE(d.x, a.x);
     CORRADE_COMPARE(d.y, a.y);
     CORRADE_COMPARE(d.z, a.z);

--- a/src/Magnum/Math/Test/VectorTest.cpp
+++ b/src/Magnum/Math/Test/VectorTest.cpp
@@ -314,7 +314,11 @@ void VectorTest::convert() {
     constexpr Vector3 c{a};
     CORRADE_COMPARE(c, b);
 
+#if defined(CORRADE_TARGET_MSVC) && CORRADE_CXX_STANDARD >= 202002L
+    constexpr auto d = Vec3(b);
+#else
     constexpr Vec3 d(b);
+#endif
     CORRADE_COMPARE(d.x, a.x);
     CORRADE_COMPARE(d.y, a.y);
     CORRADE_COMPARE(d.z, a.z);


### PR DESCRIPTION
Note: for the `BitVector` part, it may fail on old compilers unless you merge the first thunk of mosra/corrade#152 (changing `CORRADE_CONSTEXPR14` to be based on `__cpp_constexpr` value).