### PR TITLE
add simple timer functionality to Timeline

### DIFF
--- a/src/Magnum/Timeline.cpp
+++ b/src/Magnum/Timeline.cpp
@@ -61,4 +61,19 @@ Float Timeline::previousFrameTime() const {
     return duration_cast<microseconds>(_previousFrameTime-_startTime).count()/1e6f;
 }
 
+Float Timeline::currentFrameDuration() const {
+    if (!running) return 0;
+
+    auto now = high_resolution_clock::now();
+    auto duration = UnsignedInt(duration_cast<microseconds>(now-_previousFrameTime).count());
+    return duration/1e6f;
+}
+
+Float Timeline::currentFrameTime() const {
+    if (!running) return 0;
+
+    auto now = high_resolution_clock::now();
+    return duration_cast<microseconds>(now-_startTime).count()/1e6f;
+}
+
 }

--- a/src/Magnum/Timeline.h
+++ b/src/Magnum/Timeline.h
@@ -134,6 +134,22 @@ class MAGNUM_EXPORT Timeline {
          */
         Float previousFrameDuration() const { return _previousFrameDuration; }
 
+        /**
+         * @brief Time since the last frame (in seconds)
+         *
+         * Returns time elapsed since nextFrame() was called. If the timeline is
+         * stopped, the function returns @cpp 0.0f @ce.
+         */
+        Float currentFrameDuration() const;
+
+        /**
+         * @brief Present time (in seconds)
+         *
+         * Returns time elapsed since start() was called. If the timeline is
+         * stopped, the function returns @cpp 0.0f @ce.
+         */
+        Float currentFrameTime() const;
+
     private:
         std::chrono::high_resolution_clock::time_point _startTime;
         std::chrono::high_resolution_clock::time_point _previousFrameTime;


### PR DESCRIPTION
The Timeline class already has all the data it needs to act as a stopwatch timer.

One example use-case is jitter-correcting framerate throttling when minimized or lacking window focus.