### PR TITLE
Fix Emscripten TextureImage.cpp no deprecated build

### DIFF
--- a/src/Magnum/DebugTools/TextureImage.cpp
+++ b/src/Magnum/DebugTools/TextureImage.cpp
@@ -37,6 +37,7 @@
 #if defined(MAGNUM_TARGET_GLES) && !defined(MAGNUM_TARGET_GLES2)
 #include <Corrade/Containers/Iterable.h>
 #include <Corrade/Containers/Reference.h>
+#include <Corrade/Containers/StringView.h>
 #include <Corrade/Utility/Resource.h>
 
 #include "Magnum/GL/AbstractShaderProgram.h"
@@ -56,7 +57,7 @@ static void importDebugToolsResources() {
 namespace Magnum { namespace DebugTools {
 
 #if defined(MAGNUM_TARGET_GLES) && !defined(MAGNUM_TARGET_GLES2)
-using namespace Containers::Literals;
+using namespace Corrade::Containers::Literals;
 
 namespace {
 


### PR DESCRIPTION
The Emscripten build in non-deprecated mode is broken due to this file, this seems to be the only issue with that build configuration