### PR TITLE
Platform: silence Sdl2App warning on <SDL.h>

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.cpp
+++ b/src/Magnum/Platform/Sdl2Application.cpp
@@ -27,6 +27,10 @@
 
 #include "Sdl2Application.h"
 
+#ifdef CORRADE_TARGET_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 #ifdef CORRADE_TARGET_CLANG_CL
 /* SDL does #pragma pack(push,8) and #pragma pack(pop,8) in different headers
    (begin_code.h and end_code.h) and clang-cl doesn't like that, even though it
@@ -37,6 +41,9 @@
 #include <SDL.h>
 #ifdef CORRADE_TARGET_CLANG_CL
 #pragma clang diagnostic pop
+#endif
+#ifdef CORRADE_TARGET_GCC
+#pragma GCC diagnostic pop
 #endif
 #ifndef CORRADE_TARGET_EMSCRIPTEN
 #include <tuple>

--- a/src/Magnum/Platform/Test/Sdl2ApplicationTest.cpp
+++ b/src/Magnum/Platform/Test/Sdl2ApplicationTest.cpp
@@ -34,6 +34,10 @@
 #include "Magnum/Trade/AbstractImporter.h"
 #include "Magnum/Trade/ImageData.h"
 
+#ifdef CORRADE_TARGET_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 #ifdef CORRADE_TARGET_CLANG_CL
 /* SDL does #pragma pack(push,8) and #pragma pack(pop,8) in different headers
    (begin_code.h and end_code.h) and clang-cl doesn't like that, even though it
@@ -44,6 +48,9 @@
 #include <SDL_events.h>
 #ifdef CORRADE_TARGET_CLANG_CL
 #pragma clang diagnostic pop
+#endif
+#ifdef CORRADE_TARGET_GCC
+#pragma GCC diagnostic pop
 #endif
 
 #ifdef MAGNUM_TARGET_GL


### PR DESCRIPTION
Magnum is otherwise clean on `-Wold-style-cast`. This warning is enabled by default on clang, but not presently enabled by default on GCC.