### PR TITLE
GL: Cleanup std::string usage in Shader/AbstractShaderProgram

### DIFF
--- a/src/Magnum/GL/AbstractShaderProgram.h
+++ b/src/Magnum/GL/AbstractShaderProgram.h
@@ -31,8 +31,9 @@
  * @brief Class @ref Magnum::GL::AbstractShaderProgram, macro @ref MAGNUM_GL_ABSTRACTSHADERPROGRAM_SUBCLASS_DRAW_IMPLEMENTATION(), @ref MAGNUM_GL_ABSTRACTSHADERPROGRAM_SUBCLASS_DISPATCH_IMPLEMENTATION()
  */
 
-#include <string>
 #include <Corrade/Containers/ArrayView.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Containers/StringView.h>
 
 #include "Magnum/Tags.h"
 #include "Magnum/GL/AbstractObject.h"
@@ -40,7 +41,7 @@
 #include "Magnum/GL/GL.h"
 
 #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_GLES2)
-#include <vector>
+#include <Corrade/Containers/Array.h>
 #endif
 
 #ifdef MAGNUM_BUILD_DEPRECATED
@@ -832,7 +833,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          *      @def_gl{VALIDATE_STATUS}, @def_gl{INFO_LOG_LENGTH},
          *      @fn_gl_keyword{GetProgramInfoLog}
          */
-        std::pair<bool, std::string> validate();
+        Containers::Pair<bool, Containers::String> validate();
 
         /**
          * @brief Draw a mesh
@@ -1433,7 +1434,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          *      @ref GL-AbstractShaderProgram-attribute-location "class documentation"
          *      for more information.
          */
-        void bindAttributeLocation(UnsignedInt location, const std::string& name) {
+        void bindAttributeLocation(UnsignedInt location, Containers::StringView name) {
             bindAttributeLocationInternal(location, {name.data(), name.size()});
         }
 
@@ -1462,7 +1463,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          * @requires_gl Multiple blend function inputs are not available in
          *      OpenGL ES or WebGL.
          */
-        void bindFragmentDataLocationIndexed(UnsignedInt location, UnsignedInt index, const std::string& name) {
+        void bindFragmentDataLocationIndexed(UnsignedInt location, UnsignedInt index, Containers::StringView name) {
             bindFragmentDataLocationIndexedInternal(location, index, {name.data(), name.size()});
         }
 
@@ -1489,7 +1490,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          *      in OpenGL ES 2.0 and @webgl_extension{WEBGL,draw_buffers} in
          *      WebGL 1.0.
          */
-        void bindFragmentDataLocation(UnsignedInt location, const std::string& name) {
+        void bindFragmentDataLocation(UnsignedInt location, Containers::StringView name) {
             bindFragmentDataLocationInternal(location, {name.data(), name.size()});
         }
 
@@ -1532,8 +1533,8 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          * @requires_gl Special output names `gl_NextBuffer` and
          *      `gl_SkipComponents#` are not available in OpenGL ES or WebGL.
          */
-        void setTransformFeedbackOutputs(Containers::ArrayView<const std::string> outputs, TransformFeedbackBufferMode bufferMode);
-        void setTransformFeedbackOutputs(std::initializer_list<std::string> outputs, TransformFeedbackBufferMode bufferMode); /**< @overload */
+        void setTransformFeedbackOutputs(Containers::ArrayView<const Containers::String> outputs, TransformFeedbackBufferMode bufferMode);
+        void setTransformFeedbackOutputs(std::initializer_list<Containers::String> outputs, TransformFeedbackBufferMode bufferMode); /**< @overload */
         #endif
 
         /**
@@ -1601,7 +1602,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          *      @ref GL-AbstractShaderProgram-uniform-location "class documentation"
          *      for more information.
          */
-        Int uniformLocation(const std::string& name) {
+        Int uniformLocation(Containers::StringView name) {
             return uniformLocationInternal({name.data(), name.size()});
         }
 
@@ -1627,7 +1628,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
          *      @ref GL-AbstractShaderProgram-uniform-block-binding "class documentation"
          *      for more information.
          */
-        UnsignedInt uniformBlockIndex(const std::string& name) {
+        UnsignedInt uniformBlockIndex(Containers::StringView name) {
             return uniformBlockIndexInternal({name.data(), name.size()});
         }
 
@@ -1920,18 +1921,18 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
         UnsignedInt uniformBlockIndexInternal(Containers::ArrayView<const char> name);
 
         #ifndef MAGNUM_TARGET_GLES2
-        void MAGNUM_GL_LOCAL transformFeedbackVaryingsImplementationDefault(Containers::ArrayView<const std::string> outputs, TransformFeedbackBufferMode bufferMode);
+        void MAGNUM_GL_LOCAL transformFeedbackVaryingsImplementationDefault(Containers::ArrayView<const Containers::String> outputs, TransformFeedbackBufferMode bufferMode);
         #ifdef CORRADE_TARGET_WINDOWS
-        void MAGNUM_GL_LOCAL transformFeedbackVaryingsImplementationDanglingWorkaround(Containers::ArrayView<const std::string> outputs, TransformFeedbackBufferMode bufferMode);
+        void MAGNUM_GL_LOCAL transformFeedbackVaryingsImplementationDanglingWorkaround(Containers::ArrayView<const Containers::String> outputs, TransformFeedbackBufferMode bufferMode);
         #endif
         #endif
 
-        static MAGNUM_GL_LOCAL void cleanLogImplementationNoOp(std::string& message);
+        static MAGNUM_GL_LOCAL void cleanLogImplementationNoOp(Containers::String& message);
         #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_GLES)
-        static MAGNUM_GL_LOCAL void cleanLogImplementationIntelWindows(std::string& message);
+        static MAGNUM_GL_LOCAL void cleanLogImplementationIntelWindows(Containers::String& message);
         #endif
         #if defined(MAGNUM_TARGET_GLES) && !defined(MAGNUM_TARGET_WEBGL)
-        static MAGNUM_GL_LOCAL void cleanLogImplementationAngle(std::string& message);
+        static MAGNUM_GL_LOCAL void cleanLogImplementationAngle(Containers::String& message);
         #endif
 
         MAGNUM_GL_LOCAL static void APIENTRY completionStatusImplementationFallback(GLuint, GLenum, GLint*);
@@ -2009,7 +2010,7 @@ class MAGNUM_GL_EXPORT AbstractShaderProgram: public AbstractObject {
         #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_GLES2)
         /* Needed for the nv-windows-dangling-transform-feedback-varying-names
            workaround */
-        std::vector<std::string> _transformFeedbackVaryingNames;
+        Containers::Array<Containers::String> _transformFeedbackVaryingNames;
         #endif
 };
 

--- a/src/Magnum/GL/Implementation/ShaderProgramState.h
+++ b/src/Magnum/GL/Implementation/ShaderProgramState.h
@@ -46,9 +46,9 @@ struct ShaderProgramState {
     void reset();
 
     #ifndef MAGNUM_TARGET_GLES2
-    void(AbstractShaderProgram::*transformFeedbackVaryingsImplementation)(Containers::ArrayView<const std::string>, AbstractShaderProgram::TransformFeedbackBufferMode);
+    void(AbstractShaderProgram::*transformFeedbackVaryingsImplementation)(Containers::ArrayView<const Containers::String>, AbstractShaderProgram::TransformFeedbackBufferMode);
     #endif
-    void(*cleanLogImplementation)(std::string&);
+    void(*cleanLogImplementation)(Containers::String&);
     /* This is a direct pointer to a GL function, so needs a __stdcall on
        Windows to compile properly on 32 bits */
     void(APIENTRY *completionStatusImplementation)(GLuint, GLenum, GLint* value);

--- a/src/Magnum/GL/Implementation/ShaderState.h
+++ b/src/Magnum/GL/Implementation/ShaderState.h
@@ -52,8 +52,8 @@ struct ShaderState {
         #endif
     };
 
-    void(Shader::*addSourceImplementation)(std::string);
-    void(*cleanLogImplementation)(std::string&);
+    void(Shader::*addSourceImplementation)(Containers::StringView);
+    void(*cleanLogImplementation)(Containers::String&);
     /* This is a direct pointer to a GL function, so needs a __stdcall on
        Windows to compile properly on 32 bits */
     void(APIENTRY *completionStatusImplementation)(GLuint, GLenum, GLint* value);

--- a/src/Magnum/GL/Shader.h
+++ b/src/Magnum/GL/Shader.h
@@ -30,9 +30,10 @@
  * @brief Class @ref Magnum::GL::Shader
  */
 
-#include <string>
-#include <vector>
+#include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/ArrayView.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Containers/StringView.h>
 
 #include "Magnum/Tags.h"
 #include "Magnum/GL/AbstractObject.h"
@@ -646,7 +647,7 @@ class MAGNUM_GL_EXPORT Shader: public AbstractObject {
         Type type() const { return _type; }
 
         /** @brief Shader sources */
-        std::vector<std::string> sources() const;
+        const Containers::Array<Containers::String>& sources() const;
 
         /**
          * @brief Add shader source
@@ -658,7 +659,7 @@ class MAGNUM_GL_EXPORT Shader: public AbstractObject {
          * @ref GL-Shader-errors "compilation error reporting".
          * @see @ref addFile()
          */
-        Shader& addSource(std::string source);
+        Shader& addSource(Containers::StringView source);
 
         /**
          * @brief Add shader source file
@@ -668,7 +669,7 @@ class MAGNUM_GL_EXPORT Shader: public AbstractObject {
          * The file must exist and must be readable. Calls @ref addSource()
          * with the contents.
          */
-        Shader& addFile(const std::string& filename);
+        Shader& addFile(Containers::StringView filename);
 
         /**
          * @brief Compile the shader
@@ -745,14 +746,14 @@ class MAGNUM_GL_EXPORT Shader: public AbstractObject {
     private:
         explicit Shader(Type type, GLuint id, ObjectFlags flags) noexcept;
 
-        void MAGNUM_GL_LOCAL addSourceImplementationDefault(std::string source);
+        void MAGNUM_GL_LOCAL addSourceImplementationDefault(Containers::StringView source);
         #if defined(CORRADE_TARGET_EMSCRIPTEN) && defined(__EMSCRIPTEN_PTHREADS__)
-        void MAGNUM_GL_LOCAL addSourceImplementationEmscriptenPthread(std::string source);
+        void MAGNUM_GL_LOCAL addSourceImplementationEmscriptenPthread(Containers::StringView source);
         #endif
 
-        static MAGNUM_GL_LOCAL void cleanLogImplementationNoOp(std::string& message);
+        static MAGNUM_GL_LOCAL void cleanLogImplementationNoOp(Containers::String& message);
         #if defined(CORRADE_TARGET_WINDOWS) && !defined(MAGNUM_TARGET_GLES)
-        static MAGNUM_GL_LOCAL void cleanLogImplementationIntelWindows(std::string& message);
+        static MAGNUM_GL_LOCAL void cleanLogImplementationIntelWindows(Containers::String& message);
         #endif
 
         MAGNUM_GL_LOCAL static void APIENTRY completionStatusImplementationFallback(GLuint, GLenum, GLint*);
@@ -765,7 +766,7 @@ class MAGNUM_GL_EXPORT Shader: public AbstractObject {
         bool _offsetLineByOneOnOldGlsl;
         #endif
 
-        std::vector<std::string> _sources;
+        Containers::Array<Containers::String> _sources;
 };
 
 /** @debugoperatorclassenum{Shader,Shader::Type} */

--- a/src/Magnum/GL/Test/AbstractShaderProgramGLTest.cpp
+++ b/src/Magnum/GL/Test/AbstractShaderProgramGLTest.cpp
@@ -25,6 +25,7 @@
 
 #include <sstream>
 #include <Corrade/Containers/Iterable.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/Reference.h>
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Containers/StringStl.h> /** @todo remove when Shader is <string>-free */
@@ -281,7 +282,7 @@ void AbstractShaderProgramGLTest::create() {
 
     program.bindAttributeLocation(0, "position");
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
@@ -356,7 +357,7 @@ void AbstractShaderProgramGLTest::createAsync() {
 
     CORRADE_VERIFY(program.checkLink({vert, frag}));
     CORRADE_VERIFY(program.isLinkFinished());
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     {
@@ -418,7 +419,7 @@ void AbstractShaderProgramGLTest::createMultipleOutputs() {
     program.bindFragmentDataLocation(0, "first");
     program.bindFragmentDataLocation(1, "second");
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
@@ -477,7 +478,7 @@ void AbstractShaderProgramGLTest::createMultipleOutputsIndexed() {
     program.bindFragmentDataLocationIndexed(0, 0, "first");
     program.bindFragmentDataLocationIndexed(0, 1, "second");
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);
@@ -921,7 +922,7 @@ void AbstractShaderProgramGLTest::createUniformBlocks() {
     MAGNUM_VERIFY_NO_GL_ERROR();
 
     const bool linked = program.link();
-    const bool valid = program.validate().first;
+    const bool valid = program.validate().first();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_VERIFY(linked);

--- a/src/Magnum/GL/Test/ShaderGLTest.cpp
+++ b/src/Magnum/GL/Test/ShaderGLTest.cpp
@@ -123,9 +123,9 @@ void ShaderGLTest::construct() {
         CORRADE_VERIFY(shader.id() > 0);
         CORRADE_COMPARE(shader.type(), Shader::Type::Fragment);
         #ifndef MAGNUM_TARGET_GLES
-        CORRADE_COMPARE(shader.sources(), std::vector<std::string>{"#version 130\n"});
+        CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {"#version 130\n"}}));
         #else
-        CORRADE_COMPARE(shader.sources(), std::vector<std::string>{"#version 300 es\n"});
+        CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {"#version 300 es\n"})});
         #endif
     }
 
@@ -134,7 +134,7 @@ void ShaderGLTest::construct() {
 
 void ShaderGLTest::constructNoVersion() {
     const Shader shader(Version::None, Shader::Type::Fragment);
-    CORRADE_VERIFY(shader.sources().empty());
+    CORRADE_VERIFY(shader.sources().isEmpty());
 }
 
 void ShaderGLTest::constructMove() {
@@ -154,9 +154,9 @@ void ShaderGLTest::constructMove() {
     CORRADE_COMPARE(b.id(), id);
     CORRADE_COMPARE(b.type(), Shader::Type::Fragment);
     #ifndef MAGNUM_TARGET_GLES
-    CORRADE_COMPARE(b.sources(), std::vector<std::string>{"#version 130\n"});
+    CORRADE_COMPARE(b.sources(), (Containers::Array<Containers::String>{InPlaceInit, {"#version 130\n"}}));
     #else
-    CORRADE_COMPARE(b.sources(), std::vector<std::string>{"#version 300 es\n"});
+    CORRADE_COMPARE(b.sources(), (Containers::Array<Containers::String>{InPlaceInit, {"#version 300 es\n"}}));
     #endif
 
     #ifndef MAGNUM_TARGET_GLES
@@ -173,9 +173,9 @@ void ShaderGLTest::constructMove() {
     CORRADE_COMPARE(c.id(), id);
     CORRADE_COMPARE(c.type(), Shader::Type::Fragment);
     #ifndef MAGNUM_TARGET_GLES
-    CORRADE_COMPARE(c.sources(), std::vector<std::string>{"#version 130\n"});
+    CORRADE_COMPARE(c.sources(), (Containers::Array<Containers::String>{InPlaceInit, {"#version 130\n"}}));
     #else
-    CORRADE_COMPARE(c.sources(), std::vector<std::string>{"#version 300 es\n"});
+    CORRADE_COMPARE(c.sources(), (Containers::Array<Containers::String>{InPlaceInit, {"#version 300 es\n"}}));
     #endif
 
     CORRADE_VERIFY(std::is_nothrow_move_constructible<Shader>::value);
@@ -232,7 +232,7 @@ void ShaderGLTest::addSource() {
           .addSource("void main() {}\n");
 
     #ifndef MAGNUM_TARGET_GLES
-    CORRADE_COMPARE(shader.sources(), (std::vector<std::string>{
+    CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {
         "#version 120\n",
         /* On (desktop) GLSL < 330 the #line affect next line, not current
            line; see compileFailure() for a correctness verification */
@@ -240,15 +240,15 @@ void ShaderGLTest::addSource() {
         "#define FOO BAR\n",
         "#line 0 2\n",
         "void main() {}\n"
-    }));
+    }}));
     #else
-    CORRADE_COMPARE(shader.sources(), (std::vector<std::string>{
+    CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {
         "#version 100\n",
         "#line 1 1\n",
         "#define FOO BAR\n",
         "#line 1 2\n",
         "void main() {}\n"
-    }));
+    }}));
     #endif
 }
 
@@ -264,7 +264,7 @@ void ShaderGLTest::addSourceNoVersion() {
           .addSource("void main() {}\n");
 
     #ifndef MAGNUM_TARGET_GLES
-    CORRADE_COMPARE(shader.sources(), (std::vector<std::string>{
+    CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {
         "",
         /* Here, even though there's #version 120 eventually added by the user,
            it assumes the specified version was new GLSL, not old. Explicitly
@@ -275,16 +275,16 @@ void ShaderGLTest::addSourceNoVersion() {
         "#define FOO BAR\n",
         "#line 1 2\n",
         "void main() {}\n"
-    }));
+    }}));
     #else
-    CORRADE_COMPARE(shader.sources(), (std::vector<std::string>{
+    CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {
         "",
         "#version 100\n",
         "#line 1 1\n",
         "#define FOO BAR\n",
         "#line 1 2\n",
         "void main() {}\n"
-    }));
+    }}));
     #endif
 }
 
@@ -298,19 +298,19 @@ void ShaderGLTest::addFile() {
     shader.addFile(Utility::Path::join(SHADERGLTEST_FILES_DIR, "shader.glsl"));
 
     #ifndef MAGNUM_TARGET_GLES
-    CORRADE_COMPARE(shader.sources(), (std::vector<std::string>{
+    CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {
         "#version 120\n",
         /* On (desktop) GLSL < 330 the #line affect next line, not current
            line; see compileFailure() for a correctness verification */
         "#line 0 1\n",
         "void main() {}\n"
-    }));
+    }}));
     #else
-    CORRADE_COMPARE(shader.sources(), (std::vector<std::string>{
+    CORRADE_COMPARE(shader.sources(), (Containers::Array<Containers::String>{InPlaceInit, {
         "#version 100\n",
         "#line 1 1\n",
         "void main() {}\n"
-    }));
+    }}));
     #endif
 }
 

--- a/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
+++ b/src/Magnum/GL/Test/TransformFeedbackGLTest.cpp
@@ -23,9 +23,11 @@
     DEALINGS IN THE SOFTWARE.
 */
 
+#include <string>
 #include <Corrade/Containers/Iterable.h>
 #include <Corrade/Containers/Reference.h>
 #include <Corrade/Containers/Triple.h>
+#include <Corrade/Utility/Format.h>
 
 #include "Magnum/Image.h"
 #include "Magnum/GL/AbstractShaderProgram.h"
@@ -618,11 +620,11 @@ void TransformFeedbackGLTest::draw() {
                 "    vertexOutput = vec2(0.3);\n"
                 "    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);\n"
                 "}\n");
-            if(stream) geom.addSource(
+            if(stream) geom.addSource(Utility::format(
                 "#extension GL_ARB_gpu_shader5: require\n"
-                "#define STREAM " + std::to_string(stream) + "\n" +
-                "layout(stream = 0) out mediump float otherOutput;\n" +
-                "layout(stream = STREAM) out mediump vec2 geomOutput;\n");
+                "#define STREAM {}\n"
+                "layout(stream = 0) out mediump float otherOutput;\n"
+                "layout(stream = STREAM) out mediump vec2 geomOutput;\n", stream));
             else geom.addSource(
                 "out mediump vec2 geomOutput;\n");
             geom.addSource(

--- a/src/Magnum/Shaders/Test/DistanceFieldVectorGLTest.cpp
+++ b/src/Magnum/Shaders/Test/DistanceFieldVectorGLTest.cpp
@@ -382,7 +382,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -406,7 +406,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::constructAsync(
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -449,7 +449,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::constructUnifor
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -484,7 +484,7 @@ template<UnsignedInt dimensions> void DistanceFieldVectorGLTest::constructUnifor
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/FlatGLTest.cpp
+++ b/src/Magnum/Shaders/Test/FlatGLTest.cpp
@@ -861,7 +861,7 @@ template<UnsignedInt dimensions> void FlatGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -885,7 +885,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -932,7 +932,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructUniformBuffers() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -966,7 +966,7 @@ template<UnsignedInt dimensions> void FlatGLTest::constructUniformBuffersAsync()
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/MeshVisualizerGLTest.cpp
+++ b/src/Magnum/Shaders/Test/MeshVisualizerGLTest.cpp
@@ -1411,7 +1411,7 @@ void MeshVisualizerGLTest::construct2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1434,7 +1434,7 @@ void MeshVisualizerGLTest::construct2DAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1515,7 +1515,7 @@ void MeshVisualizerGLTest::constructUniformBuffers2D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1549,7 +1549,7 @@ void MeshVisualizerGLTest::constructUniformBuffers2DAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1611,7 +1611,7 @@ void MeshVisualizerGLTest::construct3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1633,7 +1633,7 @@ void MeshVisualizerGLTest::construct3DAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1714,7 +1714,7 @@ void MeshVisualizerGLTest::constructUniformBuffers3D() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1747,7 +1747,7 @@ void MeshVisualizerGLTest::constructUniformBuffers3DAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/PhongGLTest.cpp
+++ b/src/Magnum/Shaders/Test/PhongGLTest.cpp
@@ -1196,7 +1196,7 @@ void PhongGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1221,7 +1221,7 @@ void PhongGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1268,7 +1268,7 @@ void PhongGLTest::constructUniformBuffers() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -1304,7 +1304,7 @@ void PhongGLTest::constructUniformBuffersAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/VectorGLTest.cpp
+++ b/src/Magnum/Shaders/Test/VectorGLTest.cpp
@@ -378,7 +378,7 @@ template<UnsignedInt dimensions> void VectorGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -402,7 +402,7 @@ template<UnsignedInt dimensions> void VectorGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -445,7 +445,7 @@ template<UnsignedInt dimensions> void VectorGLTest::constructUniformBuffers() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -480,7 +480,7 @@ template<UnsignedInt dimensions> void VectorGLTest::constructUniformBuffersAsync
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/Magnum/Shaders/Test/VertexColorGLTest.cpp
+++ b/src/Magnum/Shaders/Test/VertexColorGLTest.cpp
@@ -314,7 +314,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::construct() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -335,7 +335,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::constructAsync() {
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -377,7 +377,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::constructUniformBuffers
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();
@@ -409,7 +409,7 @@ template<UnsignedInt dimensions> void VertexColorGLTest::constructUniformBuffers
         #if defined(CORRADE_TARGET_APPLE) && !defined(MAGNUM_TARGET_GLES)
         CORRADE_EXPECT_FAIL("macOS drivers need insane amount of state to validate properly.");
         #endif
-        CORRADE_VERIFY(shader.validate().first);
+        CORRADE_VERIFY(shader.validate().first());
     }
 
     MAGNUM_VERIFY_NO_GL_ERROR();


### PR DESCRIPTION
I stumbled on this remaining usage of `std::string`, `std::vector` and `std::pair` so I'm giving a shot at migrating it.

Not sure exactly yet what's the backwards compatibility strategy to employ here, so I'm kind of opening this PR to figure it out, hope it's not too much of a bother!