### PR TITLE
Fix use of deprecated UDL syntax

### DIFF
--- a/src/Magnum/Math/Angle.h
+++ b/src/Magnum/Math/Angle.h
@@ -179,7 +179,7 @@ Example usage:
 @see @link operator""_degf() @endlink, @link operator""_rad() @endlink
 @m_keywords{_deg deg}
 */
-constexpr Deg<Double> operator"" _deg(long double value) { return Deg<Double>(Double(value)); }
+constexpr Deg<Double> operator""_deg(long double value) { return Deg<Double>(Double(value)); }
 
 /** @relatesalso Magnum::Math::Deg
 @brief Single-precision degree value literal
@@ -191,7 +191,7 @@ Example usage:
 @see @link operator""_deg() @endlink, @link operator""_radf() @endlink
 @m_keywords{_degf degf}
 */
-constexpr Deg<Float> operator"" _degf(long double value) { return Deg<Float>(Float(value)); }
+constexpr Deg<Float> operator""_degf(long double value) { return Deg<Float>(Float(value)); }
 #if defined(CORRADE_TARGET_CLANG) && __clang_major__ >= 17
 #pragma clang diagnostic pop
 #endif
@@ -279,7 +279,7 @@ See @link operator""_deg() @endlink for more information.
 @see @link operator""_radf() @endlink
 @m_keywords{_rad rad}
 */
-constexpr Rad<Double> operator"" _rad(long double value) { return Rad<Double>(Double(value)); }
+constexpr Rad<Double> operator""_rad(long double value) { return Rad<Double>(Double(value)); }
 
 /** @relatesalso Magnum::Math::Rad
 @brief Single-precision radian value literal
@@ -288,7 +288,7 @@ See @link operator""_degf() @endlink for more information.
 @see @link operator""_rad() @endlink
 @m_keywords{_radf radf}
 */
-constexpr Rad<Float> operator"" _radf(long double value) { return Rad<Float>(Float(value)); }
+constexpr Rad<Float> operator""_radf(long double value) { return Rad<Float>(Float(value)); }
 #if defined(CORRADE_TARGET_CLANG) && __clang_major__ >= 17
 #pragma clang diagnostic pop
 #endif

--- a/src/Magnum/Math/Color.cpp
+++ b/src/Magnum/Math/Color.cpp
@@ -154,16 +154,16 @@ Debug& operator<<(Debug& debug, const Color4<UnsignedByte>& value) {
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
 namespace Literals { inline namespace ColorLiterals {
 
-Color3<Half> operator"" _rgbh(unsigned long long value) {
+Color3<Half> operator""_rgbh(unsigned long long value) {
     return Color3<Half>{Color3<Float>::fromLinearRgbInt(value)};
 }
-Color3<Half> operator"" _srgbh(unsigned long long value) {
+Color3<Half> operator""_srgbh(unsigned long long value) {
     return Color3<Half>{Color3<Float>::fromSrgbInt(value)};
 }
-Color4<Half> operator"" _rgbah(unsigned long long value) {
+Color4<Half> operator""_rgbah(unsigned long long value) {
     return Color4<Half>{Color4<Float>::fromLinearRgbaInt(value)};
 }
-Color4<Half> operator"" _srgbah(unsigned long long value) {
+Color4<Half> operator""_srgbah(unsigned long long value) {
     return Color4<Half>{Color4<Float>::fromSrgbAlphaInt(value)};
 }
 

--- a/src/Magnum/Math/Color.h
+++ b/src/Magnum/Math/Color.h
@@ -1527,11 +1527,11 @@ Unpacks the literal into three 8-bit values. Example usage:
    implementation, so the previous implementation is used instead. See
    ColorTest::literalMsvc2019PermissiveCrash() for details. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-constexpr Color3<UnsignedByte> operator"" _rgb(unsigned long long value) {
+constexpr Color3<UnsignedByte> operator""_rgb(unsigned long long value) {
     return {UnsignedByte(value >> 16), UnsignedByte(value >> 8), UnsignedByte(value)};
 }
 #else
-template<char... chars> constexpr Color3<UnsignedByte> operator"" _rgb() {
+template<char... chars> constexpr Color3<UnsignedByte> operator""_rgb() {
     return Implementation::color3Literal<Color3<UnsignedByte>, 1, sizeof...(chars), chars...>();
 }
 #endif
@@ -1560,11 +1560,11 @@ RGB. Use this literal to document that given value is in sRGB. Example usage:
 /* Output is a Vector3 to hint that it doesn't have any (additive,
    multiplicative) semantics of a linear RGB color. See above for MSVC 2019. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-constexpr Vector3<UnsignedByte> operator"" _srgb(unsigned long long value) {
+constexpr Vector3<UnsignedByte> operator""_srgb(unsigned long long value) {
     return {UnsignedByte(value >> 16), UnsignedByte(value >> 8), UnsignedByte(value)};
 }
 #else
-template<char... chars> constexpr Vector3<UnsignedByte> operator"" _srgb() {
+template<char... chars> constexpr Vector3<UnsignedByte> operator""_srgb() {
     return Implementation::color3Literal<Vector3<UnsignedByte>, 1, sizeof...(chars), chars...>();
 }
 #endif
@@ -1588,11 +1588,11 @@ Unpacks the literal into four 8-bit values. Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-constexpr Color4<UnsignedByte> operator"" _rgba(unsigned long long value) {
+constexpr Color4<UnsignedByte> operator""_rgba(unsigned long long value) {
     return {UnsignedByte(value >> 24), UnsignedByte(value >> 16), UnsignedByte(value >> 8), UnsignedByte(value)};
 }
 #else
-template<char... chars> constexpr Color4<UnsignedByte> operator"" _rgba() {
+template<char... chars> constexpr Color4<UnsignedByte> operator""_rgba() {
     return Implementation::color4Literal<Color4<UnsignedByte>, 1, sizeof...(chars), chars...>();
 }
 #endif
@@ -1622,11 +1622,11 @@ usage:
 /* Output is a Vector3 to hint that it doesn't have any (additive,
    multiplicative) semantics of a linear RGB color. See above for MSVC 2019. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-constexpr Vector4<UnsignedByte> operator"" _srgba(unsigned long long value) {
+constexpr Vector4<UnsignedByte> operator""_srgba(unsigned long long value) {
     return {UnsignedByte(value >> 24), UnsignedByte(value >> 16), UnsignedByte(value >> 8), UnsignedByte(value)};
 }
 #else
-template<char... chars> constexpr Vector4<UnsignedByte> operator"" _srgba() {
+template<char... chars> constexpr Vector4<UnsignedByte> operator""_srgba() {
     return Implementation::color4Literal<Vector4<UnsignedByte>, 1, sizeof...(chars), chars...>();
 }
 #endif
@@ -1651,13 +1651,13 @@ Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-constexpr Color3<Float> operator"" _rgbf(unsigned long long value) {
+constexpr Color3<Float> operator""_rgbf(unsigned long long value) {
     return {((value >> 16) & 0xff)/255.0f,
             ((value >>  8) & 0xff)/255.0f,
             ((value >>  0) & 0xff)/255.0f};
 }
 #else
-template<char... chars> constexpr Color3<Float> operator"" _rgbf() {
+template<char... chars> constexpr Color3<Float> operator""_rgbf() {
     return Implementation::color3Literal<Color3<Float>, 255, sizeof...(chars), chars...>();
 }
 #endif
@@ -1677,11 +1677,11 @@ usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-inline Color3<Float> operator"" _srgbf(unsigned long long value) {
+inline Color3<Float> operator""_srgbf(unsigned long long value) {
     return Color3<Float>::fromSrgbInt(UnsignedInt(value));
 }
 #else
-template<char... chars> inline Color3<Float> operator"" _srgbf() {
+template<char... chars> inline Color3<Float> operator""_srgbf() {
     return Color3<Float>::fromSrgb(Implementation::color3Literal<Vector3<UnsignedByte>, 1, sizeof...(chars), chars...>());
 }
 #endif
@@ -1706,14 +1706,14 @@ Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-constexpr Color4<Float> operator"" _rgbaf(unsigned long long value) {
+constexpr Color4<Float> operator""_rgbaf(unsigned long long value) {
     return {((value >> 24) & 0xff)/255.0f,
             ((value >> 16) & 0xff)/255.0f,
             ((value >>  8) & 0xff)/255.0f,
             ((value >>  0) & 0xff)/255.0f};
 }
 #else
-template<char... chars> constexpr Color4<Float> operator"" _rgbaf() {
+template<char... chars> constexpr Color4<Float> operator""_rgbaf() {
     return Implementation::color4Literal<Color4<Float>, 255, sizeof...(chars), chars...>();
 }
 #endif
@@ -1733,11 +1733,11 @@ Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-inline Color4<Float> operator"" _srgbaf(unsigned long long value) {
+inline Color4<Float> operator""_srgbaf(unsigned long long value) {
     return Color4<Float>::fromSrgbAlphaInt(UnsignedInt(value));
 }
 #else
-template<char... chars> inline Color4<Float> operator"" _srgbaf() {
+template<char... chars> inline Color4<Float> operator""_srgbaf() {
     return Color4<Float>::fromSrgbAlpha(Implementation::color4Literal<Vector4<UnsignedByte>, 1, sizeof...(chars), chars...>());
 }
 #endif
@@ -1763,7 +1763,7 @@ then casting from a float to a half-float type. Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above. Deinlined to avoid including Half.h. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-MAGNUM_EXPORT Color3<Half> operator"" _rgbh(unsigned long long value);
+MAGNUM_EXPORT Color3<Half> operator""_rgbh(unsigned long long value);
 #else
 template<char... chars> inline
 #ifdef DOXYGEN_GENERATING_OUTPUT
@@ -1771,7 +1771,7 @@ Color3<Half> /* to avoid including Half.h */
 #else
 typename Implementation::HalfColor<sizeof...(chars)>::Type3
 #endif
-operator"" _rgbh() {
+operator""_rgbh() {
     return Color3<Half>{Implementation::color3Literal<Color3<Float>, 255, sizeof...(chars), chars...>()};
 }
 #endif
@@ -1792,7 +1792,7 @@ casting from a float to a half-float type. Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above. Deinlined to avoid including Half.h. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-MAGNUM_EXPORT Color3<Half> operator"" _srgbh(unsigned long long value);
+MAGNUM_EXPORT Color3<Half> operator""_srgbh(unsigned long long value);
 #else
 template<char... chars> inline
 #ifdef DOXYGEN_GENERATING_OUTPUT
@@ -1800,7 +1800,7 @@ Color3<Half> /* to avoid including Half.h */
 #else
 typename Implementation::HalfColor<sizeof...(chars)>::Type3
 #endif
-operator"" _srgbh() {
+operator""_srgbh() {
     return Color3<Half>{Color3<Float>::fromSrgb(Implementation::color3Literal<Vector3<UnsignedByte>, 1, sizeof...(chars), chars...>())};
 }
 #endif
@@ -1826,7 +1826,7 @@ then casting from a float to a half-float type. Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above. Deinlined to avoid including Half.h. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-MAGNUM_EXPORT Color4<Half> operator"" _rgbah(unsigned long long value);
+MAGNUM_EXPORT Color4<Half> operator""_rgbah(unsigned long long value);
 #else
 template<char... chars> inline
 #ifdef DOXYGEN_GENERATING_OUTPUT
@@ -1834,7 +1834,7 @@ Color4<Half> /* to avoid including Half.h */
 #else
 typename Implementation::HalfColor<sizeof...(chars)>::Type4
 #endif
-operator"" _rgbah() {
+operator""_rgbah() {
     return Color4<Half>{Implementation::color4Literal<Color4<Float>, 255, sizeof...(chars), chars...>()};
 }
 #endif
@@ -1855,7 +1855,7 @@ then casting from a float to a half-float type. Example usage:
 /* MSVC 2019 with the /permissive- flag crashes with the variadic template
    implementation, see above. Deinlined to avoid including Half.h. */
 #if defined(CORRADE_TARGET_MSVC) && !defined(CORRADE_TARGET_CLANG_CL) && _MSC_VER >= 1920 && _MSC_VER < 1930
-MAGNUM_EXPORT Color4<Half> operator"" _srgbah(unsigned long long value);
+MAGNUM_EXPORT Color4<Half> operator""_srgbah(unsigned long long value);
 #else
 template<char... chars> inline
 #ifdef DOXYGEN_GENERATING_OUTPUT
@@ -1863,7 +1863,7 @@ Color4<Half> /* to avoid including Half.h */
 #else
 typename Implementation::HalfColor<sizeof...(chars)>::Type4
 #endif
-operator"" _srgbah() {
+operator""_srgbah() {
     return Color4<Half>{Color4<Float>::fromSrgbAlpha(Implementation::color4Literal<Vector4<UnsignedByte>, 1, sizeof...(chars), chars...>())};
 }
 #endif

--- a/src/Magnum/Math/Half.h
+++ b/src/Magnum/Math/Half.h
@@ -202,7 +202,7 @@ namespace Literals {
 
 See @ref Half for more information.
 */
-inline Half operator"" _h(long double value) { return Half(Float(value)); }
+inline Half operator""_h(long double value) { return Half(Float(value)); }
 #if defined(CORRADE_TARGET_CLANG) && __clang_major__ >= 17
 #pragma clang diagnostic pop
 #endif

--- a/src/Magnum/Math/Time.h
+++ b/src/Magnum/Math/Time.h
@@ -316,7 +316,7 @@ fractions of nanoseconds. Usage example:
     @link operator""_sec() @endlink
 @m_keywords{_nsec nsec}
 */
-constexpr Nanoseconds<Long> operator"" _nsec(unsigned long long value) {
+constexpr Nanoseconds<Long> operator""_nsec(unsigned long long value) {
     return Nanoseconds<Long>{Long(value)};
 }
 
@@ -339,7 +339,7 @@ precision on a range of roughly ±8 seconds. For example:
     @ref CORRADE_LONG_DOUBLE_SAME_AS_DOUBLE
 @m_keywords{_usec usec}
 */
-constexpr Nanoseconds<Long> operator"" _usec(long double value) {
+constexpr Nanoseconds<Long> operator""_usec(long double value) {
     return Nanoseconds<Long>{Long(value*1000.0l)};
 }
 
@@ -362,7 +362,7 @@ precision on a range of roughly ±2 hours. For example:
     @ref CORRADE_LONG_DOUBLE_SAME_AS_DOUBLE
 @m_keywords{_msec msec}
 */
-constexpr Nanoseconds<Long> operator"" _msec(long double value) {
+constexpr Nanoseconds<Long> operator""_msec(long double value) {
     return Nanoseconds<Long>{Long(value*1000000.0l)};
 }
 
@@ -385,7 +385,7 @@ precision on a range of roughly ±2 hours. For example:
     @ref CORRADE_LONG_DOUBLE_SAME_AS_DOUBLE
 @m_keywords{_sec sec}
 */
-constexpr Nanoseconds<Long> operator"" _sec(long double value) {
+constexpr Nanoseconds<Long> operator""_sec(long double value) {
     return Nanoseconds<Long>{Long(value*1000000000.0l)};
 }
 #if defined(CORRADE_TARGET_CLANG) && __clang_major__ >= 17


### PR DESCRIPTION
C++23 has deprecated spaces between quotes and suffix in user-defined string literals. See [C++23 draft N4950 [depr.lit] (Annex D.9)](https://timsong-cpp.github.io/cppwp/n4950/depr.lit).

This addresses the following GCC 15 compiler warnings:
```
warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]
```


See also:
- https://github.com/mosra/corrade/pull/201