### PR TITLE
debugger/natvis additions for Vector, Quaternion, Deg & Rad types

### DIFF
--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -132,10 +132,21 @@
     <DisplayString IncludeView="simple">{{ {hue._value,g}, {saturation,g}, {value,g} }}</DisplayString>
     <DisplayString ExcludeView="simple">{{ h={hue._value,g} s={saturation,g} v={value,g} }}</DisplayString>
   </Type>
-  <!-- Math::Quaternion -->
-  <Type Name="Magnum::Math::Quaternion&lt;*&gt;">
+  <!-- Math::Quaternion< Float > -->
+  <Type Name="Magnum::Math::Quaternion&lt;float&gt;">
+    <Intrinsic Name="Dot" Expression="_vector._data[0]*_vector._data[0]+_vector._data[1]*_vector._data[1]+_vector._data[2]*_vector._data[2]+_scalar*_scalar"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_vector._data[0],g}, {_vector._data[1],g}, {_vector._data[2],g}, {_scalar,g} }}</DisplayString>
-    <DisplayString ExcludeView="simple">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT QUATERNION x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
+  </Type>
+  <!-- Math::Quaternion< Double > -->
+  <Type Name="Magnum::Math::Quaternion&lt;double&gt;">
+    <Intrinsic Name="Dot" Expression="_vector._data[0]*_vector._data[0]+_vector._data[1]*_vector._data[1]+_vector._data[2]*_vector._data[2]+_scalar*_scalar"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_vector._data[0],g}, {_vector._data[1],g}, {_vector._data[2],g}, {_scalar,g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT QUATERNION x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
   </Type>
   <!-- Math::RectangularMatrix -->
   <Type Name="Magnum::Math::RectangularMatrix&lt;*&gt;">

--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -161,24 +161,14 @@
       </ArrayItems>
     </Expand>
   </Type>
-  <!-- Magnum::Math::Deg< Float > -->
-  <Type Name="Magnum::Math::Deg&lt;float&gt;">
-    <DisplayString IncludeView="simple">{_value,g}° ({_value * 3.14159274f / 180.0f,g} radians)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,g}° ({_value * 3.14159274f / 180.0f,g} radians)</DisplayString>
+  <!-- Magnum::Math::Deg -->
+  <Type Name="Magnum::Math::Deg&lt;*&gt;">
+    <DisplayString IncludeView="simple">{_value,g}° ({_value * 3.1415926535897931 / 180.0,g} radians)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,g}° ({_value * 3.1415926535897931 / 180.0,g} radians)</DisplayString>
   </Type>
-  <!-- Magnum::Math::Deg< Double > -->
-  <Type Name="Magnum::Math::Deg&lt;double&gt;">
-    <DisplayString IncludeView="simple">{_value,h}° ({_value * 3.1415926535897931 / 180.0,h} radians)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,h}° ({_value * 3.1415926535897931 / 180.0,h} radians)</DisplayString>
-  </Type>
-  <!-- Magnum::Math::Rad< Float > -->
-  <Type Name="Magnum::Math::Rad&lt;float&gt;">
-    <DisplayString IncludeView="simple">{_value,g} radians ({180.0f * _value / 3.14159274f,g}°)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,g} radians ({180.0f * _value / 3.14159274f,g}°)</DisplayString>
-  </Type>
-  <!-- Magnum::Math::Rad< Double > -->
-  <Type Name="Magnum::Math::Rad&lt;double&gt;">
-    <DisplayString IncludeView="simple">{_value,h} radians ({180.0 * _value / 3.1415926535897931,h}°)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,h} radians ({180.0 * _value / 3.1415926535897931,h}°)</DisplayString>
+  <!-- Magnum::Math::Rad -->
+  <Type Name="Magnum::Math::Rad&lt;*&gt;">
+    <DisplayString IncludeView="simple">{_value,g} radians ({180.0 * _value / 3.1415926535897931,g}°)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,g} radians ({180.0 * _value / 3.1415926535897931,g}°)</DisplayString>
   </Type>
 </AutoVisualizer>

--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -7,6 +7,7 @@
                 2020, 2021, 2022, 2023 Vladimír Vondruš <mosra@centrum.cz>
     Copyright © 2021 Jonathan Hale <squareys@googlemail.com>
     Copyright © 2023 Pablo Escobar <mail@rvrs.in>
+    Copyright © 2023 Burak Canik <canik.burak@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -159,5 +160,25 @@
         <ValuePointer>($T3 *)_data</ValuePointer>
       </ArrayItems>
     </Expand>
+  </Type>
+  <!-- Magnum::Math::Deg< Float > -->
+  <Type Name="Magnum::Math::Deg&lt;float&gt;">
+    <DisplayString IncludeView="simple">{_value,g}° ({_value * 0.0174532924,g} radians)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,g}° ({_value * 0.0174532924,g} radians)</DisplayString>
+  </Type>
+  <!-- Magnum::Math::Deg< Double > -->
+  <Type Name="Magnum::Math::Deg&lt;double&gt;">
+    <DisplayString IncludeView="simple">{_value,h}° ({_value * 0.017453292519943295,h} radians)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,h}° ({_value * 0.017453292519943295,h} radians)</DisplayString>
+  </Type>
+  <!-- Magnum::Math::Rad< Float > -->
+  <Type Name="Magnum::Math::Rad&lt;float&gt;">
+    <DisplayString IncludeView="simple">{_value,g} radians ({_value * 57.2957764,g}°)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,g} radians ({_value * 57.2957764,g}°)</DisplayString>
+  </Type>
+  <!-- Magnum::Math::Rad< Double > -->
+  <Type Name="Magnum::Math::Rad&lt;double&gt;">
+    <DisplayString IncludeView="simple">{_value,h} radians ({_value * 57.295779513082323,h}°)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,h} radians ({_value * 57.295779513082323,h}°)</DisplayString>
   </Type>
 </AutoVisualizer>

--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -38,15 +38,63 @@
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} }}</DisplayString>
     <DisplayString ExcludeView="simple">{{ x={_data[0],g} y={_data[1],g} }}</DisplayString>
   </Type>
+  <!-- Math::Vector2< Float > -->
+  <Type Name="Magnum::Math::Vector&lt;2,float&gt;">
+    <Intrinsic Name="Dot" Expression="_data[0]*_data[0]+_data[1]*_data[1]"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} }}</DisplayString>
+  </Type>
+  <!-- Math::Vector2< Double > -->
+  <Type Name="Magnum::Math::Vector&lt;2,double&gt;">
+    <Intrinsic Name="Dot" Expression="_data[0]*_data[0]+_data[1]*_data[1]"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} }}</DisplayString>
+  </Type>
   <!-- Math::Vector3 -->
   <Type Name="Magnum::Math::Vector&lt;3,*&gt;">
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g}, {_data[2],g} }}</DisplayString>
     <DisplayString ExcludeView="simple">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
   </Type>
+  <!-- Math::Vector3< Float > -->
+  <Type Name="Magnum::Math::Vector&lt;3,float&gt;">
+    <Intrinsic Name="Dot" Expression="_data[0]*_data[0]+_data[1]*_data[1]+_data[2]*_data[2]"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
+  </Type>
+  <!-- Math::Vector3< Double > -->
+  <Type Name="Magnum::Math::Vector&lt;3,double&gt;">
+    <Intrinsic Name="Dot" Expression="_data[0]*_data[0]+_data[1]*_data[1]+_data[2]*_data[2]"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
+  </Type>
   <!-- Math::Vector4 -->
   <Type Name="Magnum::Math::Vector&lt;4,*&gt;">
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g}, {_data[2],g}, {_data[3],g} }}</DisplayString>
     <DisplayString ExcludeView="simple">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
+  </Type>
+  <!-- Math::Vector4< Float > -->
+  <Type Name="Magnum::Math::Vector&lt;4,float&gt;">
+    <Intrinsic Name="Dot" Expression="_data[0]*_data[0]+_data[1]*_data[1]+_data[2]*_data[2]+_data[3]*_data[3]"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} {_data[3],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
+  </Type>
+  <!-- Math::Vector4< Double > -->
+  <Type Name="Magnum::Math::Vector&lt;4,double&gt;">
+    <Intrinsic Name="Dot" Expression="_data[0]*_data[0]+_data[1]*_data[1]+_data[2]*_data[2]+_data[3]*_data[3]"></Intrinsic>
+    <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
+    <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} {_data[3],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
   </Type>
   <!-- Math::BitVector2 -->
   <Type Name="Magnum::Math::BitVector&lt;2&gt;">

--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -163,22 +163,22 @@
   </Type>
   <!-- Magnum::Math::Deg< Float > -->
   <Type Name="Magnum::Math::Deg&lt;float&gt;">
-    <DisplayString IncludeView="simple">{_value,g}° ({_value * 0.0174532924,g} radians)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,g}° ({_value * 0.0174532924,g} radians)</DisplayString>
+    <DisplayString IncludeView="simple">{_value,g}° ({_value * 3.14159274f / 180.0f,g} radians)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,g}° ({_value * 3.14159274f / 180.0f,g} radians)</DisplayString>
   </Type>
   <!-- Magnum::Math::Deg< Double > -->
   <Type Name="Magnum::Math::Deg&lt;double&gt;">
-    <DisplayString IncludeView="simple">{_value,h}° ({_value * 0.017453292519943295,h} radians)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,h}° ({_value * 0.017453292519943295,h} radians)</DisplayString>
+    <DisplayString IncludeView="simple">{_value,h}° ({_value * 3.1415926535897931 / 180.0,h} radians)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,h}° ({_value * 3.1415926535897931 / 180.0,h} radians)</DisplayString>
   </Type>
   <!-- Magnum::Math::Rad< Float > -->
   <Type Name="Magnum::Math::Rad&lt;float&gt;">
-    <DisplayString IncludeView="simple">{_value,g} radians ({_value * 57.2957764,g}°)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,g} radians ({_value * 57.2957764,g}°)</DisplayString>
+    <DisplayString IncludeView="simple">{_value,g} radians ({180.0f * _value / 3.14159274f,g}°)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,g} radians ({180.0f * _value / 3.14159274f,g}°)</DisplayString>
   </Type>
   <!-- Magnum::Math::Rad< Double > -->
   <Type Name="Magnum::Math::Rad&lt;double&gt;">
-    <DisplayString IncludeView="simple">{_value,h} radians ({_value * 57.295779513082323,h}°)</DisplayString>
-    <DisplayString ExcludeView="simple">{_value,h} radians ({_value * 57.295779513082323,h}°)</DisplayString>
+    <DisplayString IncludeView="simple">{_value,h} radians ({180.0 * _value / 3.1415926535897931,h}°)</DisplayString>
+    <DisplayString ExcludeView="simple">{_value,h} radians ({180.0 * _value / 3.1415926535897931,h}°)</DisplayString>
   </Type>
 </AutoVisualizer>

--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -45,7 +45,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_data[0],g} y={_data[1],g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::Vector2< Double > -->
   <Type Name="Magnum::Math::Vector&lt;2,double&gt;">
@@ -53,7 +53,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_data[0],g} y={_data[1],g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::Vector3 -->
   <Type Name="Magnum::Math::Vector&lt;3,*&gt;">
@@ -66,7 +66,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::Vector3< Double > -->
   <Type Name="Magnum::Math::Vector&lt;3,double&gt;">
@@ -74,7 +74,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::Vector4 -->
   <Type Name="Magnum::Math::Vector&lt;4,*&gt;">
@@ -87,7 +87,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} {_data[3],g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::Vector4< Double > -->
   <Type Name="Magnum::Math::Vector&lt;4,double&gt;">
@@ -95,7 +95,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_data[0],g}, {_data[1],g} {_data[2],g} {_data[3],g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT VECTOR x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_data[0],g} y={_data[1],g} z={_data[2],g} w={_data[3],g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::BitVector2 -->
   <Type Name="Magnum::Math::BitVector&lt;2&gt;">

--- a/src/debuggers/natvis/magnum.natvis
+++ b/src/debuggers/natvis/magnum.natvis
@@ -139,7 +139,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99980000000500002&amp;Dot()&lt;1.0001999999950000"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_vector._data[0],g}, {_vector._data[1],g}, {_vector._data[2],g}, {_scalar,g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT QUATERNION x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::Quaternion< Double > -->
   <Type Name="Magnum::Math::Quaternion&lt;double&gt;">
@@ -147,7 +147,7 @@
     <Intrinsic Name="IsNormalized" Expression="Dot()&gt;0.99999999999998002&amp;Dot()&lt;1.0000000000000200"></Intrinsic>
     <DisplayString IncludeView="simple">{{ {_vector._data[0],g}, {_vector._data[1],g}, {_vector._data[2],g}, {_scalar,g} }}</DisplayString>
     <DisplayString ExcludeView="simple" Condition="!IsNormalized()">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
-    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ UNIT QUATERNION x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} }}</DisplayString>
+    <DisplayString ExcludeView="simple" Condition="IsNormalized()">{{ x={_vector._data[0],g} y={_vector._data[1],g} z={_vector._data[2],g} w={_scalar,g} (normalized) }}</DisplayString>
   </Type>
   <!-- Math::RectangularMatrix -->
   <Type Name="Magnum::Math::RectangularMatrix&lt;*&gt;">


### PR DESCRIPTION
Many thanks to @pezcode for the initial work he did. I also stole that file and used it in my own opengl framework repo 🙏

I've made some modifications to the magnum.natvis file in order to augment debug visualization for:

- `Vector` & `Quaternion` types: to display whether they are normalized (i.e, unit vectors/quaternions) or not,
- Angle (`Deg` & `Rad`) types: to display the current value nicely (with degrees symbol for `Deg` & `radians` suffix for `Rad`) as well as display the other equivalent angle value (`Rad` for `Deg` & `Deg` for `Rad` respectively) in parentheses.

Magnum's epsilon (from `Magnum::Math::TypeTraits`) values were utilized for unit vector queries, by creating two intrinsic .natvis functions `Dot()` & `IsNormalized()`, the latter utilizing said epsilons (added to and subtracted from 1.0, as we can not use `abs()` in the .natvis file).

Similarly, `Magnum::Math::Constants<T>::pi()` was used in `Deg`/`Rad` conversions.

Separate `Float` & `Double` variants were added for all types mentioned since they use different epsilons/conversion multipliers.

 `'h'` (hexadecimal integer) format specifier was used for `Radd` & `Degd`, to display more digits in the debugger.
 
 Let me know if you want me to revise anything.