### PR TITLE
Windows: near and far undef cause failure when including Windows headers

### DIFF
--- a/src/Magnum/Math/Frustum.h
+++ b/src/Magnum/Math/Frustum.h
@@ -43,8 +43,16 @@
 #include "Magnum/Math/Vector4.h"
 
 #ifdef CORRADE_TARGET_WINDOWS /* I so HATE windef.h */
+/* far/near and FAR/NEAR are defined by minwindef.h, but the former are used by this file as variables.
+   While they are all empty defines, the Windows headers expect FAR/NEAR to be defined and so we redefine them here.
+   far/near are left undefined because they are not used directly in Windows headers.
+   */
 #undef near
+#undef NEAR
+#define NEAR
 #undef far
+#undef FAR
+#define FAR
 #endif
 
 namespace Magnum { namespace Math {

--- a/src/Magnum/Math/Matrix4.h
+++ b/src/Magnum/Math/Matrix4.h
@@ -38,8 +38,16 @@
 #include "Magnum/Math/Vector4.h"
 
 #ifdef CORRADE_TARGET_WINDOWS /* I so HATE windef.h */
+/* far/near and FAR/NEAR are defined by minwindef.h, but the former are used by this file as variables.
+   While they are all empty defines, the Windows headers expect FAR/NEAR to be defined and so we redefine them here.
+   far/near are left undefined because they are not used directly in Windows headers.
+   */
 #undef near
+#undef NEAR
+#define NEAR
 #undef far
+#undef FAR
+#define FAR
 #endif
 
 namespace Magnum { namespace Math {

--- a/src/Magnum/SceneGraph/Camera.h
+++ b/src/Magnum/SceneGraph/Camera.h
@@ -36,8 +36,16 @@
 #include "Magnum/SceneGraph/visibility.h"
 
 #ifdef CORRADE_TARGET_WINDOWS /* I so HATE windef.h */
+/* far/near and FAR/NEAR are defined by minwindef.h, but the former are used by this file as variables.
+   While they are all empty defines, the Windows headers expect FAR/NEAR to be defined and so we redefine them here.
+   far/near are left undefined because they are not used directly in Windows headers.
+   */
 #undef near
+#undef NEAR
+#define NEAR
 #undef far
+#undef FAR
+#define FAR
 #endif
 
 namespace Magnum { namespace SceneGraph {

--- a/src/Magnum/Trade/CameraData.h
+++ b/src/Magnum/Trade/CameraData.h
@@ -35,8 +35,16 @@
 #include "Magnum/Trade/visibility.h"
 
 #ifdef CORRADE_TARGET_WINDOWS /* I so HATE windef.h */
+/* far/near and FAR/NEAR are defined by minwindef.h, but the former are used by this file as variables.
+   While they are all empty defines, the Windows headers expect FAR/NEAR to be defined and so we redefine them here.
+   far/near are left undefined because they are not used directly in Windows headers.
+   */
 #undef near
+#undef NEAR
+#define NEAR
 #undef far
+#undef FAR
+#define FAR
 #endif
 
 namespace Magnum { namespace Trade {


### PR DESCRIPTION
Fixes #689