### PR TITLE
Fix configuration width size typo in doc/snippets/Platform.cpp

### DIFF
--- a/doc/snippets/Platform.cpp
+++ b/doc/snippets/Platform.cpp
@@ -163,7 +163,7 @@ struct MyApplication: Platform::Application {
 MyApplication::MyApplication(const Arguments& arguments):
     Platform::Application{arguments, Configuration{}
         .setTitle("My Application")
-        .setSize({12800, 800})}
+        .setSize({1280, 800})}
 {
     DOXYGEN_ELLIPSIS()
 }


### PR DESCRIPTION
Specifying configuration to be exact,

<img width="1920" height="851" alt="image" src="https://github.com/user-attachments/assets/92f9dfa9-e2d6-41d2-a7db-140a9c15508c" />

12800 is an obscure size and stuff and it would make the most sense if it would be 1280

<img width="1301" height="842" alt="image" src="https://github.com/user-attachments/assets/c851d934-c22f-4d90-b641-5e8508850b9f" />
