### PR TITLE
Made arguments struct within SDL2application take in (and store) argc by value instead of reference

### DIFF
--- a/src/Magnum/Platform/Sdl2Application.h
+++ b/src/Magnum/Platform/Sdl2Application.h
@@ -484,9 +484,9 @@ class Sdl2Application {
         /** @brief Application arguments */
         struct Arguments {
             /** @brief Constructor */
-            /*implicit*/ constexpr Arguments(int& argc, char** argv) noexcept: argc{argc}, argv{argv} {}
+            /*implicit*/ constexpr Arguments(int argc, char** argv) noexcept: argc{argc}, argv{argv} {}
 
-            int& argc;      /**< @brief Argument count */
+            int argc;       /**< @brief Argument count */
             char** argv;    /**< @brief Argument values */
         };
 


### PR DESCRIPTION
I think this must be left over from a previous version of the software or something, it seems really weird that this struct needs to hold onto argc as a reference, and why it cant just copy it in, its one int, and I have no idea why it would change.